### PR TITLE
docs: add real commands and fix strictness claim in CONTRIBUTING.md (plan 035)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,27 @@
 
 Thank you for your interest in contributing to this project. Please review the following guidelines before submitting your contributions.
 
+## Getting Started
+
+This project uses **pnpm** — always use pnpm commands, not npm or yarn.
+
+```bash
+pnpm install             # install dependencies
+
+pnpm run build            # build with tsdown
+pnpm run typecheck        # type-check with tsc --noEmit
+pnpm run test:ci           # run the test suite once
+pnpm run lint              # lint with oxlint
+pnpm run format            # format with oxfmt (writes in place)
+```
+
+All of the above (`typecheck`, `test:ci`, `lint:ci`, `format:ci`, `build:ci`)
+run in CI on every pull request — run them locally before submitting.
+
 ### Code Quality Standards
 
 - **Incremental Changes**: Submit small, focused changes that maintain project stability. Avoid large, monolithic pull requests that combine multiple unrelated features or fixes.
-- **Type Safety**: All code must be written in TypeScript with strict type checking enabled. Avoid using `any` types unless absolutely necessary and well-documented.
+- **Type Safety**: All code must be written in TypeScript. `tsconfig.json` does not currently enable `strict` mode — avoid using `any` types where a real type is easy to express, but existing code and PRs are not held to strict-mode-level type checking today.
 - **Functional Programming**: Use functional programming paradigms. Classes are not permitted; prefer pure functions, composition, and immutability.
 - **Code Clarity**: Write clear, self-documenting code. Variable and function names should be descriptive and follow established naming conventions.
 
@@ -19,12 +36,19 @@ Thank you for your interest in contributing to this project. Please review the f
 
 All contributions must adhere to the following directory structure:
 
-| Directory       | Purpose                     |
-| --------------- | --------------------------- |
-| `/src`          | Source code                 |
-| `/src/commands` | CLI command implementations |
-| `/docs`         | Project documentation       |
-| `/fixtures`     | Code fixtures               |
+| Directory           | Purpose                              |
+| ------------------- | ------------------------------------- |
+| `/src`               | Source code                           |
+| `/src/commands`      | CLI command implementations           |
+| `/src/config`        | Config loading and zod schema         |
+| `/src/rules`         | Compliance rules engine               |
+| `/src/swc-parser`    | SWC-based AST parsing engine          |
+| `/src/npm-registry`  | Registry client, cache, release-age enrichment |
+| `/src/lock-parser`   | npm/yarn/pnpm lockfile adapters       |
+| `/src/utils`         | Shared utilities and output formatting |
+| `/tests`             | All tests (mirrors `/src`)            |
+| `/docs`              | Project documentation                 |
+| `/fixtures`          | Code fixtures used by tests           |
 
 ## Style Guide
 


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` had zero runnable commands — no install step, no build/test/lint/format commands — so a contributor following it alone couldn't even install dependencies. Added a "Getting Started" section mirroring the already-correct commands in `CLAUDE.md`.
- Fixed the Project Structure table, which was missing 6 of 10 actual `/src` subdirectories.
- Corrected the "strict type checking enabled" claim, which `tsconfig.json` directly contradicts (`strict: false`). Does not enable strict mode — that's tracked separately in plan 044.

Generated from [plans/035-contributing-md-accuracy.md](../blob/main/plans/035-contributing-md-accuracy.md) via `/improve execute`. Docs-only change.

## Test plan
- [x] `grep -n 'pnpm install' CONTRIBUTING.md` → 1 match
- [x] `grep -n '/tests' CONTRIBUTING.md` → 1 match
- [x] `grep -n 'strict type checking enabled' CONTRIBUTING.md` → no matches
- [x] `pnpm run lint`, `pnpm run format:ci` → exit 0
- [x] Only `CONTRIBUTING.md` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)