### PR TITLE
fix: patch brace-expansion DoS (CVE-2026-13149) — no override needed, and dropped the picomatch override too

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,10 +87,5 @@
   },
   "engines": {
     "node": ">=24.11.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "micromatch>picomatch": "^2.3.2"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  micromatch>picomatch: ^2.3.2
-
 importers:
 
   .:
@@ -1376,9 +1373,9 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3740,7 +3737,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4311,7 +4308,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- `brace-expansion` was pinned to a vulnerable `5.0.6` (CVE-2026-13149, high severity, exponential-time hang on crafted `{}` glob patterns) purely because the lockfile hadn't been refreshed — `minimatch@10.2.5` already declares `brace-expansion: ^5.0.5`, a range that already permits the patched `5.0.7`/`5.0.8`. A scoped `pnpm update brace-expansion` bumped it to `5.0.8` with zero unrelated package movement — **no `pnpm.overrides` entry needed**.
- Bonus: also tried dropping the pre-existing `micromatch>picomatch` override from `package.json` (added back in commit `cee1c81` after two different `pnpm update` attempts had unwanted side effects at the time). Today, `micromatch@4.0.8`'s own declared range (`picomatch: ^2.3.1`) already resolves cleanly to `2.3.2` without the override — removed it. Verified both previously-fixed picomatch advisories (GHSA-c2c7-rcm5-vvqj, GHSA-3v7f-55p6-f55p) stay clean.
- Net result: `pnpm.overrides` block removed from `package.json` entirely; `pnpm audit` shows zero advisories reachable from runtime dependencies (remaining `handlebars`/`lodash-es`/`vite` advisories are devDependency-only, out of scope per the plan).

Generated from [plans/031-fix-brace-expansion-cve.md](../blob/main/plans/031-fix-brace-expansion-cve.md) via `/improve execute` (plan revised before execution per an explicit request to avoid overrides where possible).

## Test plan
- [x] `pnpm audit --json` — no `brace-expansion` or `picomatch` advisories
- [x] `pnpm run build`, `pnpm run test:ci` (306 tests), `pnpm run lint`, `pnpm run typecheck` — all exit 0
- [x] Only `package.json` + `pnpm-lock.yaml` touched, diff is minimal (5 lines removed from package.json, 13-line lockfile diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)