### PR TITLE
perf: precompile CODEOWNERS matchers in findOwningEntry (plan 038, rebuilt after conflict)

### DIFF
--- a/src/rules/codeowners.ts
+++ b/src/rules/codeowners.ts
@@ -89,13 +89,36 @@ export function codeownersPatternToGlobs(pattern: string): string[] {
   return globs;
 }
 
+// Precompiled-matcher cache, keyed by the entries array identity. Avoids
+// re-parsing each entry's glob(s) into a regex on every findOwningEntry()
+// call — evaluateCodeowners calls this once per scanned file against the
+// same `entries` array (both directly, and via fileIsOwned), so this turns
+// an O(files x entries) sequence of fresh `micromatch.isMatch` glob
+// evaluations into a one-time compile plus cheap `RegExp.test` calls.
+// Entries are treated as static for the lifetime of one `entries` array; a
+// WeakMap means a fresh `entries` array (e.g. a new `parseCodeowners` call)
+// naturally gets a fresh compiled cache instead of reading stale matchers.
+const compiledMatchersCache = new WeakMap<CodeownersEntry[], RegExp[][]>();
+
+function getCompiledMatchers(entries: CodeownersEntry[]): RegExp[][] {
+  let compiled = compiledMatchersCache.get(entries);
+  if (!compiled) {
+    compiled = entries.map((entry) =>
+      entry.globs.map((glob) => micromatch.makeRe(glob, { dot: true })),
+    );
+    compiledMatchersCache.set(entries, compiled);
+  }
+  return compiled;
+}
+
 /** Last matching entry, or null if none match. */
 export function findOwningEntry(
   file: string,
   entries: CodeownersEntry[],
 ): CodeownersEntry | null {
+  const compiled = getCompiledMatchers(entries);
   for (let i = entries.length - 1; i >= 0; i--) {
-    if (micromatch.isMatch(file, entries[i].globs, { dot: true })) {
+    if (compiled[i].some((re) => re.test(file))) {
       return entries[i];
     }
   }

--- a/tests/rules/codeowners.test.ts
+++ b/tests/rules/codeowners.test.ts
@@ -99,6 +99,39 @@ describe('fileIsOwned', () => {
     ];
     expect(fileIsOwned('docs/guide/x.md', entries)).toBe(true);
   });
+
+  it('precompiled-matcher cache produces identical results across repeated calls with the same entries array', () => {
+    // Covers a bare-name pattern, an anchored pattern, and an unowned
+    // override pattern — mirrors "last matching rule wins" above, but calls
+    // fileIsOwned multiple times against the same entries array reference
+    // to exercise the internal per-array matcher cache in findOwningEntry.
+    const entries: CodeownersEntry[] = [
+      {
+        pattern: 'docs',
+        globs: codeownersPatternToGlobs('docs'),
+        owners: ['@a'],
+      },
+      {
+        pattern: '/packages/core/',
+        globs: codeownersPatternToGlobs('/packages/core/'),
+        owners: ['@b'],
+      },
+      {
+        pattern: 'packages/core/generated.ts',
+        globs: codeownersPatternToGlobs('packages/core/generated.ts'),
+        owners: [],
+      },
+    ];
+
+    // Call twice for each file with the same entries array reference — the
+    // second call must hit the cache and still return the same result.
+    for (let i = 0; i < 2; i++) {
+      expect(fileIsOwned('docs/guide/x.md', entries)).toBe(true);
+      expect(fileIsOwned('packages/core/util.ts', entries)).toBe(true);
+      expect(fileIsOwned('packages/core/generated.ts', entries)).toBe(false);
+      expect(fileIsOwned('unrelated/file.txt', entries)).toBe(false);
+    }
+  });
 });
 
 describe('evaluateCodeowners', () => {


### PR DESCRIPTION
## Summary
- Supersedes #47 (closed — conflicted with #48/plan 039, which merged first and refactored `fileIsOwned` into a new `findOwningEntry` helper this branch didn't know about).
- Same, already-measured fix (500 entries × 5,000 files: ~3.4s → ~108ms, 31.6x speedup — see the original investigation in plan 038's history), rebuilt to target `findOwningEntry` instead of the old inline `fileIsOwned` loop.
- Bonus over the original: since `evaluateCodeowners`'s `requiredOwners` check (plan 039) also calls `findOwningEntry` directly, this speeds up **both** the ownership check and the required-owner check, not just the one path originally measured.
- `fileIsOwned` and `evaluateCodeowners` bodies are untouched — pure internal algorithm swap inside `findOwningEntry`.

Generated from [plans/038-investigate-codeowners-perf.md](../blob/main/plans/038-investigate-codeowners-perf.md) via `/improve execute`.

**Reviewer note**: `pnpm run test:ci` shows one flaky failure in `tests/e2e/cli.test.ts` — its `beforeAll` hook runs `pnpm run build` and occasionally exceeds vitest's default 10s hook timeout. Verified this is pre-existing and unrelated to this change: it reproduces identically on unmodified `main` (via `git stash`), the build itself times at ~3s when run directly, and the full suite passes cleanly with an extended hook timeout (28/28 files, 321/321 tests).

## Test plan
- [x] `findOwningEntry` uses precompiled `RegExp` matchers instead of `micromatch.isMatch` per call
- [x] `fileIsOwned`/`evaluateCodeowners` bodies unchanged
- [x] All 20 pre-existing `codeowners.test.ts` tests pass unchanged (including plan 039's 4 `requiredOwners` tests, which exercise `findOwningEntry` via a different call path) + 1 new equivalence test = 21/21
- [x] `pnpm run typecheck`, `pnpm run lint` — exit 0
- [x] Only `src/rules/codeowners.ts` + its test file modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)