### PR TITLE
fix: comply gate on minor/patch release-age breaches, preserve worstLevel on fallback

### DIFF
--- a/docs-templates/__examples.md
+++ b/docs-templates/__examples.md
@@ -205,7 +205,7 @@ If `enforceOn` is omitted, every package's release age counts toward compliance 
 <!-- @package name --> comply
 ```
 
-- **Exit `0`** — compliant: no `error`-severity rule violations, no `error`-severity banned packages, no `error`-severity `mandatory_upgrade` release-age entries.
+- **Exit `0`** — compliant: no `error`-severity rule violations, no `error`-severity banned packages, no `error`-severity release-age threshold breaches (minor/patch or major).
 - **Exit `1`** — not compliant: at least one mandatory violation found.
 - **Exit `2`** — hermex couldn't run the check at all (no files matched, or an internal error).
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -207,7 +207,7 @@ If `enforceOn` is omitted, every package's release age counts toward compliance 
 hermex comply
 ```
 
-- **Exit `0`** — compliant: no `error`-severity rule violations, no `error`-severity banned packages, no `error`-severity `mandatory_upgrade` release-age entries.
+- **Exit `0`** — compliant: no `error`-severity rule violations, no `error`-severity banned packages, no `error`-severity release-age threshold breaches (minor/patch or major).
 - **Exit `1`** — not compliant: at least one mandatory violation found.
 - **Exit `2`** — hermex couldn't run the check at all (no files matched, or an internal error).
 

--- a/src/npm-registry/enricher.ts
+++ b/src/npm-registry/enricher.ts
@@ -42,8 +42,7 @@ function upgradeLevel(
   const threshold = thresholds[bump];
   if (threshold === false || threshold === undefined) return null;
   if (daysAgo > threshold) {
-    // major bump past its threshold → mandatory, minor/patch → needs
-    return bump === 'major' ? 'mandatory_upgrade' : 'needs_upgrade';
+    return bump === 'major' ? 'major_overdue' : 'minor_overdue';
   }
   return null;
 }
@@ -138,12 +137,6 @@ function computeReleaseAge(
     minCompliantVersion = latestVersion;
     minCompliantReleasedDaysAgo = latestReleasedDaysAgo;
   }
