### PR TITLE
perf: resolve package from import path in O(P) instead of resorting on every call (plan 034)

### DIFF
--- a/src/utils/package-distribution.ts
+++ b/src/utils/package-distribution.ts
@@ -32,16 +32,18 @@ function resolvePackageFromImportPath(
     return 'local';
   }
 
-  const sortedPackages = [...availablePackages].sort(
-    (a, b) => b.length - a.length,
-  );
-
-  for (const pkg of sortedPackages) {
-    if (importPath === pkg) return pkg;
-    if (importPath.startsWith(`${pkg}/`)) return pkg;
+  let longestMatch: string | null = null;
+  for (const pkg of availablePackages) {
+    const isMatch = importPath === pkg || importPath.startsWith(`${pkg}/`);
+    if (
+      isMatch &&
+      (longestMatch === null || pkg.length > longestMatch.length)
+    ) {
+      longestMatch = pkg;
+    }
   }
 
-  return 'unknown';
+  return longestMatch ?? 'unknown';
 }
 
 export function findComponentSource(

--- a/tests/utils/package-distribution.test.ts
+++ b/tests/utils/package-distribution.test.ts
@@ -63,6 +63,22 @@ describe('findComponentSource', () => {
 
     expect(findComponentSource('Ghost', report, ['antd'])).toBe('unknown');
   });
+
+  it('resolves to the longest matching package name when multiple prefixes match', () => {
+    const report = createMockReport();
+    report.patterns.imports.named.push({
+      name: 'Thing',
+      source: '@scope/pkg/sub/thing',
+    });
+
+    expect(
+      findComponentSource('Thing', report, ['@scope/pkg', '@scope/pkg/sub']),
+    ).toBe('@scope/pkg/sub');
+
+    expect(
+      findComponentSource('Thing', report, ['@scope/pkg/sub', '@scope/pkg']),
+    ).toBe('@scope/pkg/sub');
+  });
 });
 
 describe('calculatePackageDistribution', () => {


### PR DESCRIPTION
## Summary
- `resolvePackageFromImportPath` re-sorted the entire lockfile package list from scratch on every call, just to find the longest prefix match — O(N·P·log P) across a scan instead of O(P) per call.
- Replaced the sort with a single linear scan tracking the longest match directly — identical "longest match wins" semantics, no signature change, no caller changes needed.
- Added a regression test (with both orderings of the input array) pinning the exact behavior the old sort existed to guarantee.

Generated from [plans/034-fix-package-distribution-resort.md](../blob/main/plans/034-fix-package-distribution-resort.md) via `/improve execute`.

## Test plan
- [x] `resolvePackageFromImportPath` contains no `.sort(` call
- [x] New longest-match test passes (both array orderings)
- [x] `pnpm run test:ci` (307 tests), `pnpm run typecheck`, `pnpm run lint` — all exit 0
- [x] Only `src/utils/package-distribution.ts` + its test file modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)