### PR TITLE
feat: emit a title in comply --summary-file output

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -213,6 +213,33 @@ hermex comply
 
 `warn` and `info`-severity violations are always reported but never fail the build — only `error`-severity violations are mandatory. `hermex comply` respects `output.format: 'json'` the same way `scan` does, so CI pipelines can parse the full report while still relying on the exit code as the pass/fail signal.
 
+### CI Job Summary / PR Comment
+
+`--summary-file <path>` writes a concise, ANSI-free markdown summary (title, rules, flagged packages, verdict) to `<path>`, suitable for posting as a GitHub Actions job summary or a PR comment — the same file can be reused verbatim for both surfaces, no need to generate it twice:
+
+```bash
+hermex comply --summary-file summary.md
+hermex comply --summary-file summary.md --summary-title "Custom Heading"  # default: "Hermex Compliance Report"
+```
+
+Because `hermex comply` exits non-zero on violations, and GitHub Actions `run:` steps default to `bash -eo pipefail` (errexit is already on), a step that's expected to sometimes fail will otherwise kill the job before later steps (like posting the comment) can run. Rather than wrapping the command in `set +e` / `set -e` and manually capturing `exit_code=$?`, use `continue-on-error` and read the step's `outcome` later:
+
+```yaml
+- name: Run comply
+  id: comply
+  run: hermex comply --summary-file summary.md
+  continue-on-error: true
+
+- name: Post/update PR comment
+  run: cat summary.md >> "$GITHUB_STEP_SUMMARY" # and/or post via your comment action of choice
+
+- name: Fail the job if not compliant
+  if: steps.comply.outcome == 'failure'
+  run: exit 1
+```
+
+`steps.comply.outcome` is readable in any step that follows, so the pass/fail signal from the exit code is preserved without any manual exit-code plumbing.
+
 ## Output Control
 
 All output sections are toggled in config, not via CLI flags:

--- a/src/commands/comply.ts
+++ b/src/commands/comply.ts
@@ -6,7 +6,10 @@ import { printPackages } from '../utils/print-packages';
 import { printVersus } from '../utils/print-versus';
 import { printComplianceVerdict } from '../utils/print-compliance';
 import { computeCompliance } from '../utils/compliance';
-import { writeSummaryFile } from '../utils/write-summary-file';
+import {
+  writeSummaryFile,
+  DEFAULT_SUMMARY_TITLE,
+} from '../utils/write-summary-file';
 import { loadConfig } from '../config/loader';
 import { runPipeline } from './pipeline';
 import { createCommandContext } from './command-context';
@@ -34,12 +37,18 @@ export function registerComplyCommand(program: Command) {
       '--summary-file <path>',
       'Write a concise, ANSI-free markdown summary (rules, flagged packages, verdict) to this path, for a CI job summary or PR comment',
     )
+    .option(
+      '--summary-title <text>',
+      'Title/heading for the --summary-file markdown output',
+      DEFAULT_SUMMARY_TITLE,
+    )
     .action(
       async (options: {
         config?: string;
         format?: 'human' | 'json';
         color?: boolean;
         summaryFile?: string;
+        summaryTitle: string;
       }) => {
         const config = await loadConfig(process.cwd(), options.config);
         await executeComply(
@@ -49,6 +58,7 @@ export function registerComplyCommand(program: Command) {
             color: options.color,
           },
           options.summaryFile,
+          options.summaryTitle,
         );
       },
     );