-  // True only when *every* touched tier never had an achievable compliant
-  // candidate (the fallback above is what set minCompliantVersion) — the
-  // threshold exists to catch avoidable staleness, not to penalize an
-  // install for the ecosystem not having shipped anything fresher (#26).
-  const compliantByLatestFallback =
-    !hadInWindowCandidate && minCompliantVersion !== undefined;
 
   for (const upgrade of finalUpgrades) {
     if (latestVersion && upgrade.version === latestVersion) {
@@ -151,13 +144,17 @@ function computeReleaseAge(
     }
   }
 
-  const worstLevel: UpgradeLevel | null = compliantByLatestFallback
-    ? null
-    : finalUpgrades.some((u) => u.level === 'mandatory_upgrade')
-      ? 'mandatory_upgrade'
-      : finalUpgrades.length > 0
-        ? 'needs_upgrade'
-        : null;
+  // The latest-fallback above is a display convenience for "closest
+  // achievable target" — it must not also erase worstLevel. A package with
+  // breached upgrades is still overdue even when latest itself is past the
+  // threshold and there's nothing fresher to recommend instead (#29).
+  const worstLevel: UpgradeLevel | null = finalUpgrades.some(
+    (u) => u.level === 'major_overdue',
+  )
+    ? 'major_overdue'
+    : finalUpgrades.length > 0
+      ? 'minor_overdue'
+      : null;
 
   // Only surface a "coming due" advisory when nothing has breached yet — a
   // package that's already in violation on one tier doesn't also need an

--- a/src/npm-registry/types.ts
+++ b/src/npm-registry/types.ts
@@ -1,4 +1,4 @@
-export type UpgradeLevel = 'needs_upgrade' | 'mandatory_upgrade';
+export type UpgradeLevel = 'minor_overdue' | 'major_overdue';
 export type SemverBump = 'patch' | 'minor' | 'major';
 
 export interface AvailableUpgrade {
@@ -30,10 +30,11 @@ export interface ReleaseAgeEntry {
   installedVersion: string;
   upgrades: AvailableUpgrade[];
   /**
-   * `null` when compliant, including when no release newer than
-   * `installedVersion` has ever fallen inside its bump tier's threshold —
-   * in that case the only achievable target is `latestVersion` itself, so
-   * there's nothing avoidably stale to flag (#26).
+   * `null` only when there are no breached upgrades at all. Independent of
+   * whether `minCompliantVersion` fell back to `latestVersion` — a package
+   * can still be overdue on a breached tier even when latest itself is past
+   * that tier's threshold and there's nothing fresher to recommend instead
+   * (#29).
    */
   worstLevel: UpgradeLevel | null;
   pendingUpgrade?: PendingUpgrade;

--- a/src/utils/compliance.ts
+++ b/src/utils/compliance.ts
@@ -7,15 +7,15 @@ export interface ComplianceResult {
   compliant: boolean;
   errorRuleViolations: RuleViolation[];
   errorBannedPackageViolations: BannedPackageViolation[];
-  mandatoryReleaseAgeViolations: PackageDistribution[];
+  releaseAgeViolations: PackageDistribution[];
 }
 
 /**
- * A package is a mandatory compliance failure only when its releaseAge
- * severity is 'error' (i.e. it's in scope per `releaseAge.enforceOn`) AND
- * its worstLevel is 'mandatory_upgrade' — 'needs_upgrade' (patch/minor) is
- * advisory even for enforced packages, matching the existing "mandatory"
- * vocabulary already used by upgradeLevel().
+ * A package is a compliance failure when its releaseAge severity is 'error'
+ * (i.e. it's in scope per `releaseAge.enforceOn`) AND it has any breached
+ * threshold at all (worstLevel is non-null) — both 'minor_overdue' and
+ * 'major_overdue' fail comply for an enforced package; only severity
+ * decides mandatory vs advisory, not which tier breached (#28).
  */
 export function computeCompliance(
   aggregated: AggregatedReport,
@@ -25,19 +25,18 @@ export function computeCompliance(
   );
   const errorBannedPackageViolations =
     aggregated.bannedPackageViolations.filter((v) => v.severity === 'error');
-  const mandatoryReleaseAgeViolations = aggregated.packageDistribution.filter(
+  const releaseAgeViolations = aggregated.packageDistribution.filter(
     (p) =>
-      p.releaseAge?.severity === 'error' &&
-      p.releaseAge?.worstLevel === 'mandatory_upgrade',
+      p.releaseAge?.severity === 'error' && p.releaseAge?.worstLevel !== null,
   );
 
   return {
     compliant:
       errorRuleViolations.length === 0 &&
       errorBannedPackageViolations.length === 0 &&
-      mandatoryReleaseAgeViolations.length === 0,
+      releaseAgeViolations.length === 0,
     errorRuleViolations,
     errorBannedPackageViolations,
-    mandatoryReleaseAgeViolations,
+    releaseAgeViolations,
   };
 }

--- a/src/utils/print-compliance.ts
+++ b/src/utils/print-compliance.ts
@@ -3,7 +3,7 @@ import type { ComplianceResult } from './compliance';
 import { severityIcon } from './severity-format';
 
 /**
- * Prints only the bottom-line verdict — the Compliance and Packages sections
+ * Prints only the bottom-line verdict — the Rules and Packages sections
  * printed above this already itemize every violation (rule and release-age
  * alike), so repeating them here would just restate the same 🔴 rows.
  */
@@ -11,7 +11,7 @@ export function printComplianceVerdict(result: ComplianceResult): void {
   const mandatoryCount =
     result.errorRuleViolations.length +
     result.errorBannedPackageViolations.length +
-    result.mandatoryReleaseAgeViolations.length;
+    result.releaseAgeViolations.length;
 
   if (result.compliant) {
     console.log(

--- a/src/utils/print-packages.ts
+++ b/src/utils/print-packages.ts
@@ -59,7 +59,7 @@ function formatUpgradeCell(releaseAge?: ReleaseAgeEntry): string {
       ? 'no compliant release available'
       : formatDaysOverdue(top.breachReleasedDaysAgo, top.thresholdDays);
 
-  if (worstLevel === 'mandatory_upgrade') {
+  if (worstLevel === 'major_overdue') {
     const icon = severityIcon(severity === 'warn' ? 'warn' : 'error');
     return `${icon} ${top.semverBump} ${top.version} (${overdue})${suffix}`;
   }

--- a/src/utils/print-rules.ts
+++ b/src/utils/print-rules.ts
@@ -71,14 +71,12 @@ export function printRules(aggregated: AggregatedReport): void {
   const hasBannedViolations = bannedPackageViolations.length > 0;
 
   if (!hasRuleViolations && !hasBannedViolations) {
-    console.log(
-      chalk.greenBright.bold(`\n${severityIcon('success')} Compliance\n`),
-    );
-    console.log(chalk.gray('  All compliance checks passed'));
+    console.log(chalk.greenBright.bold(`\n${severityIcon('success')} Rules\n`));
+    console.log(chalk.gray('  All rule checks passed'));
     return;
   }
 
-  console.log(chalk.blueBright.bold('\n🔍 Compliance\n'));
+  console.log(chalk.blueBright.bold('\n🔍 Rules\n'));
 
   if (hasRuleViolations) {
     for (const v of ruleViolations) {

--- a/tests/helpers/mock-reports.test.ts
+++ b/tests/helpers/mock-reports.test.ts
@@ -24,7 +24,7 @@ describe('mock report factory', () => {
   });
 
   it('createMockReleaseAge returns a valid ReleaseAgeEntry', () => {
-    const entry = createMockReleaseAge({ worstLevel: 'needs_upgrade' });
-    expect(entry.worstLevel).toBe('needs_upgrade');
+    const entry = createMockReleaseAge({ worstLevel: 'minor_overdue' });
+    expect(entry.worstLevel).toBe('minor_overdue');
   });
 });

--- a/tests/npm-registry/enricher.test.ts
+++ b/tests/npm-registry/enricher.test.ts
@@ -77,7 +77,7 @@ describe('enrichWithReleaseAge — upgrade detection', () => {
     expect(enriched[0].releaseAge?.upgrades).toHaveLength(0);
   });
 
-  it('detects needs_upgrade when patch version exceeds threshold', async () => {
+  it('detects minor_overdue when patch version exceeds threshold', async () => {
     const pkg = createMockPackage('react', { version: '18.0.0' });
     mockFetch.mockResolvedValueOnce({
       name: 'react',
@@ -85,12 +85,12 @@ describe('enrichWithReleaseAge — upgrade detection', () => {
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('needs_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('minor_overdue');
     expect(enriched[0].releaseAge?.upgrades[0].semverBump).toBe('patch');
     expect(enriched[0].releaseAge?.upgrades[0].thresholdDays).toBe(30);
   });
 
-  it('detects mandatory_upgrade when major version exceeds threshold', async () => {
+  it('detects major_overdue when major version exceeds threshold', async () => {
     const pkg = createMockPackage('react', { version: '17.0.0' });
     mockFetch.mockResolvedValueOnce({
       name: 'react',
@@ -98,7 +98,7 @@ describe('enrichWithReleaseAge — upgrade detection', () => {
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('mandatory_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.upgrades[0].thresholdDays).toBe(60);
   });
 
@@ -127,7 +127,7 @@ describe('enrichWithReleaseAge — upgrade detection', () => {
       name: 'mixed-lib',
       time: {
         '1.0.0': daysAgo(500),
-        // major candidate breaches the 60-day threshold → mandatory_upgrade
+        // major candidate breaches the 60-day threshold → major_overdue
         '2.0.0': daysAgo(90),
         // minor candidate is still within its 45-day threshold
         '1.5.0': daysAgo(33),
@@ -135,7 +135,7 @@ describe('enrichWithReleaseAge — upgrade detection', () => {
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('mandatory_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.pendingUpgrade).toBeUndefined();
   });
 
@@ -287,7 +287,7 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
   it('finds a compliant release inside an intermediate major line, not just the latest', async () => {
     // Mirrors the @guestyci/foundation example from the issue: installed
     // 10.x. 11.0.0 is old enough (400d) to breach the 60-day major
-    // threshold and drive worstLevel to mandatory_upgrade; 12.0.0 (55d) is
+    // threshold and drive worstLevel to major_overdue; 12.0.0 (55d) is
     // still within that threshold and should become minCompliantVersion —
     // the whole point of #21 is that this doesn't have to be the newest
     // release (13.5.5, 10d) to count as compliant.
@@ -306,12 +306,12 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('mandatory_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('12.0.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(55);
   });
 
-  it('falls back to latestVersion as minCompliantVersion — and reports compliant, not mandatory — when every major-line candidate has already aged past the threshold (#26)', async () => {
+  it('falls back to latestVersion as minCompliantVersion, but still reports major_overdue, when every major-line candidate has already aged past the threshold (#26, #29)', async () => {
     const pkg = createMockPackage('react', { version: '17.0.0' });
     mockFetch.mockResolvedValueOnce({
       name: 'react',
@@ -324,9 +324,10 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
     // 18.0.0 is the only thing that has ever existed to upgrade to, and it's
-    // latest — there was never an achievable fresher target, so this isn't
-    // an avoidable-staleness violation.
-    expect(enriched[0].releaseAge?.worstLevel).toBeNull();
+    // latest, so minCompliantVersion falls back to it as the closest
+    // achievable display target — but the package is still genuinely overdue
+    // on the major tier, so worstLevel must keep reflecting that (#29).
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('18.0.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(90);
   });
@@ -337,7 +338,7 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
       name: '@guestyci/arc',
       time: {
         '0.15.1': daysAgo(900),
-        '1.0.0': daysAgo(400), // breaches the 60-day threshold, drives mandatory_upgrade
+        '1.0.0': daysAgo(400), // breaches the 60-day threshold, drives major_overdue
         '1.5.0': daysAgo(55), // compliant, oldest of the compliant set — should win
         '1.10.0': daysAgo(30), // compliant, but newer than 1.5.0
         '1.17.1': daysAgo(5), // latest, compliant, newest of all
@@ -345,7 +346,7 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('mandatory_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('1.5.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(55);
   });
@@ -356,13 +357,13 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
       name: 'some-lib',
       time: {
         '2.1.0': daysAgo(300),
-        '2.5.0': daysAgo(50), // breaches the 45-day minor threshold, drives needs_upgrade
+        '2.5.0': daysAgo(50), // breaches the 45-day minor threshold, drives minor_overdue
         '2.3.0': daysAgo(40), // within the 45-day minor threshold — compliant
       },
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('needs_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('minor_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('2.3.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(40);
   });
@@ -381,12 +382,12 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
         '1.0.0': daysAgo(900),
         '1.5.0': daysAgo(40), // minor, compliant
         '2.0.0': daysAgo(55), // major, compliant, oldest compliant overall — should win
-        '3.0.0': daysAgo(400), // major, breaches the threshold, drives mandatory_upgrade
+        '3.0.0': daysAgo(400), // major, breaches the threshold, drives major_overdue
       },
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('mandatory_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('2.0.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(55);
   });
@@ -410,7 +411,7 @@ describe('enrichWithReleaseAge — minCompliantVersion for all bump tiers (#21)'
 });
 
 describe('enrichWithReleaseAge — minCompliantVersion falls back to latest (#26)', () => {
-  it('falls back to latest and reports compliant when both a breached minor and a breached major tier exist and neither ever had an in-window candidate', async () => {
+  it('falls back minCompliantVersion to latest for display but still reports major_overdue when a breached major tier exists (#29)', async () => {
     const pkg = createMockPackage('@guestyci/stale-lib', { version: '1.0.0' });
     mockFetch.mockResolvedValueOnce({
       name: '@guestyci/stale-lib',
@@ -423,9 +424,28 @@ describe('enrichWithReleaseAge — minCompliantVersion falls back to latest (#26
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBeNull();
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('2.0.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(90);
+    expect(enriched[0].releaseAge?.pendingUpgrade).toBeUndefined();
+  });
+
+  it('falls back minCompliantVersion to latest but still reports minor_overdue when only a breached minor tier exists (#29)', async () => {
+    const pkg = createMockPackage('some-lib', { version: '1.0.0' });
+    mockFetch.mockResolvedValueOnce({
+      name: 'some-lib',
+      time: {
+        '1.0.0': daysAgo(900),
+        '1.5.0': daysAgo(90), // minor, breaches the 45-day threshold, also latest — no in-window candidate
+      },
+      'dist-tags': { latest: '1.5.0' },
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
+    expect(enriched[0].releaseAge?.worstLevel).toBe('minor_overdue');
+    expect(enriched[0].releaseAge?.minCompliantVersion).toBe('1.5.0');
+    expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(90);
+    expect(enriched[0].releaseAge?.pendingUpgrade).toBeUndefined();
   });
 
   it('still reports mandatory when a different tier has a genuine in-window candidate that was ignored, even though the major tier itself has no fresh target', async () => {
@@ -445,7 +465,7 @@ describe('enrichWithReleaseAge — minCompliantVersion falls back to latest (#26
       versions: {},
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(enriched[0].releaseAge?.worstLevel).toBe('mandatory_upgrade');
+    expect(enriched[0].releaseAge?.worstLevel).toBe('major_overdue');
     expect(enriched[0].releaseAge?.minCompliantVersion).toBe('1.5.0');
     expect(enriched[0].releaseAge?.minCompliantReleasedDaysAgo).toBe(40);
   });
@@ -544,7 +564,7 @@ describe('enrichWithReleaseAge — overdue basis uses oldest breach, not newest 
     });
     const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
     const entry = enriched[0].releaseAge!;
-    expect(entry.worstLevel).toBe('mandatory_upgrade');
+    expect(entry.worstLevel).toBe('major_overdue');
 
     const upgrade = entry.upgrades.find((u) => u.semverBump === 'major');
     // Unchanged #14 behavior: the target is still the newest stable release.

--- a/tests/utils/compliance.test.ts
+++ b/tests/utils/compliance.test.ts
@@ -35,7 +35,7 @@ describe('computeCompliance', () => {
     expect(result.compliant).toBe(true);
     expect(result.errorRuleViolations).toHaveLength(0);
     expect(result.errorBannedPackageViolations).toHaveLength(0);
-    expect(result.mandatoryReleaseAgeViolations).toHaveLength(0);
+    expect(result.releaseAgeViolations).toHaveLength(0);
   });
 
   it('is non-compliant when an error-severity rule violation is present', () => {
@@ -95,10 +95,10 @@ describe('computeCompliance', () => {
     expect(result.compliant).toBe(true);
   });
 
-  it('is non-compliant when an enforced package has a mandatory_upgrade', () => {
+  it('is non-compliant when an enforced package has a major_overdue breach', () => {
     const pkg = createMockPackage('@my-org/internal', {
       releaseAge: createMockReleaseAge({
-        worstLevel: 'mandatory_upgrade',
+        worstLevel: 'major_overdue',
         severity: 'error',
       }),
     });
@@ -106,13 +106,13 @@ describe('computeCompliance', () => {
       makeAggregated({ packageDistribution: [pkg] }),
     );
     expect(result.compliant).toBe(false);
-    expect(result.mandatoryReleaseAgeViolations).toEqual([pkg]);
+    expect(result.releaseAgeViolations).toEqual([pkg]);
   });
 
-  it('a mandatory_upgrade on a warn-severity (not enforced) package does not affect compliance', () => {
+  it('a major_overdue on a warn-severity (not enforced) package does not affect compliance', () => {
     const pkg = createMockPackage('react', {
       releaseAge: createMockReleaseAge({
-        worstLevel: 'mandatory_upgrade',
+        worstLevel: 'major_overdue',
         severity: 'warn',
       }),
     });
@@ -122,11 +122,25 @@ describe('computeCompliance', () => {
     expect(result.compliant).toBe(true);
   });
 
-  it('a needs_upgrade on an enforced package does not affect compliance (only mandatory_upgrade does)', () => {
+  it('is non-compliant when an enforced package has a minor_overdue breach', () => {
     const pkg = createMockPackage('@my-org/internal', {
       releaseAge: createMockReleaseAge({
-        worstLevel: 'needs_upgrade',
+        worstLevel: 'minor_overdue',
         severity: 'error',
+      }),
+    });
+    const result = computeCompliance(
+      makeAggregated({ packageDistribution: [pkg] }),
+    );
+    expect(result.compliant).toBe(false);
+    expect(result.releaseAgeViolations).toEqual([pkg]);
+  });
+
+  it('a minor_overdue on a warn-severity (not enforced) package does not affect compliance', () => {
+    const pkg = createMockPackage('react', {
+      releaseAge: createMockReleaseAge({
+        worstLevel: 'minor_overdue',
+        severity: 'warn',
       }),
     });
     const result = computeCompliance(

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -96,7 +96,7 @@ describe('printPackages', () => {
       packageDistribution: [
         createMockPackage('lodash', {
           releaseAge: createMockReleaseAge({
-            worstLevel: 'mandatory_upgrade',
+            worstLevel: 'major_overdue',
             severity: 'error',
             upgrades: [
               {
@@ -104,7 +104,7 @@ describe('printPackages', () => {
                 releasedDaysAgo: 10,
                 breachReleasedDaysAgo: 100,
                 semverBump: 'major',
-                level: 'mandatory_upgrade',
+                level: 'major_overdue',
                 thresholdDays: 60,
               },
             ],
@@ -129,7 +129,7 @@ describe('printPackages', () => {
       packageDistribution: [
         createMockPackage('@guestyci/feature-toggle-fe', {
           releaseAge: createMockReleaseAge({
-            worstLevel: 'mandatory_upgrade',
+            worstLevel: 'major_overdue',
             severity: 'error',
             upgrades: [
               {
@@ -137,7 +137,7 @@ describe('printPackages', () => {
                 releasedDaysAgo: 14,
                 breachReleasedDaysAgo: 1000,
                 semverBump: 'major',
-                level: 'mandatory_upgrade',
+                level: 'major_overdue',
                 thresholdDays: 60,
               },
             ],
@@ -158,7 +158,7 @@ describe('printPackages', () => {
       packageDistribution: [
         createMockPackage('react', {
           releaseAge: createMockReleaseAge({
-            worstLevel: 'mandatory_upgrade',
+            worstLevel: 'major_overdue',
             severity: 'error',
             upgrades: [
               {
@@ -166,7 +166,7 @@ describe('printPackages', () => {
                 releasedDaysAgo: 90,
                 breachReleasedDaysAgo: 90,
                 semverBump: 'major',
-                level: 'mandatory_upgrade',
+                level: 'major_overdue',
                 thresholdDays: 60,
               },
             ],
@@ -246,7 +246,7 @@ describe('printRules', () => {
     const output = consoleSpy.mock.calls
       .map((call) => call.join(' '))
       .join('\n');
-    expect(output).toContain('All compliance checks passed');
+    expect(output).toContain('All rule checks passed');
   });
 
   it('prints violations when present', () => {
@@ -377,7 +377,7 @@ describe('printComplianceVerdict', () => {
     };
     const pkg = createMockPackage('@my-org/internal', {
       releaseAge: createMockReleaseAge({
-        worstLevel: 'mandatory_upgrade',
+        worstLevel: 'major_overdue',
         severity: 'error',
         upgrades: [
           {
@@ -385,7 +385,7 @@ describe('printComplianceVerdict', () => {
             releasedDaysAgo: 90,
             breachReleasedDaysAgo: 90,
             semverBump: 'major',
-            level: 'mandatory_upgrade',
+            level: 'major_overdue',
             thresholdDays: 60,
           },
         ],
@@ -403,7 +403,7 @@ describe('printComplianceVerdict', () => {
       .join('\n');
     expect(output).toContain('NOT COMPLIANT');
     expect(output).toContain('2 mandatory violations');
-    // per-violation detail belongs to the Compliance/Packages sections above
+    // per-violation detail belongs to the Rules/Packages sections above
     // the verdict, not the verdict itself — see printPackages tests for the
     // "days overdue" phrasing this same data renders as there.
     expect(output).not.toContain('@my-org/internal');


### PR DESCRIPTION
## Summary

- Fixes #28: `hermex comply` only failed on **major**-bump release-age breaches (`worstLevel === 'mandatory_upgrade'`). A package on `releaseAge.enforceOn` that was overdue on its **minor** or **patch** threshold got `worstLevel: 'needs_upgrade'` and stayed advisory, silently passing comply even though it breached a configured, enforced threshold. `computeCompliance` now fails on any breached threshold (`worstLevel !== null`) for `severity: 'error'` packages — `severity` alone now decides mandatory vs. advisory, not which tier breached.
- Fixes #29: when `minCompliantVersion` fell back to `latestVersion` (no in-window upgrade candidate on any tier), `worstLevel` was force-nulled even when real breaches existed in `upgrades[]` — silently hiding overdue packages from comply, `pendingUpgrade`, and fleet reporting (confirmed: ~121 `@guestyci/foundation`/`foundation-legacy` rows vanished from hermex-scans after 2.0.2). `worstLevel` is now derived straight from `finalUpgrades`, independent of that display-only fallback.
- Renamed the now-misleading `UpgradeLevel` values `'needs_upgrade'`/`'mandatory_upgrade'` → `'minor_overdue'`/`'major_overdue'` (they no longer encode mandatory-vs-advisory, only major-vs-minor for display), and `ComplianceResult.mandatoryReleaseAgeViolations` → `releaseAgeViolations` to match.
- Fixed `print-rules.ts`: it prints rule/banned-package violations but labeled its section "Compliance" — that term is reserved for the overall pass/fail verdict printed separately by `print-compliance.ts`. Now says "Rules".

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm run test:ci` — 276/276 passing, including new/updated cases in `tests/utils/compliance.test.ts` and `tests/npm-registry/enricher.test.ts` covering both issues
- [x] `pnpm run lint:ci` / `pnpm run format:ci`
- [x] Manual sanity check against a synthetic report exercising both fixes together (enforced minor breach, enforced major breach behind a latest-fallback, non-enforced advisory breach, fully compliant package) — confirmed `comply` now exits non-zero for the minor breach and the fallback package no longer disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)