### PR TITLE
feat: add requiredOwners option to the codeowners rule (plan 039)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -161,6 +161,27 @@ nothing after it) explicitly un-assigns ownership for files it matches,
 even if an earlier pattern owned them. If no CODEOWNERS file is found at
 all, this rule reports a single violation rather than silently passing.
 
+Require a *specific* owner (not just "owned by someone"), useful for
+critical paths that must be reviewed by a particular team:
+
+```ts
+export default defineConfig({
+  rules: {
+    codeowners: {
+      severity: 'error',
+      requiredOwners: ['@org/platform-team'],
+      message: 'Critical paths must be owned by @org/platform-team',
+    },
+  },
+});
+```
+
+`requiredOwners` matches CODEOWNERS entries' owner strings exactly (as
+written in the file, e.g. `@org/team` or `@individual`) — it does not
+resolve GitHub team membership. Files with no CODEOWNERS coverage at all
+are still reported as "unowned," separately from files owned by someone
+who isn't in `requiredOwners`.
+
 ### Script and Field Requirements
 
 ```ts

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -34,6 +34,8 @@ const EngineVersionRuleSchema = z.object({
 const CodeownersRuleSchema = z.object({
   severity: RuleSeveritySchema,
   message: z.string().optional(),
+  /** If set, matched files must be owned by at least one of these owner strings (exact match against CODEOWNERS entries, e.g. "@org/team"). */
+  requiredOwners: z.array(z.string()).optional(),
 });
 
 const ThresholdSchema = z.union([z.number(), z.literal(false)]);

--- a/src/rules/codeowners.ts
+++ b/src/rules/codeowners.ts
@@ -89,14 +89,23 @@ export function codeownersPatternToGlobs(pattern: string): string[] {
   return globs;
 }
 
-/** Last matching entry wins; owned iff that entry has >= 1 owner. */
-export function fileIsOwned(file: string, entries: CodeownersEntry[]): boolean {
+/** Last matching entry, or null if none match. */
+export function findOwningEntry(
+  file: string,
+  entries: CodeownersEntry[],
+): CodeownersEntry | null {
   for (let i = entries.length - 1; i >= 0; i--) {
     if (micromatch.isMatch(file, entries[i].globs, { dot: true })) {
-      return entries[i].owners.length > 0;
+      return entries[i];
     }
   }
-  return false;
+  return null;
+}
+
+/** Last matching entry wins; owned iff that entry has >= 1 owner. */
+export function fileIsOwned(file: string, entries: CodeownersEntry[]): boolean {
+  const entry = findOwningEntry(file, entries);
+  return entry !== null && entry.owners.length > 0;
 }
 
 export function evaluateCodeowners(
@@ -124,16 +133,46 @@ export function evaluateCodeowners(
   const relFiles = scannedFiles.map((f) =>
     (path.isAbsolute(f) ? path.relative(repoPath, f) : f).replace(/\\/g, '/'),
   );
-  const unowned = relFiles.filter((f) => !fileIsOwned(f, entries));
-  if (unowned.length === 0) return [];
 
-  return [
-    {
+  const unowned: string[] = [];
+  const wrongOwner: string[] = [];
+  const requiredOwners = rule.requiredOwners;
+
+  for (const f of relFiles) {
+    const entry = findOwningEntry(f, entries);
+    const owned = entry !== null && entry.owners.length > 0;
+    if (!owned) {
+      unowned.push(f);
+      continue;
+    }
+    if (requiredOwners && requiredOwners.length > 0) {
+      const hasRequiredOwner = entry!.owners.some((o) =>
+        requiredOwners.includes(o),
+      );
+      if (!hasRequiredOwner) wrongOwner.push(f);
+    }
+  }
+
+  const violations: RuleViolation[] = [];
+  if (unowned.length > 0) {
+    violations.push({
       type: 'codeowners',
       severity: rule.severity,
       patterns: [path.basename(filePath)],
       message: rule.message,
       matchedFiles: unowned,
-    },
-  ];
+    });
+  }
+  if (wrongOwner.length > 0) {
+    violations.push({
+      type: 'codeowners',
+      severity: rule.severity,
+      patterns: [path.basename(filePath)],
+      message:
+        rule.message ??
+        `Files must be owned by one of: ${requiredOwners!.join(', ')}`,
+      matchedFiles: wrongOwner,
+    });
+  }
+  return violations;
 }

--- a/tests/rules/codeowners.test.ts
+++ b/tests/rules/codeowners.test.ts
@@ -166,3 +166,81 @@ describe('evaluateCodeowners', () => {
     expect(result).toHaveLength(0);
   });
 });
+
+describe('evaluateCodeowners — requiredOwners', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('flags a file owned by someone other than the required owner', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
+    mkdirSync(join(tempDir, '.github'));
+    writeFileSync(join(tempDir, '.github', 'CODEOWNERS'), 'src/ @other-team\n');
+    const result = evaluateCodeowners(
+      tempDir,
+      {
+        ...emptyRules,
+        codeowners: { severity: 'error', requiredOwners: ['@platform-team'] },
+      },
+      ['src/App.tsx'],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].matchedFiles).toEqual(['src/App.tsx']);
+  });
+
+  it('does not flag a file owned by a required owner', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
+    mkdirSync(join(tempDir, '.github'));
+    writeFileSync(
+      join(tempDir, '.github', 'CODEOWNERS'),
+      'src/ @platform-team @other-team\n',
+    );
+    const result = evaluateCodeowners(
+      tempDir,
+      {
+        ...emptyRules,
+        codeowners: { severity: 'error', requiredOwners: ['@platform-team'] },
+      },
+      ['src/App.tsx'],
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('reports unowned and wrong-owner files as separate violations', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
+    mkdirSync(join(tempDir, '.github'));
+    writeFileSync(join(tempDir, '.github', 'CODEOWNERS'), 'src/ @other-team\n');
+    const result = evaluateCodeowners(
+      tempDir,
+      {
+        ...emptyRules,
+        codeowners: { severity: 'error', requiredOwners: ['@platform-team'] },
+      },
+      ['src/App.tsx', 'lib/x.ts'],
+    );
+    expect(result).toHaveLength(2);
+    const unownedViolation = result.find((v) =>
+      v.matchedFiles.includes('lib/x.ts'),
+    );
+    const wrongOwnerViolation = result.find((v) =>
+      v.matchedFiles.includes('src/App.tsx'),
+    );
+    expect(unownedViolation).toBeDefined();
+    expect(wrongOwnerViolation).toBeDefined();
+    expect(unownedViolation).not.toBe(wrongOwnerViolation);
+  });
+
+  it('is a no-op when requiredOwners is not set (existing behavior unchanged)', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
+    mkdirSync(join(tempDir, '.github'));
+    writeFileSync(join(tempDir, '.github', 'CODEOWNERS'), 'src/ @any-team\n');
+    const result = evaluateCodeowners(
+      tempDir,
+      { ...emptyRules, codeowners: { severity: 'error' } },
+      ['src/App.tsx'],
+    );
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `CodeownersEntry.owners` already parses the full owner list per CODEOWNERS pattern, but `fileIsOwned` only ever checked "owned by someone" vs. unowned — no way to require a *specific* owner/team.
- Adds an optional `requiredOwners?: string[]` field to the `codeowners` rule config. When set, files owned by someone not in that list are flagged separately from truly-unowned files (distinct violation messages, so the two concerns aren't conflated).
- Refactored `fileIsOwned` into a new `findOwningEntry` helper (pure refactor, zero behavior change) that both the existing ownership check and the new required-owner check build on.
- Extended the CODEOWNERS Rule doc section (added by plan 036) with a `requiredOwners` example.

Note: this is a new feature, not a bug fix — unlike most of this batch, it's picking up optional capability the maintainer can choose to use or ignore.

Generated from [plans/039-codeowners-required-owner-option.md](../blob/main/plans/039-codeowners-required-owner-option.md) via `/improve execute`.

## Test plan
- [x] `findOwningEntry` refactor step verified behavior-identical before adding new logic (16/16 pre-existing tests unchanged)
- [x] 4 new tests: wrong-owner flagged, correct-owner not flagged, unowned + wrong-owner reported as separate violations, no-op when `requiredOwners` unset — 20/20 total pass
- [x] `docs/examples.md` documents `requiredOwners`
- [x] `pnpm run build`, `pnpm run test:ci` (320 tests), `pnpm run lint`, `pnpm run typecheck` — all exit 0
- [x] Only the 4 in-scope files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)