@@ -58,6 +68,7 @@ export async function executeComply(
   config: HermexConfig,
   contextOptions: CommandContextOptions = {},
   summaryFile?: string,
+  summaryTitle: string = DEFAULT_SUMMARY_TITLE,
 ) {
   const { isJson, spinner } = createCommandContext(config, contextOptions);
 
@@ -86,7 +97,7 @@ export async function executeComply(
     }
 
     if (summaryFile) {
-      writeSummaryFile(summaryFile, aggregated, compliance);
+      writeSummaryFile(summaryFile, aggregated, compliance, summaryTitle);
     }
 
     process.exitCode = compliance.compliant ? 0 : 1;

--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -90,18 +90,22 @@ function buildVerdictSection(compliance: ComplianceResult): string {
   return `### ${severityIcon('error')} NOT COMPLIANT\n\n${mandatoryCount} mandatory violation${mandatoryCount > 1 ? 's' : ''} found\n`;
 }
 
+export const DEFAULT_SUMMARY_TITLE = 'Hermex Compliance Report';
+
 /**
- * Writes a concise, ANSI-free markdown summary (rules, mandatory package
- * violations, verdict) for CI surfaces that can't render the full human
- * report — a sticky PR comment or job summary (#31). Omits Versus and
+ * Writes a concise, ANSI-free markdown summary (title, rules, mandatory
+ * package violations, verdict) for CI surfaces that can't render the full
+ * human report — a sticky PR comment or job summary (#31). Omits Versus and
  * progress chrome by construction; never touches ora or the Versus renderer.
  */
 export function writeSummaryFile(
   path: string,
   aggregated: AggregatedReport,
   compliance: ComplianceResult,
+  title: string = DEFAULT_SUMMARY_TITLE,
 ): void {
   const sections = [
+    `# ${title}\n`,
     buildRulesSection(aggregated),
     buildPackagesSection(compliance),
     buildVerdictSection(compliance),

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -305,6 +305,34 @@ describe('comply command', () => {
     }
   });
 
+  it('--summary-title overrides the default heading in the --summary-file output', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'hermex-summary-e2e-'));
+    try {
+      const summaryPath = join(tempDir, 'summary.md');
+      const configPath = join(
+        ROOT,
+        'tests',
+        'e2e',
+        'hermex-comply-pass.config.ts',
+      );
+      const result = run([
+        'comply',
+        '--config',
+        configPath,
+        '--summary-file',
+        summaryPath,
+        '--summary-title',
+        'Custom CI Title',
+      ]);
+      expect(result.status).toBe(0);
+      const content = readFileSync(summaryPath, 'utf8');
+      expect(content).toContain('# Custom CI Title');
+      expect(content).not.toContain('# Hermex Compliance Report');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('--summary-file still writes the file when the primary format is json', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'hermex-summary-e2e-'));
     try {

--- a/tests/utils/write-summary-file.test.ts
+++ b/tests/utils/write-summary-file.test.ts
@@ -7,7 +7,10 @@ import type { AggregatedReport } from '../../src/utils/aggregator';
 import type { RuleViolation } from '../../src/rules/evaluator';
 import type { BannedPackageViolation } from '../../src/utils/package-rules';
 import { computeCompliance } from '../../src/utils/compliance';
-import { writeSummaryFile } from '../../src/utils/write-summary-file';
+import {
+  writeSummaryFile,
+  DEFAULT_SUMMARY_TITLE,
+} from '../../src/utils/write-summary-file';
 import {
   createMockPackage,
   createMockReleaseAge,
@@ -49,10 +52,28 @@ describe('writeSummaryFile', () => {
     chalk.level = originalChalkLevel;
   });
 
-  function write(aggregated: AggregatedReport): string {
-    writeSummaryFile(summaryPath, aggregated, computeCompliance(aggregated));
+  function write(aggregated: AggregatedReport, title?: string): string {
+    writeSummaryFile(
+      summaryPath,
+      aggregated,
+      computeCompliance(aggregated),
+      title,
+    );
     return readFileSync(summaryPath, 'utf8');
   }
+
+  describe('title', () => {
+    it('defaults to DEFAULT_SUMMARY_TITLE when no title is passed', () => {
+      const content = write(makeAggregated());
+      expect(content).toContain(`# ${DEFAULT_SUMMARY_TITLE}`);
+    });
+
+    it('uses a custom title when one is passed', () => {
+      const content = write(makeAggregated(), 'Custom Compliance Report');
+      expect(content).toContain('# Custom Compliance Report');
+      expect(content).not.toContain(DEFAULT_SUMMARY_TITLE);
+    });
+  });
 
   it('writes a file with no ANSI escape sequences, even when chalk color is forced on', () => {
     chalk.level = 1;


### PR DESCRIPTION
## Summary
- `writeSummaryFile` now prepends a title (`# Hermex Compliance Report` by default) to the `--summary-file` markdown output
- New `--summary-title <text>` flag on `hermex comply` to override it
- Documents a `continue-on-error` + `steps.<id>.outcome` GitHub Actions recipe in docs/examples.md, replacing the manual `set +e` / `set -e` / `exit_code=$?` dance needed to capture the exit code while still running later steps (e.g. posting a PR comment)

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run test:ci` (306 passed, incl. new unit tests for default/custom title and a new e2e case for `--summary-title`)
- [x] `pnpm run lint` / `pnpm run typecheck` / `pnpm run format:ci`
- [x] Manually inspected generated summary markdown with default and custom titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)