### PR TITLE
fix: relax engines.node so consumers aren't forced onto Node 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "vitest": "^4.1.10"
   },
   "engines": {
-    "node": ">=26.4.0"
+    "node": ">=24.11.1"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- Reverts `engines.node` from `>=26.4.0` back to `>=24.11.1`. `.nvmrc` and CI (`node-version: 26`) stay on Node 26.

## Why
The Node 26 pin landed in #36 to satisfy `@semantic-release/git` v11 / `@semantic-release/changelog` v7's own engine requirement (`>=24.15` or `^22.22.2`) when *building/releasing* hermex. That's a devDependency/CI concern only — it has nothing to do with what Node version is needed to *run* the published `hermex` CLI.

Bumping `engines.node` to `>=26.4.0` alongside the CI pin was a mistake: it forces every consumer still on Node 24 (Active LTS) into an engine warning, or a hard install failure under `engine-strict`, for no functional reason. `tsdown.config.ts` targets `node24` and nothing in `src/` uses a Node 26-only API — the compiled `dist/cli.mjs` runs fine on 24.11.1+.

Net effect: we build/release on Node 26, but consumers on Node 24+ can still install and run hermex without warnings.

## Test plan
- [x] `pnpm run lint:ci` passes
- [x] `pnpm run format:ci` passes
- [x] Confirmed `tsdown.config.ts` target is `node24` and no Node 26-only APIs are used in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)