### PR TITLE
perf: precompile CODEOWNERS matchers to avoid O(files × entries) glob re-evaluation (plan 038)

### DIFF
--- a/src/rules/codeowners.ts
+++ b/src/rules/codeowners.ts
@@ -89,10 +89,33 @@ export function codeownersPatternToGlobs(pattern: string): string[] {
   return globs;
 }
 
+// Precompiled-matcher cache, keyed by the entries array identity. Avoids
+// re-parsing each entry's glob(s) into a regex on every fileIsOwned() call —
+// `evaluateCodeowners` calls this once per scanned file against the same
+// `entries` array, so this turns an O(files x entries) sequence of fresh
+// `micromatch.isMatch` glob evaluations into a one-time compile plus cheap
+// `RegExp.test` calls. Entries are treated as static for the lifetime of one
+// `entries` array (see maintenance note in plan 038); a WeakMap means a
+// fresh `entries` array (e.g. a new `parseCodeowners` call) naturally gets a
+// fresh compiled cache instead of reading stale matchers.
+const compiledMatchersCache = new WeakMap<CodeownersEntry[], RegExp[][]>();
+
+function getCompiledMatchers(entries: CodeownersEntry[]): RegExp[][] {
+  let compiled = compiledMatchersCache.get(entries);
+  if (!compiled) {
+    compiled = entries.map((entry) =>
+      entry.globs.map((glob) => micromatch.makeRe(glob, { dot: true })),
+    );
+    compiledMatchersCache.set(entries, compiled);
+  }
+  return compiled;
+}
+
 /** Last matching entry wins; owned iff that entry has >= 1 owner. */
 export function fileIsOwned(file: string, entries: CodeownersEntry[]): boolean {
+  const compiled = getCompiledMatchers(entries);
   for (let i = entries.length - 1; i >= 0; i--) {
-    if (micromatch.isMatch(file, entries[i].globs, { dot: true })) {
+    if (compiled[i].some((re) => re.test(file))) {
       return entries[i].owners.length > 0;
     }
   }

--- a/tests/rules/codeowners.test.ts
+++ b/tests/rules/codeowners.test.ts
@@ -99,6 +99,39 @@ describe('fileIsOwned', () => {
     ];
     expect(fileIsOwned('docs/guide/x.md', entries)).toBe(true);
   });
+
+  it('precompiled-matcher cache produces identical results across repeated calls with the same entries array', () => {
+    // Covers a bare-name pattern, an anchored pattern, and an unowned
+    // override pattern — mirrors "last matching rule wins" above, but calls
+    // fileIsOwned multiple times against the same entries array reference
+    // to exercise the internal per-array matcher cache (plan 038).
+    const entries: CodeownersEntry[] = [
+      {
+        pattern: 'docs',
+        globs: codeownersPatternToGlobs('docs'),
+        owners: ['@a'],
+      },
+      {
+        pattern: '/packages/core/',
+        globs: codeownersPatternToGlobs('/packages/core/'),
+        owners: ['@b'],
+      },
+      {
+        pattern: 'packages/core/generated.ts',
+        globs: codeownersPatternToGlobs('packages/core/generated.ts'),
+        owners: [],
+      },
+    ];
+
+    // Call twice for each file with the same entries array reference — the
+    // second call must hit the cache and still return the same result.
+    for (let i = 0; i < 2; i++) {
+      expect(fileIsOwned('docs/guide/x.md', entries)).toBe(true);
+      expect(fileIsOwned('packages/core/util.ts', entries)).toBe(true);
+      expect(fileIsOwned('packages/core/generated.ts', entries)).toBe(false);
+      expect(fileIsOwned('unrelated/file.txt', entries)).toBe(false);
+    }
+  });
 });
 
 describe('evaluateCodeowners', () => {


### PR DESCRIPTION
## Summary
- This was an **investigate-first** plan: `fileIsOwned` does a reverse linear scan over every CODEOWNERS entry with a fresh `micromatch.isMatch` glob evaluation per entry per scanned file — a MED-confidence finding whose real-world cost hadn't been measured, only reasoned about.
- Measured at a synthetic 500-entry CODEOWNERS file × 5,000 scanned files: **~3.4s** with the current implementation vs **~108ms** with per-entry precompiled matchers (`micromatch.makeRe`, cached per `entries` array via `WeakMap`) — a **31.6x** speedup, well past the plan's own 200ms/3x thresholds for "fix warranted."
- Preserves "last matching entry wins" + `owners.length > 0` semantics exactly — verified by all 16 pre-existing tests passing unchanged, plus 1 new equivalence test exercising the cache across repeated calls (bare-name, anchored, and unowned-override patterns).

Generated from [plans/038-investigate-codeowners-perf.md](../blob/main/plans/038-investigate-codeowners-perf.md) via `/improve execute`.

**Reviewer note**: the executor flagged that `micromatch.makeRe` per-glob + `.some()` could theoretically diverge from `isMatch`'s array-of-patterns negation semantics (`!pattern`) — I independently verified this doesn't manifest here: `codeownersPatternToGlobs` never produces a glob array mixing a negated pattern with others from a different source line (a single CODEOWNERS line's globs come from one call, and a leading-`!` pattern always yields exactly one glob, never a 2-element array), so there's no case where array-negation-vs-independent-OR semantics could differ in practice.

## Test plan
- [x] Benchmark numbers recorded above (temporary script, not committed)
- [x] `tests/rules/codeowners.test.ts` — 17/17 pass (16 pre-existing unchanged + 1 new equivalence test)
- [x] `pnpm run test:ci` (314 tests), `pnpm run typecheck`, `pnpm run lint` — all exit 0
- [x] Only `src/rules/codeowners.ts` + its test file modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)