### PR TITLE
test: cover spread-prop and complex-prop detection in props.ts (plan 033)

### DIFF
--- a/tests/swc-parser/patterns/jsx-unit.test.ts
+++ b/tests/swc-parser/patterns/jsx-unit.test.ts
@@ -49,4 +49,89 @@ describe('Parser - JSX usage', () => {
     expect(report.patterns.usage.jsx[0].component).toContain('.');
     expect(report.patterns.usage.jsx[0].component).toBe('UI.Button');
   });
+
+  test('spread props are flagged with hasSpread and a warning', () => {
+    const code = `${PREAMBLE}function App() { return <Button {...props} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const analysis = report.patterns.usage.jsx[0].propsAnalysis;
+    expect(analysis.hasSpread).toBe(true);
+    expect(analysis.hasComplexProps).toBe(true);
+    const spreadDetail = analysis.propDetails.find((p) => p.isSpread);
+    expect(spreadDetail?.warning).toBe(
+      'Spread props cannot be statically analyzed',
+    );
+  });
+
+  test('a component with only named props does not get hasSpread', () => {
+    const code = `${PREAMBLE}function App() { return <Button variant="primary" />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    expect(report.patterns.usage.jsx[0].propsAnalysis.hasSpread).toBe(false);
+  });
+
+  test('an object-expression prop value is flagged as complex', () => {
+    const code = `${PREAMBLE}function App() { return <Button config={{ a: 1 }} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const analysis = report.patterns.usage.jsx[0].propsAnalysis;
+    expect(analysis.hasComplexProps).toBe(true);
+    const configDetail = analysis.propDetails.find((p) => p.name === 'config');
+    expect(configDetail?.isComplex).toBe(true);
+    expect(configDetail?.type).toBe('object');
+  });
+
+  test('an array-expression prop value is flagged as complex', () => {
+    const code = `${PREAMBLE}function App() { return <Button items={[1, 2]} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const itemsDetail =
+      report.patterns.usage.jsx[0].propsAnalysis.propDetails.find(
+        (p) => p.name === 'items',
+      );
+    expect(itemsDetail?.isComplex).toBe(true);
+    expect(itemsDetail?.type).toBe('array');
+  });
+
+  test('a call-expression prop value is flagged as complex', () => {
+    const code = `${PREAMBLE}function App() { return <Button value={compute()} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const valueDetail =
+      report.patterns.usage.jsx[0].propsAnalysis.propDetails.find(
+        (p) => p.name === 'value',
+      );
+    expect(valueDetail?.isComplex).toBe(true);
+  });
+
+  test('a conditional-expression prop value is flagged as complex', () => {
+    const code = `${PREAMBLE}function App() { return <Button x={cond ? a : b} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const xDetail = report.patterns.usage.jsx[0].propsAnalysis.propDetails.find(
+      (p) => p.name === 'x',
+    );
+    expect(xDetail?.isComplex).toBe(true);
+  });
+
+  test('a string-literal prop value is not flagged as complex', () => {
+    const code = `${PREAMBLE}function App() { return <Button label="hi" />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const labelDetail =
+      report.patterns.usage.jsx[0].propsAnalysis.propDetails.find(
+        (p) => p.name === 'label',
+      );
+    expect(labelDetail?.isComplex).toBe(false);
+    expect(report.patterns.usage.jsx[0].propsAnalysis.hasComplexProps).toBe(
+      false,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- `props.ts` detects spread props (`<Foo {...props} />`) and complex prop values (object/array/call/conditional) — patterns hermex exists specifically to flag — but had zero test coverage; every existing `hasSpread`/`isComplex` assertion in the repo was hardcoded `false` against fixtures that never exercised these branches.
- Adds 7 tests to the existing `tests/swc-parser/patterns/jsx-unit.test.ts` (matching its established pattern): spread-prop positive/negative, and complex-prop positive cases for object/array/call/conditional expressions plus a string-literal negative case.

Generated from [plans/033-spread-complex-prop-test-coverage.md](../blob/main/plans/033-spread-complex-prop-test-coverage.md) via `/improve execute`. Test-only change — no production code touched.

## Test plan
- [x] `pnpm run test:ci` → 313 tests pass (was 306, +7 new)
- [x] `pnpm run typecheck`, `pnpm run lint` → exit 0
- [x] Only `tests/swc-parser/patterns/jsx-unit.test.ts` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)