### PR TITLE
ci: bump GitHub Actions to their current major versions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
@@ -52,17 +52,17 @@ jobs:
             artifact: pull-request
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ matrix.branch }}
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
- `pnpm/action-setup@v4` still runs on GitHub's deprecated Node 20 action runtime — that was the actual source of the CI deprecation warning (our jobs already use `node-version: 24` for the checked-out code, but the action's own runtime was pinned to Node 20). Bumped to `@v6`, which runs on Node 24.
- Bumped `actions/checkout@v6` → `@v7` and `actions/setup-node@v6` → `@v7` to their current majors while in here.
- `actions/upload-artifact@v7` and `actions/download-artifact@v8` were already current — left unchanged.
- Confirmed via the GitHub API that none of these major bumps introduce breaking changes relevant to how we use them (checkout ref/no special inputs, setup-node `node-version`/`cache`, pnpm `version` input).

## Test plan
- [ ] CI run on this PR passes (validate, coverage, report-coverage jobs) with no Node 20 deprecation warning