### PR TITLE
refactor: extract shared read/parse/error-handling helpers across lockfile adapters (plan 037)

### DIFF
--- a/src/lock-parser/lock-file-adapter.ts
+++ b/src/lock-parser/lock-file-adapter.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 export type MultiVersionMap = Record<string, string[]>;
 
 export interface LockfileAdapter {
@@ -6,4 +8,35 @@ export interface LockfileAdapter {
   detect(projectPath: string): string | null;
   parse(lockfilePath: string): Record<string, string>;
   parseMultiVersion?(lockfilePath: string): MultiVersionMap;
+}
+
+/**
+ * Reads a lockfile and parses it with `parseFn`, returning `fallback` and
+ * warning to the console if the file can't be read or `parseFn` throws.
+ */
+export function readAndParseLockfile<T>(
+  lockFilePath: string,
+  parseFn: (content: string) => T,
+  fallback: T,
+  warnLabel: string,
+): T {
+  try {
+    const content = fs.readFileSync(lockFilePath, 'utf8');
+    return parseFn(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Warning: Could not parse ${warnLabel}: ${message}`);
+    return fallback;
+  }
+}
+
+/** Converts `{ pkg: Set<version> }` into a `MultiVersionMap` with sorted, deduplicated version arrays. */
+export function toSortedMultiVersionMap(
+  versionSets: Record<string, Set<string>>,
+): MultiVersionMap {
+  const result: MultiVersionMap = {};
+  for (const [pkg, versions] of Object.entries(versionSets)) {
+    result[pkg] = Array.from(versions).sort();
+  }
+  return result;
 }

--- a/src/lock-parser/patterns/npm.ts
+++ b/src/lock-parser/patterns/npm.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import type { LockfileAdapter, MultiVersionMap } from '../lock-file-adapter';
+import {
+  readAndParseLockfile,
+  toSortedMultiVersionMap,
+  type LockfileAdapter,
+  type MultiVersionMap,
+} from '../lock-file-adapter';
 
 function canonicalPackageName(pkgPath: string): string {
   // pkgPath examples:
@@ -24,80 +29,78 @@ export class NpmLockfileAdapter implements LockfileAdapter {
   }
 
   parse(lockFilePath: string): Record<string, string> {
-    try {
-      const content = fs.readFileSync(lockFilePath, 'utf8');
-      const lockData = JSON.parse(content);
-      const versions: Record<string, string> = {};
+    return readAndParseLockfile(
+      lockFilePath,
+      (content) => {
+        const lockData = JSON.parse(content);
+        const versions: Record<string, string> = {};
 
-      // npm v7+ uses "packages" field (lockfileVersion 2, 3)
-      if (lockData.packages) {
-        Object.entries(lockData.packages).forEach(
-          ([pkgPath, pkgData]: [string, any]) => {
-            if (!pkgPath || pkgPath === '') return;
+        // npm v7+ uses "packages" field (lockfileVersion 2, 3)
+        if (lockData.packages) {
+          Object.entries(lockData.packages).forEach(
+            ([pkgPath, pkgData]: [string, any]) => {
+              if (!pkgPath || pkgPath === '') return;
 
-            // Only root-level packages (no nested node_modules in path)
-            if (pkgPath.split('node_modules/').length > 2) return;
+              // Only root-level packages (no nested node_modules in path)
+              if (pkgPath.split('node_modules/').length > 2) return;
 
-            const pkgName = canonicalPackageName(pkgPath);
-            if (pkgData.version) {
-              versions[pkgName] = pkgData.version;
-            }
-          },
-        );
-      }
-
-      // npm v6 uses "dependencies" field (fallback)
-      if (lockData.dependencies && Object.keys(versions).length === 0) {
-        function extractVersions(deps: any, prefix = ''): void {
-          Object.entries(deps).forEach(([name, data]: [string, any]) => {
-            const fullName = prefix ? `${prefix}/${name}` : name;
-            if (data.version) {
-              versions[fullName] = data.version;
-            }
-            if (data.dependencies) {
-              extractVersions(data.dependencies, fullName);
-            }
-          });
+              const pkgName = canonicalPackageName(pkgPath);
+              if (pkgData.version) {
+                versions[pkgName] = pkgData.version;
+              }
+            },
+          );
         }
-        extractVersions(lockData.dependencies);
-      }
 
-      return versions;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`Warning: Could not parse package-lock.json: ${message}`);
-      return {};
-    }
+        // npm v6 uses "dependencies" field (fallback)
+        if (lockData.dependencies && Object.keys(versions).length === 0) {
+          function extractVersions(deps: any, prefix = ''): void {
+            Object.entries(deps).forEach(([name, data]: [string, any]) => {
+              const fullName = prefix ? `${prefix}/${name}` : name;
+              if (data.version) {
+                versions[fullName] = data.version;
+              }
+              if (data.dependencies) {
+                extractVersions(data.dependencies, fullName);
+              }
+            });
+          }
+          extractVersions(lockData.dependencies);
+        }
+
+        return versions;
+      },
+      {},
+      'package-lock.json',
+    );
   }
 
   parseMultiVersion(lockFilePath: string): MultiVersionMap {
-    try {
-      const content = fs.readFileSync(lockFilePath, 'utf8');
-      const lockData = JSON.parse(content);
-      const versionSets: Record<string, Set<string>> = {};
+    return readAndParseLockfile(
+      lockFilePath,
+      (content) => {
+        const lockData = JSON.parse(content);
+        const versionSets: Record<string, Set<string>> = {};
 
-      if (lockData.packages) {
-        Object.entries(lockData.packages).forEach(
-          ([pkgPath, pkgData]: [string, any]) => {
-            if (!pkgPath || pkgPath === '') return;
+        if (lockData.packages) {
+          Object.entries(lockData.packages).forEach(
+            ([pkgPath, pkgData]: [string, any]) => {
+              if (!pkgPath || pkgPath === '') return;
 
-            const pkgName = canonicalPackageName(pkgPath);
-            const version = (pkgData as any).version;
-            if (!version) return;
+              const pkgName = canonicalPackageName(pkgPath);
+              const version = (pkgData as any).version;
+              if (!version) return;
 
-            if (!versionSets[pkgName]) versionSets[pkgName] = new Set();
-            versionSets[pkgName].add(version);
-          },
-        );
-      }
+              if (!versionSets[pkgName]) versionSets[pkgName] = new Set();
+              versionSets[pkgName].add(version);
+            },
+          );
+        }
 
-      const result: MultiVersionMap = {};
-      for (const [pkg, versions] of Object.entries(versionSets)) {
-        result[pkg] = Array.from(versions).sort();
-      }
-      return result;
-    } catch {
-      return {};
-    }
+        return toSortedMultiVersionMap(versionSets);
+      },
+      {},
+      'package-lock.json (multi-version)',
+    );
   }
 }

--- a/src/lock-parser/patterns/pnpm.ts
+++ b/src/lock-parser/patterns/pnpm.ts
@@ -5,7 +5,12 @@ import {
   parse as parseDependencyPath,
   removeSuffix,
 } from '@pnpm/dependency-path';
-import type { LockfileAdapter, MultiVersionMap } from '../lock-file-adapter';
+import {
+  readAndParseLockfile,
+  toSortedMultiVersionMap,
+  type LockfileAdapter,
+  type MultiVersionMap,
+} from '../lock-file-adapter';
 
 function parsePackageKey(
   rawKey: string,
@@ -36,105 +41,106 @@ export class PnpmLockfileAdapter implements LockfileAdapter {
   }
 
   parse(lockFilePath: string): Record<string, string> {
-    try {
-      const content = fs.readFileSync(lockFilePath, 'utf8');
-      const lockData = load(content) as any;
-      const versions: Record<string, string> = {};
+    return readAndParseLockfile(
+      lockFilePath,
+      (content) => {
+        const lockData = load(content) as any;
+        const versions: Record<string, string> = {};
 
-      // pnpm v9+ uses "importers" field
-      if (lockData.importers) {
-        const rootImporter = lockData.importers['.'];
-        if (rootImporter) {
-          // Parse dependencies
-          if (rootImporter.dependencies) {
-            for (const [name, data] of Object.entries(
-              rootImporter.dependencies,
-            )) {
-              if (
-                typeof data === 'object' &&
-                data !== null &&
-                'version' in data
-              ) {
-                versions[name] = removeSuffix((data as any).version);
+        // pnpm v9+ uses "importers" field
+        if (lockData.importers) {
+          const rootImporter = lockData.importers['.'];
+          if (rootImporter) {
+            // Parse dependencies
+            if (rootImporter.dependencies) {
+              for (const [name, data] of Object.entries(
+                rootImporter.dependencies,
+              )) {
+                if (
+                  typeof data === 'object' &&
+                  data !== null &&
+                  'version' in data
+                ) {
+                  versions[name] = removeSuffix((data as any).version);
+                }
               }
             }
-          }
-          // Parse devDependencies
-          if (rootImporter.devDependencies) {
-            for (const [name, data] of Object.entries(
-              rootImporter.devDependencies,
-            )) {
-              if (
-                typeof data === 'object' &&
-                data !== null &&
-                'version' in data
-              ) {
-                versions[name] = removeSuffix((data as any).version);
+            // Parse devDependencies
+            if (rootImporter.devDependencies) {
+              for (const [name, data] of Object.entries(
+                rootImporter.devDependencies,
+              )) {
+                if (
+                  typeof data === 'object' &&
+                  data !== null &&
+                  'version' in data
+                ) {
+                  versions[name] = removeSuffix((data as any).version);
+                }
               }
             }
           }
         }
-      }
 
-      // pnpm v6-8 uses "packages" field
-      if (lockData.packages && Object.keys(versions).length === 0) {
-        Object.keys(lockData.packages).forEach((key) => {
-          // Key format: "/@babel/core/7.22.5" or "/package/1.0.0"
-          const match = key.match(/\/(.+?)\/(\d+\.\d+\.\d+.*?)(?:_|$)/);
-          if (match) {
-            const [, pkgName, version] = match;
-            versions[pkgName] = removeSuffix(version);
-          }
-        });
-      }
-
-      // pnpm v5 uses "dependencies" and "specifiers"
-      if (lockData.dependencies && Object.keys(versions).length === 0) {
-        Object.entries(lockData.dependencies).forEach(
-          ([name, versionSpec]: [string, any]) => {
-            // versionSpec format: "1.0.0" or "link:../package"
-            if (
-              typeof versionSpec === 'string' &&
-              !versionSpec.startsWith('link:')
-            ) {
-              versions[name] = removeSuffix(versionSpec);
-            } else if (typeof versionSpec === 'object' && versionSpec.version) {
-              versions[name] = removeSuffix(versionSpec.version);
+        // pnpm v6-8 uses "packages" field
+        if (lockData.packages && Object.keys(versions).length === 0) {
+          Object.keys(lockData.packages).forEach((key) => {
+            // Key format: "/@babel/core/7.22.5" or "/package/1.0.0"
+            const match = key.match(/\/(.+?)\/(\d+\.\d+\.\d+.*?)(?:_|$)/);
+            if (match) {
+              const [, pkgName, version] = match;
+              versions[pkgName] = removeSuffix(version);
             }
-          },
-        );
-      }
+          });
+        }
 
-      return versions;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`Warning: Could not parse pnpm-lock.yaml: ${message}`);
-      return {};
-    }
+        // pnpm v5 uses "dependencies" and "specifiers"
+        if (lockData.dependencies && Object.keys(versions).length === 0) {
+          Object.entries(lockData.dependencies).forEach(
+            ([name, versionSpec]: [string, any]) => {
+              // versionSpec format: "1.0.0" or "link:../package"
+              if (
+                typeof versionSpec === 'string' &&
+                !versionSpec.startsWith('link:')
+              ) {
+                versions[name] = removeSuffix(versionSpec);
+              } else if (
+                typeof versionSpec === 'object' &&
+                versionSpec.version
+              ) {
+                versions[name] = removeSuffix(versionSpec.version);
+              }
+            },
+          );
+        }
+
+        return versions;
+      },
+      {},
+      'pnpm-lock.yaml',
+    );
   }
 
   parseMultiVersion(lockFilePath: string): MultiVersionMap {
-    try {
-      const content = fs.readFileSync(lockFilePath, 'utf8');
-      const lockData = load(content) as any;
-      const versionSets: Record<string, Set<string>> = {};
+    return readAndParseLockfile(
+      lockFilePath,
+      (content) => {
+        const lockData = load(content) as any;
+        const versionSets: Record<string, Set<string>> = {};
 
-      if (lockData.packages) {
-        Object.keys(lockData.packages).forEach((key) => {
-          const parsed = parsePackageKey(key);
-          if (!parsed) return;
-          if (!versionSets[parsed.name]) versionSets[parsed.name] = new Set();
-          versionSets[parsed.name].add(parsed.version);
-        });
-      }
+        if (lockData.packages) {
+          Object.keys(lockData.packages).forEach((key) => {
+            const parsed = parsePackageKey(key);
+            if (!parsed) return;
+            if (!versionSets[parsed.name]) versionSets[parsed.name] = new Set();
+            versionSets[parsed.name].add(parsed.version);
+          });
+        }
 
-      const result: MultiVersionMap = {};
-      for (const [pkg, versions] of Object.entries(versionSets)) {
-        result[pkg] = Array.from(versions).sort();
-      }
-      return result;
-    } catch {
-      return {};
-    }
+        return toSortedMultiVersionMap(versionSets);
+      },
+      {},
+      'pnpm-lock.yaml (multi-version)',
+    );
   }
 }

--- a/src/lock-parser/patterns/yarn.ts
+++ b/src/lock-parser/patterns/yarn.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import lockfile from '@yarnpkg/lockfile';
-import type { LockfileAdapter, MultiVersionMap } from '../lock-file-adapter';
+import {
+  readAndParseLockfile,
+  toSortedMultiVersionMap,
+  type LockfileAdapter,
+  type MultiVersionMap,
+} from '../lock-file-adapter';
 
 function extractPackageName(key: string): string {
   if (key.startsWith('@')) {
@@ -22,58 +27,56 @@ export class YarnLockfileAdapter implements LockfileAdapter {
   }
 
   parse(lockFilePath: string): Record<string, string> {
-    try {
-      const content = fs.readFileSync(lockFilePath, 'utf8');
-      const parsed = lockfile.parse(content);
+    return readAndParseLockfile(
+      lockFilePath,
+      (content) => {
+        const parsed = lockfile.parse(content);
 
-      if (parsed.type !== 'success') {
-        console.warn('Warning: Failed to parse yarn.lock');
-        return {};
-      }
-
-      const versions: Record<string, string> = {};
-
-      Object.entries(parsed.object).forEach(([key, value]: [string, any]) => {
-        const pkgName = extractPackageName(key);
-
-        if (value.version && !versions[pkgName]) {
-          versions[pkgName] = value.version;
+        if (parsed.type !== 'success') {
+          console.warn('Warning: Failed to parse yarn.lock');
+          return {};
         }
-      });
 
-      return versions;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`Warning: Could not parse yarn.lock: ${message}`);
-      return {};
-    }
+        const versions: Record<string, string> = {};
+
+        Object.entries(parsed.object).forEach(([key, value]: [string, any]) => {
+          const pkgName = extractPackageName(key);
+
+          if (value.version && !versions[pkgName]) {
+            versions[pkgName] = value.version;
+          }
+        });
+
+        return versions;
+      },
+      {},
+      'yarn.lock',
+    );
   }
 
   parseMultiVersion(lockFilePath: string): MultiVersionMap {
-    try {
-      const content = fs.readFileSync(lockFilePath, 'utf8');
-      const parsed = lockfile.parse(content);
+    return readAndParseLockfile(
+      lockFilePath,
+      (content) => {
+        const parsed = lockfile.parse(content);
 
-      if (parsed.type !== 'success') {
-        return {};
-      }
+        if (parsed.type !== 'success') {
+          throw new Error('Failed to parse yarn.lock');
+        }
 
-      const versionSets: Record<string, Set<string>> = {};
+        const versionSets: Record<string, Set<string>> = {};
 
-      Object.entries(parsed.object).forEach(([key, value]: [string, any]) => {
-        if (!value.version) return;
-        const pkgName = extractPackageName(key);
-        if (!versionSets[pkgName]) versionSets[pkgName] = new Set();
-        versionSets[pkgName].add(value.version);
-      });
+        Object.entries(parsed.object).forEach(([key, value]: [string, any]) => {
+          if (!value.version) return;
+          const pkgName = extractPackageName(key);
+          if (!versionSets[pkgName]) versionSets[pkgName] = new Set();
+          versionSets[pkgName].add(value.version);
+        });
 
-      const result: MultiVersionMap = {};
-      for (const [pkg, vers] of Object.entries(versionSets)) {
-        result[pkg] = Array.from(vers).sort();
-      }
-      return result;
-    } catch {
-      return {};
-    }
+        return toSortedMultiVersionMap(versionSets);
+      },
+      {},
+      'yarn.lock (multi-version)',
+    );
   }
 }

--- a/tests/lock-parser/lock-parser.test.ts
+++ b/tests/lock-parser/lock-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { join } from 'node:path';
+import { writeFileSync, rmSync } from 'node:fs';
 import semver from 'semver';
 import { PnpmLockfileAdapter } from '../../src/lock-parser/patterns/pnpm';
 import { NpmLockfileAdapter } from '../../src/lock-parser/patterns/npm';
@@ -68,6 +69,22 @@ describe('PnpmLockfileAdapter', () => {
     );
     expect(multiVersions).toEqual({});
   });
+
+  it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corrupt = join(FIXTURES, 'corrupt-pnpm-lock.yaml');
+    writeFileSync(corrupt, ': not valid yaml: [', 'utf8');
+    try {
+      const multiVersions = adapter.parseMultiVersion(corrupt);
+      expect(multiVersions).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('pnpm-lock.yaml (multi-version)'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      rmSync(corrupt);
+    }
+  });
 });
 
 describe('NpmLockfileAdapter', () => {
@@ -87,6 +104,22 @@ describe('NpmLockfileAdapter', () => {
   it('detect returns the lockfile path when package-lock.json is present', () => {
     const result = adapter.detect(FIXTURES);
     expect(result).toBe(join(FIXTURES, 'package-lock.json'));
+  });
+
+  it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corrupt = join(FIXTURES, 'corrupt-package-lock.json');
+    writeFileSync(corrupt, '{ not valid json', 'utf8');
+    try {
+      const multiVersions = adapter.parseMultiVersion(corrupt);
+      expect(multiVersions).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('package-lock.json (multi-version)'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      rmSync(corrupt);
+    }
   });
 });
 
@@ -118,5 +151,25 @@ describe('YarnLockfileAdapter', () => {
       join(FIXTURES, 'nonexistent.lock'),
     );
     expect(multiVersions).toEqual({});
+  });
+
+  it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const corrupt = join(FIXTURES, 'corrupt-yarn.lock');
+    // @yarnpkg/lockfile's parser is lenient about plain text (it doesn't
+    // reliably return `type: 'error'`), but an unexpected token throws
+    // synchronously and fast — unlike some other malformed inputs, which
+    // this parser can take several seconds to reject.
+    writeFileSync(corrupt, '{{{ not yaml-ish at all }}}', 'utf8');
+    try {
+      const multiVersions = adapter.parseMultiVersion(corrupt);
+      expect(multiVersions).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('yarn.lock (multi-version)'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      rmSync(corrupt);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `src/lock-parser/patterns/{npm,pnpm,yarn}.ts` each duplicated the same read/try-catch/warn/fallback skeleton in `parse()` and `parseMultiVersion()`, plus an identical `Set`→sorted-array conversion. Extracted into two shared helpers in `lock-file-adapter.ts`: `readAndParseLockfile` and `toSortedMultiVersionMap`.
- Fixed a real, consistent-across-all-three behavioral gap while deduplicating: `parse()` always warned on failure, `parseMultiVersion()` never did (silent `return {}`). Both now warn consistently.
- All format-specific extraction logic (npm's `canonicalPackageName`, pnpm's `parsePackageKey` + 3-tier fallback, yarn's `extractPackageName` + `type !== 'success'` check) preserved byte-for-byte — only the surrounding wrapper changed.
- Added 3 new tests (one per adapter) covering the new warn-on-failure behavior for `parseMultiVersion`.

Generated from [plans/037-dedupe-lock-parser-adapters.md](../blob/main/plans/037-dedupe-lock-parser-adapters.md) via `/improve execute`.

**Note**: one documented deviation from the plan — the yarn corrupt-fixture content suggested in the plan (an unterminated quote) made `@yarnpkg/lockfile`'s parser take 5-6s to reject, risking flaky/slow CI. Substituted a different malformed input (`{{{ not yaml-ish at all }}}`) that exercises the identical failure path (throw → shared helper's catch → warn) in ~1ms, verified stable across repeated runs.

## Test plan
- [x] `readAndParseLockfile`/`toSortedMultiVersionMap` exported from `lock-file-adapter.ts`
- [x] No duplicated try/catch-with-warn blocks remain in npm.ts/pnpm.ts; yarn.ts keeps only its own necessary `parsed.type !== 'success'` early-warn in `parse()`
- [x] All 14 pre-existing lock-parser tests pass unchanged + 3 new warn-on-failure tests (17/17)
- [x] `pnpm run build`, `pnpm run test:ci` (316 tests), `pnpm run lint`, `pnpm run typecheck` — all exit 0
- [x] Only the 5 in-scope files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)