### PR TITLE
feat: render comply summary Packages section as a markdown table

### DIFF
--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -58,14 +58,19 @@ function buildRulesSection(aggregated: AggregatedReport): string {
 function buildPackagesSection(compliance: ComplianceResult): string {
   if (compliance.releaseAgeViolations.length === 0) return '';
 
-  const lines: string[] = ['### Packages', ''];
+  const lines: string[] = [
+    '### Packages',
+    '',
+    '| | Package | Issue |',
+    '|---|---|---|',
+  ];
   for (const pkg of compliance.releaseAgeViolations) {
     const top = pkg.releaseAge?.upgrades[0];
     const reasons: string[] = [];
     if (top) reasons.push(describeUpgradeTarget(top));
     if (pkg.releaseAge?.deprecated) reasons.push('deprecated');
     lines.push(
-      `- ${severityIcon('error')} ${pkg.packageName} — ${reasons.join(', ')}`,
+      `| ${severityIcon('error')} | \`${pkg.packageName}\` | ${reasons.join(', ')} |`,
     );
   }
 

--- a/tests/utils/write-summary-file.test.ts
+++ b/tests/utils/write-summary-file.test.ts
@@ -208,8 +208,9 @@ describe('writeSummaryFile', () => {
         makeAggregated({ packageDistribution: [overdueError] }),
       );
       expect(content).toContain('### Packages');
+      expect(content).toContain('| | Package | Issue |');
       expect(content).toContain(
-        '🔴 my-internal-pkg — major 4.2.0 (40 days overdue)',
+        '| 🔴 | `my-internal-pkg` | major 4.2.0 (40 days overdue) |',
       );
     });
 
@@ -236,7 +237,7 @@ describe('writeSummaryFile', () => {
         .split('\n')
         .find((l) => l.includes('my-internal-pkg'));
       expect(line).toBe(
-        '- 🔴 my-internal-pkg — major 4.2.0 (40 days overdue), deprecated',
+        '| 🔴 | `my-internal-pkg` | major 4.2.0 (40 days overdue), deprecated |',
       );
     });
 


### PR DESCRIPTION
## Summary
- `comply --summary-file` rendered the Packages section as a bullet list; switched it to a markdown table (icon / package / issue columns) so it scans faster once several packages are flagged.
- Kept the Rules and verdict sections unchanged — only `buildPackagesSection` in `src/utils/write-summary-file.ts` changed.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run test:ci` (303 passed, including updated `tests/utils/write-summary-file.test.ts` assertions for the new table format)
- [x] `pnpm run lint:ci` / `pnpm run format:ci`
- [x] Ran `comply --summary-file` against `fixtures/` with `releaseAge` enabled (`enforceOn: ['react', 'react-dom']`) to confirm real output renders as a GFM table

🤖 Generated with [Claude Code](https://claude.com/claude-code)