### PR TITLE
test: raise branch coverage above 90%

### DIFF
--- a/tests/lock-parser/fixtures/package-lock-nested.json
+++ b/tests/lock-parser/fixtures/package-lock-nested.json
@@ -1,0 +1,29 @@
+{
+  "name": "test-nested",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-nested"
+    },
+    "node_modules/foo": {
+      "version": "1.0.0"
+    },
+    "node_modules/foo/node_modules/bar": {
+      "version": "2.0.0"
+    },
+    "node_modules/no-version": {
+      "resolved": "https://registry.npmjs.org/no-version/-/no-version-1.0.0.tgz"
+    },
+    "packages/workspace-a": {
+      "version": "1.0.0"
+    },
+    "node_modules/dupe": {
+      "version": "1.0.0"
+    },
+    "node_modules/foo/node_modules/dupe": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/tests/lock-parser/fixtures/package-lock-v6.json
+++ b/tests/lock-parser/fixtures/package-lock-v6.json
@@ -1,0 +1,23 @@
+{
+  "name": "test-project-v6",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
+    },
+    "no-version-pkg": {
+      "resolved": "https://registry.npmjs.org/no-version-pkg/-/no-version-pkg-1.0.0.tgz"
+    },
+    "parent-pkg": {
+      "version": "1.0.0",
+      "dependencies": {
+        "nested-pkg": {
+          "version": "2.0.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/lock-parser/fixtures/pnpm-lock-deps-only.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-deps-only.yaml
@@ -1,0 +1,8 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      chalk:
+        specifier: ^5.0.0
+        version: 5.3.0

--- a/tests/lock-parser/fixtures/pnpm-lock-devdeps-only.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-devdeps-only.yaml
@@ -1,0 +1,8 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    devDependencies:
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.0

--- a/tests/lock-parser/fixtures/pnpm-lock-legacy.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-legacy.yaml
@@ -1,0 +1,5 @@
+packages:
+  /@babel/core/7.22.5:
+    resolution: { integrity: sha512-example }
+  /invalidkey:
+    resolution: { integrity: sha512-example }

--- a/tests/lock-parser/fixtures/pnpm-lock-malformed-importer.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-malformed-importer.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      chalk:
+        specifier: ^5.0.0
+        version: 5.3.0
+      bare-string-dep: 1.0.0
+      no-version-dep:
+        specifier: ^1.0.0
+    devDependencies:
+      bare-string-dev-dep: 2.0.0
+      no-version-dev-dep:
+        specifier: ^2.0.0

--- a/tests/lock-parser/fixtures/pnpm-lock-no-root-importer.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-no-root-importer.yaml
@@ -1,0 +1,8 @@
+lockfileVersion: '9.0'
+
+importers:
+  packages/foo:
+    dependencies:
+      chalk:
+        specifier: ^5.0.0
+        version: 5.3.0

--- a/tests/lock-parser/fixtures/pnpm-lock-v5.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-v5.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  chalk: 5.3.0
+  local-pkg: 'link:../local-pkg'
+  vitest:
+    version: 1.6.0
+specifiers:
+  chalk: ^5.0.0
+  local-pkg: 'link:../local-pkg'
+  vitest: ^1.0.0

--- a/tests/lock-parser/fixtures/pnpm-lock-v6.yaml
+++ b/tests/lock-parser/fixtures/pnpm-lock-v6.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '6.0'
+
+packages:
+  /chalk/5.3.0:
+    resolution: { integrity: sha512-example }
+  /lodash/4.17.21_react@18.0.0:
+    resolution: { integrity: sha512-example }
+  /badkey:
+    resolution: { integrity: sha512-example }

--- a/tests/lock-parser/fixtures/yarn.lock
+++ b/tests/lock-parser/fixtures/yarn.lock
@@ -15,3 +15,7 @@ lodash@^3.0.0:
 lodash@^4.0.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+
+"@scope/pkg@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@scope/pkg/-/pkg-1.0.0.tgz"

--- a/tests/lock-parser/lock-parser.test.ts
+++ b/tests/lock-parser/lock-parser.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { join } from 'node:path';
 import { writeFileSync, rmSync } from 'node:fs';
 import semver from 'semver';
+import lockfileLib from '@yarnpkg/lockfile';
 import { PnpmLockfileAdapter } from '../../src/lock-parser/patterns/pnpm';
 import { NpmLockfileAdapter } from '../../src/lock-parser/patterns/npm';
 import { YarnLockfileAdapter } from '../../src/lock-parser/patterns/yarn';
+import { readAndParseLockfile } from '../../src/lock-parser/lock-file-adapter';
 
 // @yarnpkg/lockfile is a CJS bundle that sets `__esModule: true` and exports a
 // `default` that is NOT the module namespace (it's the Lockfile class). In
@@ -85,6 +87,65 @@ describe('PnpmLockfileAdapter', () => {
       rmSync(corrupt);
     }
   });
+
+  it('falls back to the v6-8 "packages" field when there is no "importers" field', () => {
+    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock-v6.yaml'));
+    expect(versions['chalk']).toBe('5.3.0');
+    expect(versions['lodash']).toBe('4.17.21');
+    expect(versions['badkey']).toBeUndefined();
+  });
+
+  it('falls back to v5 "dependencies" (string, link:, and object forms) when there is no "importers" or "packages" field', () => {
+    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock-v5.yaml'));
+    expect(versions['chalk']).toBe('5.3.0');
+    expect(versions['vitest']).toBe('1.6.0');
+    expect(versions['local-pkg']).toBeUndefined();
+  });
+
+  it('parsePackageKey resolves the legacy pnpm v5/v6 slash-separated key format', () => {
+    const multiVersions = adapter.parseMultiVersion(
+      join(FIXTURES, 'pnpm-lock-legacy.yaml'),
+    );
+    expect(multiVersions['@babel/core']).toEqual(['7.22.5']);
+  });
+
+  it('returns no versions when "importers" is present but has no root "." entry', () => {
+    const versions = adapter.parse(
+      join(FIXTURES, 'pnpm-lock-no-root-importer.yaml'),
+    );
+    expect(versions).toEqual({});
+  });
+
+  it('parses an importer that has only "dependencies" (no "devDependencies" key)', () => {
+    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock-deps-only.yaml'));
+    expect(versions['chalk']).toBe('5.3.0');
+  });
+
+  it('parses an importer that has only "devDependencies" (no "dependencies" key)', () => {
+    const versions = adapter.parse(
+      join(FIXTURES, 'pnpm-lock-devdeps-only.yaml'),
+    );
+    expect(versions['vitest']).toBe('1.6.0');
+  });
+
+  it('skips importer dependency/devDependency entries that are not a well-formed {version} object', () => {
+    const versions = adapter.parse(
+      join(FIXTURES, 'pnpm-lock-malformed-importer.yaml'),
+    );
+    expect(versions['chalk']).toBe('5.3.0');
+    expect(versions['bare-string-dep']).toBeUndefined();
+    expect(versions['no-version-dep']).toBeUndefined();
+    expect(versions['bare-string-dev-dep']).toBeUndefined();
+    expect(versions['no-version-dev-dep']).toBeUndefined();
+  });
+
+  it('parsePackageKey skips a key that matches neither the modern nor legacy format', () => {
+    const multiVersions = adapter.parseMultiVersion(
+      join(FIXTURES, 'pnpm-lock-legacy.yaml'),
+    );
+    expect(Object.keys(multiVersions)).not.toContain('invalidkey');
+    expect(Object.keys(multiVersions)).toEqual(['@babel/core']);
+  });
 });
 
 describe('NpmLockfileAdapter', () => {
@@ -104,6 +165,49 @@ describe('NpmLockfileAdapter', () => {
   it('detect returns the lockfile path when package-lock.json is present', () => {
     const result = adapter.detect(FIXTURES);
     expect(result).toBe(join(FIXTURES, 'package-lock.json'));
+  });
+
+  it('detect returns null when no package-lock.json is present', () => {
+    const result = adapter.detect(join(FIXTURES, 'does-not-exist'));
+    expect(result).toBeNull();
+  });
+
+  it('falls back to the v6 "dependencies" field (recursing into nested dependencies) when there is no "packages" field', () => {
+    const versions = adapter.parse(join(FIXTURES, 'package-lock-v6.json'));
+    expect(versions['chalk']).toBe('5.3.0');
+    expect(versions['no-version-pkg']).toBeUndefined();
+    expect(versions['parent-pkg']).toBe('1.0.0');
+    expect(versions['parent-pkg/nested-pkg']).toBe('2.0.0');
+  });
+
+  it('filters out nested node_modules entries and skips packages without a version', () => {
+    const versions = adapter.parse(join(FIXTURES, 'package-lock-nested.json'));
+    expect(versions['foo']).toBe('1.0.0');
+    expect(versions['bar']).toBeUndefined();
+    expect(versions['no-version']).toBeUndefined();
+  });
+
+  it('canonicalPackageName returns the path unchanged when it contains no "node_modules/" segment (e.g. a workspace path)', () => {
+    const versions = adapter.parse(join(FIXTURES, 'package-lock-nested.json'));
+    expect(versions['packages/workspace-a']).toBe('1.0.0');
+  });
+
+  it('parseMultiVersion skips packages entries without a version', () => {
+    const multiVersions = adapter.parseMultiVersion(
+      join(FIXTURES, 'package-lock-nested.json'),
+    );
+    expect(multiVersions['foo']).toEqual(['1.0.0']);
+    expect(multiVersions['no-version']).toBeUndefined();
+  });
+
+  it('parseMultiVersion collects multiple versions when two different paths canonicalize to the same package name', () => {
+    // "node_modules/dupe" (1.0.0) and "node_modules/foo/node_modules/dupe"
+    // (2.0.0) both canonicalize to "dupe" — parseMultiVersion (unlike parse)
+    // doesn't filter out nested node_modules paths, so both must be tracked.
+    const multiVersions = adapter.parseMultiVersion(
+      join(FIXTURES, 'package-lock-nested.json'),
+    );
+    expect(multiVersions['dupe']).toEqual(['1.0.0', '2.0.0']);
   });
 
   it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
@@ -132,9 +236,109 @@ describe('YarnLockfileAdapter', () => {
     expect(versions['vitest']).toBe('1.6.0');
   });
 
+  it('extracts a scoped package name from its key', () => {
+    const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
+    expect(versions['@scope/pkg']).toBe('1.0.0');
+  });
+
+  it('detect returns the lockfile path when yarn.lock is present', () => {
+    const result = adapter.detect(FIXTURES);
+    expect(result).toBe(join(FIXTURES, 'yarn.lock'));
+  });
+
+  it('detect returns null when no yarn.lock is present', () => {
+    const result = adapter.detect(join(FIXTURES, 'does-not-exist'));
+    expect(result).toBeNull();
+  });
+
+  it('extractPackageName falls back to the raw key when it does not match the expected @-delimited shape', () => {
+    // Real yarn.lock keys always have a name@range shape, so these
+    // fallback branches exist purely as defensive guards — reachable only
+    // by feeding the parser's output shape directly, hence mocking parse().
+    const parseSpy = vi.spyOn(lockfileLib, 'parse').mockReturnValue({
+      type: 'success',
+      object: {
+        '@scope-no-slash': { version: '1.0.0' },
+        'no-at-sign-key': { version: '2.0.0' },
+      },
+    });
+    try {
+      const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
+      expect(versions['@scope-no-slash']).toBe('1.0.0');
+      expect(versions['no-at-sign-key']).toBe('2.0.0');
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it('parseMultiVersion skips an entry with no version', () => {
+    const parseSpy = vi.spyOn(lockfileLib, 'parse').mockReturnValue({
+      type: 'success',
+      object: {
+        'no-version-pkg@^1.0.0': { resolved: 'https://example.com/x.tgz' },
+        'chalk@^5.0.0': { version: '5.3.0' },
+      },
+    });
+    try {
+      const multiVersions = adapter.parseMultiVersion(
+        join(FIXTURES, 'yarn.lock'),
+      );
+      expect(multiVersions['no-version-pkg']).toBeUndefined();
+      expect(multiVersions['chalk']).toEqual(['5.3.0']);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
+  it('parse keeps the first-seen version for a duplicate package name (dedup guard)', () => {
+    // yarn.lock fixture has both `lodash@^3.0.0` (3.10.1) and `lodash@^4.0.0`
+    // (4.17.21) resolving to the same package name "lodash".
+    const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
+    expect(versions['lodash']).toBe('3.10.1');
+  });
+
+  it('parse warns and returns empty object when the parser reports a non-success result', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const parseSpy = vi
+      .spyOn(lockfileLib, 'parse')
+      .mockReturnValue({ type: 'merge', object: {} });
+    try {
+      const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
+      expect(versions).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Warning: Failed to parse yarn.lock',
+      );
+    } finally {
+      parseSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
   it('returns empty object when file does not exist', () => {
     const versions = adapter.parse(join(FIXTURES, 'nonexistent.lock'));
     expect(versions).toEqual({});
+  });
+
+  it('parseMultiVersion warns and returns empty object when the parser reports a non-success result', () => {
+    // parseMultiVersion's non-success branch throws internally (unlike
+    // parse(), which returns {} directly) — readAndParseLockfile catches
+    // that throw and converts it into the same warn+fallback behavior.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const parseSpy = vi
+      .spyOn(lockfileLib, 'parse')
+      .mockReturnValue({ type: 'merge', object: {} });
+    try {
+      const multiVersions = adapter.parseMultiVersion(
+        join(FIXTURES, 'yarn.lock'),
+      );
+      expect(multiVersions).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('yarn.lock (multi-version)'),
+      );
+    } finally {
+      parseSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 
   it('parseMultiVersion collects all distinct versions per package', () => {
@@ -170,6 +374,29 @@ describe('YarnLockfileAdapter', () => {
     } finally {
       warnSpy.mockRestore();
       rmSync(corrupt);
+    }
+  });
+});
+
+describe('readAndParseLockfile', () => {
+  it('stringifies a thrown non-Error value in the warning message', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = readAndParseLockfile(
+        join(FIXTURES, 'yarn.lock'),
+        () => {
+          // eslint-disable-next-line no-throw-literal
+          throw 'plain string failure';
+        },
+        {},
+        'test-label',
+      );
+      expect(result).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('plain string failure'),
+      );
+    } finally {
+      warnSpy.mockRestore();
     }
   });
 });

--- a/tests/npm-registry/cache.test.ts
+++ b/tests/npm-registry/cache.test.ts
@@ -51,6 +51,18 @@ describe('readCache / writeCache', () => {
     expect(result).toBeNull();
   });
 
+  it('falls back to the default cache directory when no cacheDir override is given', async () => {
+    // No cacheDir passed at all — exercises the `?? DEFAULT_CACHE_DIR`
+    // fallback. A cache miss on this path is read-only (readFile + catch),
+    // so this is safe to run against the real default location without any
+    // writes or directory creation.
+    const result = await readCache(
+      REGISTRY,
+      '@hermex-test/definitely-not-a-real-package-xyz',
+    );
+    expect(result).toBeNull();
+  });
+
   it('returns null and does not throw on a corrupt cache file', async () => {
     const info = makeInfo('lodash');
     await writeCache(REGISTRY, 'lodash', info, { cacheDir });
@@ -59,6 +71,29 @@ describe('readCache / writeCache', () => {
     await writeFile(path, 'not valid json {{{', 'utf8');
 
     const result = await readCache(REGISTRY, 'lodash', { cacheDir });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the cached entry belongs to a different registry/package (filename collision)', async () => {
+    const info = makeInfo('react');
+    await writeCache(REGISTRY, 'react', info, { cacheDir });
+    // Overwrite with a same-path entry recorded under a different registry.
+    await writeCache('https://registry.npmjs.org', 'react', info, {
+      cacheDir,
+    });
+    const path = join(cacheDir, 'registry.npmjs.org', 'react.json');
+    await writeFile(
+      path,
+      JSON.stringify({
+        cachedAt: Date.now(),
+        registryUrl: 'https://other-registry.example.com',
+        packageName: 'react',
+        data: info,
+      }),
+      'utf8',
+    );
+
+    const result = await readCache(REGISTRY, 'react', { cacheDir });
     expect(result).toBeNull();
   });
 

--- a/tests/rules/codeowners.test.ts
+++ b/tests/rules/codeowners.test.ts
@@ -184,6 +184,19 @@ describe('evaluateCodeowners', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('converts an absolute scanned-file path to repo-relative before matching', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
+    mkdirSync(join(tempDir, '.github'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(join(tempDir, '.github', 'CODEOWNERS'), 'src/ @a\n');
+    const result = evaluateCodeowners(
+      tempDir,
+      { ...emptyRules, codeowners: { severity: 'error' } },
+      [join(tempDir, 'src', 'App.tsx')],
+    );
+    expect(result).toHaveLength(0);
+  });
+
   it('prefers .github/CODEOWNERS over root CODEOWNERS when both exist', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
     mkdirSync(join(tempDir, '.github'));
@@ -263,6 +276,26 @@ describe('evaluateCodeowners — requiredOwners', () => {
     expect(unownedViolation).toBeDefined();
     expect(wrongOwnerViolation).toBeDefined();
     expect(unownedViolation).not.toBe(wrongOwnerViolation);
+  });
+
+  it('uses a custom message for a wrong-owner violation when one is configured', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hermex-codeowners-test-'));
+    mkdirSync(join(tempDir, '.github'));
+    writeFileSync(join(tempDir, '.github', 'CODEOWNERS'), 'src/ @other-team\n');
+    const result = evaluateCodeowners(
+      tempDir,
+      {
+        ...emptyRules,
+        codeowners: {
+          severity: 'error',
+          requiredOwners: ['@platform-team'],
+          message: 'wrong owner for this path',
+        },
+      },
+      ['src/App.tsx'],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('wrong owner for this path');
   });
 
   it('is a no-op when requiredOwners is not set (existing behavior unchanged)', () => {

--- a/tests/rules/evaluator.test.ts
+++ b/tests/rules/evaluator.test.ts
@@ -195,6 +195,30 @@ describe('evaluateScriptRules', () => {
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('require_scripts');
   });
+
+  it('returns nothing when no require_scripts rules are configured', () => {
+    const result = evaluateScriptRules(tempDir, emptyRules);
+    expect(result).toHaveLength(0);
+  });
+
+  it('falls back to an empty script list when package.json has no scripts field', () => {
+    const emptyDir = mkdtempSync(
+      join(tmpdir(), 'hermex-rules-test-noscripts-'),
+    );
+    try {
+      writeFileSync(
+        join(emptyDir, 'package.json'),
+        JSON.stringify({ name: 'no-scripts-project' }),
+      );
+      const result = evaluateScriptRules(emptyDir, {
+        ...emptyRules,
+        require_scripts: [{ severity: 'error', patterns: ['build'] }],
+      });
+      expect(result).toHaveLength(1);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('evaluatePackageFieldRules', () => {
@@ -297,6 +321,48 @@ describe('evaluatePackageFieldRules', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('never matches a values pattern when the forbidden field value is an object', () => {
+    const objectFieldDir = mkdtempSync(
+      join(tmpdir(), 'hermex-rules-test-objectfield-'),
+    );
+    try {
+      writeFileSync(
+        join(objectFieldDir, 'package.json'),
+        JSON.stringify({ name: 'x', jest: { testEnvironment: 'node' } }),
+      );
+      const result = evaluatePackageFieldRules(objectFieldDir, {
+        ...emptyRules,
+        forbid_package_fields: [
+          { severity: 'error', patterns: ['jest'], values: ['*'] },
+        ],
+      });
+      expect(result).toHaveLength(0);
+    } finally {
+      rmSync(objectFieldDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never matches a values pattern when the forbidden field value is null', () => {
+    const nullFieldDir = mkdtempSync(
+      join(tmpdir(), 'hermex-rules-test-nullfield-'),
+    );
+    try {
+      writeFileSync(
+        join(nullFieldDir, 'package.json'),
+        JSON.stringify({ name: 'x', license: null }),
+      );
+      const result = evaluatePackageFieldRules(nullFieldDir, {
+        ...emptyRules,
+        forbid_package_fields: [
+          { severity: 'error', patterns: ['license'], values: ['*'] },
+        ],
+      });
+      expect(result).toHaveLength(0);
+    } finally {
+      rmSync(nullFieldDir, { recursive: true, force: true });
+    }
+  });
+
   it('violation when forbidden field value matches the values pattern', () => {
     const result = evaluatePackageFieldRules(tempDir, {
       ...emptyRules,
@@ -347,6 +413,54 @@ describe('evaluateEngineVersion', () => {
     expect(result[0].type).toBe('engine_version');
     expect(result[0].installedRange).toBe('>=18.0.0');
     expect(result[0].requiredRange).toBe('>=24.0.0');
+  });
+
+  it('returns nothing when no engine_version rule is configured', () => {
+    const result = evaluateEngineVersion(tempDir, emptyRules);
+    expect(result).toHaveLength(0);
+  });
+
+  describe('when package.json has no engines field', () => {
+    let noEnginesDir: string;
+
+    beforeAll(() => {
+      noEnginesDir = mkdtempSync(
+        join(tmpdir(), 'hermex-rules-test-noengines-'),
+      );
+      writeFileSync(
+        join(noEnginesDir, 'package.json'),
+        JSON.stringify({ name: 'no-engines-project' }),
+      );
+    });
+
+    afterAll(() => {
+      rmSync(noEnginesDir, { recursive: true, force: true });
+    });
+
+    it('reports "not specified" with the default message when no message is configured', () => {
+      const result = evaluateEngineVersion(noEnginesDir, {
+        ...emptyRules,
+        engine_version: { severity: 'error', range: '>=18.0.0' },
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].installedRange).toBeUndefined();
+      expect(result[0].requiredRange).toBe('>=18.0.0');
+      expect(result[0].message).toBe(
+        'engines.node not specified in package.json',
+      );
+    });
+
+    it('uses a custom message when configured', () => {
+      const result = evaluateEngineVersion(noEnginesDir, {
+        ...emptyRules,
+        engine_version: {
+          severity: 'error',
+          range: '>=18.0.0',
+          message: 'add an engines.node field',
+        },
+      });
+      expect(result[0].message).toBe('add an engines.node field');
+    });
   });
 });
 

--- a/tests/utils/chart-renderer.test.ts
+++ b/tests/utils/chart-renderer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderBarChart } from '../../src/utils/chart-renderer';
+
+let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+});
+
+describe('renderBarChart', () => {
+  it('prints a placeholder and returns early when data is empty', () => {
+    renderBarChart([]);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('No data to display');
+  });
+
+  it('prints a placeholder and returns early when every value is zero', () => {
+    renderBarChart([{ label: 'a', value: 0 }]);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('All values are zero');
+  });
+
+  it('renders bars with values by default', () => {
+    renderBarChart([{ label: 'react', value: 10 }]);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('react');
+    expect(output).toContain('10');
+  });
+
+  it('omits the value string when showValues is false', () => {
+    renderBarChart([{ label: 'react', value: 10 }], { showValues: false });
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('react');
+    expect(output).not.toContain('10');
+  });
+
+  it('uses custom bar and empty characters when provided', () => {
+    renderBarChart(
+      [
+        { label: 'a', value: 5 },
+        { label: 'bb', value: 1 },
+      ],
+      {
+        barChar: '#',
+        emptyChar: '.',
+      },
+    );
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('#');
+    expect(output).toContain('.');
+  });
+});

--- a/tests/utils/format-utils.test.ts
+++ b/tests/utils/format-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCount,
+  formatDuration,
+  formatDaysOverdue,
+  formatDaysRemaining,
+  formatTruncatedList,
+} from '../../src/utils/format-utils';
+
+describe('formatCount', () => {
+  it('adds thousand separators', () => {
+    expect(formatCount(1234567)).toBe('1,234,567');
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats seconds to two decimal places', () => {
+    expect(formatDuration(10.2)).toBe('10.20s');
+  });
+});
+
+describe('formatDaysOverdue', () => {
+  it('pluralizes "days" when the overdue count is not 1', () => {
+    expect(formatDaysOverdue(100, 60)).toBe('40 days overdue');
+  });
+
+  it('uses the singular "day" when the overdue count is exactly 1', () => {
+    expect(formatDaysOverdue(61, 60)).toBe('1 day overdue');
+  });
+});
+
+describe('formatDaysRemaining', () => {
+  it('pluralizes "days" when the remaining count is not 1', () => {
+    expect(formatDaysRemaining(12)).toBe('12 days remaining');
+  });
+
+  it('uses the singular "day" when the remaining count is exactly 1', () => {
+    expect(formatDaysRemaining(1)).toBe('1 day remaining');
+  });
+});
+
+describe('formatTruncatedList', () => {
+  it('shows every item with no "and N others" suffix when nothing is truncated', () => {
+    expect(formatTruncatedList(['a', 'b'], 'file')).toBe('a, b');
+  });
+
+  it('pluralizes the truncated-count noun when more than one item is hidden', () => {
+    expect(formatTruncatedList(['a', 'b', 'c', 'd'], 'file')).toBe(
+      'a, b and 2 other files',
+    );
+  });
+
+  it('uses the singular noun when exactly one item is hidden', () => {
+    expect(formatTruncatedList(['a', 'b', 'c'], 'file')).toBe(
+      'a, b and 1 other file',
+    );
+  });
+});

--- a/tests/utils/package-distribution.test.ts
+++ b/tests/utils/package-distribution.test.ts
@@ -144,6 +144,50 @@ describe('calculatePackageDistribution', () => {
     expect(distribution[0].version).toBeNull();
   });
 
+  it('resolves a scoped subpath import (e.g. "@scope/pkg/sub") to the base package version', () => {
+    const componentUsageMap = new Map<string, ComponentUsage>([
+      ['Icon', makeComponent('Icon', '@my-org/ui/icons', 1)],
+    ]);
+
+    const distribution = calculatePackageDistribution(componentUsageMap, {
+      '@my-org/ui': '2.0.0',
+    });
+
+    expect(distribution[0].version).toBe('2.0.0');
+  });
+
+  it('resolves a non-scoped subpath import (e.g. "pkg/sub") to the base package version', () => {
+    const componentUsageMap = new Map<string, ComponentUsage>([
+      ['debounce', makeComponent('debounce', 'lodash/debounce', 1)],
+    ]);
+
+    const distribution = calculatePackageDistribution(componentUsageMap, {
+      lodash: '4.17.21',
+    });
+
+    expect(distribution[0].version).toBe('4.17.21');
+  });
+
+  it('leaves version null for a scoped subpath import when the base package is also absent from the versions map', () => {
+    const componentUsageMap = new Map<string, ComponentUsage>([
+      ['Icon', makeComponent('Icon', '@my-org/ui/icons', 1)],
+    ]);
+
+    const distribution = calculatePackageDistribution(componentUsageMap, {});
+
+    expect(distribution[0].version).toBeNull();
+  });
+
+  it('leaves version null for a non-scoped subpath import when the base package is also absent from the versions map', () => {
+    const componentUsageMap = new Map<string, ComponentUsage>([
+      ['debounce', makeComponent('debounce', 'lodash/debounce', 1)],
+    ]);
+
+    const distribution = calculatePackageDistribution(componentUsageMap, {});
+
+    expect(distribution[0].version).toBeNull();
+  });
+
   it('flags hasVersionConflict and populates allVersions when multiVersions has 2+ entries for a package', () => {
     const componentUsageMap = new Map<string, ComponentUsage>([
       ['Button', makeComponent('Button', 'antd', 1)],

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -2,15 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AggregatedReport } from '../../src/utils/aggregator';
 import type { RuleViolation } from '../../src/rules/evaluator';
 import { printSummary } from '../../src/utils/print-summary';
+import { stripAnsi } from '../../src/utils/severity-format';
 import {
   printPackages,
   describeUpgradeTarget,
+  formatPackageName,
+  formatUpgradeCell,
 } from '../../src/utils/print-packages';
 import { printComponents } from '../../src/utils/print-components';
 import { printPatterns } from '../../src/utils/print-patterns';
 import { printDetails } from '../../src/utils/print-details';
 import { printVersus } from '../../src/utils/print-versus';
-import { printRules } from '../../src/utils/print-rules';
+import { printRules, describeViolation } from '../../src/utils/print-rules';
 import { printErrors } from '../../src/utils/print-errors';
 import { printJson } from '../../src/utils/print-json';
 import { printComplianceVerdict } from '../../src/utils/print-compliance';
@@ -61,6 +64,21 @@ describe('printSummary', () => {
   it('prints without throwing on minimal data', () => {
     expect(() => printSummary(makeAggregated())).not.toThrow();
     expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('excludes unknown- and local-sourced components from the External Components count', () => {
+    const aggregated = makeAggregated({
+      topComponents: [
+        { name: 'Button', source: 'react', count: 4, files: new Set() },
+        { name: 'Local', source: 'local', count: 2, files: new Set() },
+        { name: 'Mystery', source: 'unknown', count: 1, files: new Set() },
+      ],
+    });
+    printSummary(aggregated);
+    const output = stripAnsi(
+      consoleSpy.mock.calls.map((call) => call.join(' ')).join('\n'),
+    );
+    expect(output).toMatch(/External Components\s*│\s*1/);
   });
 });
 
@@ -246,6 +264,186 @@ describe('printPackages', () => {
       .join('\n');
     expect(output).toContain('12 days remaining');
   });
+
+  it('renders chart mode with a populated package entry', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('react', { usageCount: 8, percentage: 100 }),
+      ],
+    });
+    printPackages(aggregated, 'chart');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('react');
+    expect(output).toContain('100.0%');
+  });
+
+  it('shows "N/A" for a package with no version and no conflict', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('mystery-pkg', {
+          version: null,
+          hasVersionConflict: false,
+        }),
+      ],
+    });
+    printPackages(aggregated, 'table');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('N/A');
+  });
+
+  it('does nothing for an unrecognized mode value', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [createMockPackage('react')],
+    });
+    printPackages(aggregated, 'bogus' as unknown as 'table');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('chart mode pads an internal package label wider to make room for the [int] tag', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('@my-org/ui', { internal: true, percentage: 100 }),
+      ],
+    });
+    expect(() => printPackages(aggregated, 'chart')).not.toThrow();
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('[int]');
+  });
+
+  it('marks a package with multiple resolved versions as a version conflict', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('lodash', {
+          hasVersionConflict: true,
+          allVersions: ['3.10.1', '4.17.21'],
+        }),
+      ],
+    });
+    printPackages(aggregated, 'table');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('3.10.1, 4.17.21');
+    expect(output).toContain('2 versions');
+  });
+});
+
+describe('formatPackageName', () => {
+  it('prefixes a deprecated package', () => {
+    const pkg = createMockPackage('left-pad', {
+      releaseAge: createMockReleaseAge({ deprecated: 'use String.padStart' }),
+    });
+    expect(formatPackageName(pkg)).toContain('[DEPRECATED]');
+  });
+
+  it('prefixes an error-severity banned package as [BANNED]', () => {
+    const pkg = createMockPackage('moment');
+    expect(
+      formatPackageName(pkg, { packageName: 'moment', severity: 'error' }),
+    ).toContain('[BANNED]');
+  });
+
+  it('prefixes a warn-severity banned package as [RESTRICTED]', () => {
+    const pkg = createMockPackage('moment');
+    expect(
+      formatPackageName(pkg, { packageName: 'moment', severity: 'warn' }),
+    ).toContain('[RESTRICTED]');
+  });
+
+  it('prefixes an internal package as [int] when not banned', () => {
+    const pkg = createMockPackage('@my-org/utils', { internal: true });
+    expect(formatPackageName(pkg)).toContain('[int]');
+  });
+
+  it('prefers [BANNED]/[RESTRICTED] over [int] when a package is both internal and banned', () => {
+    const pkg = createMockPackage('@my-org/utils', { internal: true });
+    const name = formatPackageName(pkg, {
+      packageName: '@my-org/utils',
+      severity: 'error',
+    });
+    expect(name).toContain('[BANNED]');
+    expect(name).not.toContain('[int]');
+  });
+
+  it('combines [DEPRECATED] with [BANNED] when both apply', () => {
+    const pkg = createMockPackage('moment', {
+      releaseAge: createMockReleaseAge({ deprecated: 'use dayjs' }),
+    });
+    const name = formatPackageName(pkg, {
+      packageName: 'moment',
+      severity: 'error',
+    });
+    expect(name).toContain('[DEPRECATED]');
+    expect(name).toContain('[BANNED]');
+  });
+});
+
+describe('formatUpgradeCell', () => {
+  it('returns an empty string when there is no release-age data', () => {
+    expect(formatUpgradeCell(undefined)).toBe('');
+  });
+
+  it('returns a success icon when there is no worst level and no pending upgrade', () => {
+    expect(formatUpgradeCell(createMockReleaseAge({ worstLevel: null }))).toBe(
+      '🟢',
+    );
+  });
+
+  it('returns a success icon when worstLevel is set but the upgrades list is empty', () => {
+    expect(
+      formatUpgradeCell(
+        createMockReleaseAge({ worstLevel: 'major_overdue', upgrades: [] }),
+      ),
+    ).toBe('🟢');
+  });
+
+  it('uses the warn icon (not error) for a major_overdue upgrade at warn severity', () => {
+    const cell = formatUpgradeCell(
+      createMockReleaseAge({
+        worstLevel: 'major_overdue',
+        severity: 'warn',
+        upgrades: [
+          {
+            version: '2.0.0',
+            releasedDaysAgo: 10,
+            breachReleasedDaysAgo: 100,
+            semverBump: 'major',
+            level: 'major_overdue',
+            thresholdDays: 60,
+          },
+        ],
+      }),
+    );
+    expect(cell).toContain('🟡');
+    expect(cell).not.toContain('🔴');
+    expect(cell).toContain('[not enforced]');
+  });
+
+  it('uses the warn icon for a non-major_overdue worst level', () => {
+    const cell = formatUpgradeCell(
+      createMockReleaseAge({
+        worstLevel: 'minor_overdue',
+        severity: 'error',
+        upgrades: [
+          {
+            version: '1.1.0',
+            releasedDaysAgo: 10,
+            breachReleasedDaysAgo: 50,
+            semverBump: 'minor',
+            level: 'minor_overdue',
+            thresholdDays: 30,
+          },
+        ],
+      }),
+    );
+    expect(cell).toContain('🟡');
+  });
 });
 
 describe('describeUpgradeTarget', () => {
@@ -286,6 +484,41 @@ describe('printComponents', () => {
     expect(() => printComponents(makeAggregated(), 'chart')).not.toThrow();
     expect(consoleSpy).toHaveBeenCalled();
   });
+
+  it('table mode filters out unknown- and local-sourced components and lists the rest', () => {
+    const aggregated = makeAggregated({
+      topComponents: [
+        { name: 'Button', source: 'react', count: 4, files: new Set() },
+        { name: 'Local', source: 'local', count: 2, files: new Set() },
+      ],
+    });
+    printComponents(aggregated, 'table');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('Button');
+    expect(output).not.toContain('Local');
+  });
+
+  it('chart mode filters out unknown- and local-sourced components and renders a bar chart for the rest', () => {
+    const aggregated = makeAggregated({
+      topComponents: [
+        { name: 'Button', source: 'react', count: 4, files: new Set() },
+        { name: 'Local', source: 'local', count: 2, files: new Set() },
+      ],
+    });
+    printComponents(aggregated, 'chart');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('Button');
+    expect(output).not.toContain('Local');
+  });
+
+  it('does nothing for an unrecognized mode value', () => {
+    printComponents(makeAggregated(), 'bogus' as unknown as 'table');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('printPatterns', () => {
@@ -298,12 +531,56 @@ describe('printPatterns', () => {
     expect(() => printPatterns(makeAggregated(), 'chart')).not.toThrow();
     expect(consoleSpy).toHaveBeenCalled();
   });
+
+  it('table mode prints "No patterns found" when every pattern count is zero', () => {
+    const aggregated = makeAggregated({
+      patternCounts: [
+        { patternType: 'usage.jsx', displayName: 'JSX Usage', count: 0 },
+      ],
+    });
+    printPatterns(aggregated, 'table');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('No patterns found');
+  });
+
+  it('chart mode prints "No patterns found" when every pattern count is zero', () => {
+    const aggregated = makeAggregated({
+      patternCounts: [
+        { patternType: 'usage.jsx', displayName: 'JSX Usage', count: 0 },
+      ],
+    });
+    printPatterns(aggregated, 'chart');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('No patterns found');
+  });
+
+  it('does nothing for an unrecognized mode value', () => {
+    printPatterns(makeAggregated(), 'bogus' as unknown as 'table');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('printDetails', () => {
   it('prints without throwing on minimal data', () => {
     expect(() => printDetails(makeAggregated())).not.toThrow();
     expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('skips a pattern line when its count is zero', () => {
+    const aggregated = makeAggregated({
+      patternCounts: [
+        { patternType: 'usage.jsx', displayName: 'JSX Usage', count: 0 },
+      ],
+    });
+    printDetails(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).not.toContain('JSX Usage');
   });
 });
 
@@ -423,9 +700,217 @@ describe('printRules', () => {
     expect(output).toContain('moment is forbidden');
     expect(output).toContain('🟡');
   });
+
+  it('renders a require_files violation as "not found"', () => {
+    const violation: RuleViolation = {
+      type: 'require_files',
+      severity: 'error',
+      patterns: ['.nvmrc'],
+      matchedFiles: [],
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('.nvmrc not found');
+  });
+
+  it('renders a require_scripts violation with the script name and package.json context', () => {
+    const violation: RuleViolation = {
+      type: 'require_scripts',
+      severity: 'error',
+      patterns: ['test'],
+      matchedFiles: [],
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('script test missing in package.json');
+  });
+
+  it('renders a require_package_fields violation with fieldPath/actualValue as a mismatch message', () => {
+    const violation: RuleViolation = {
+      type: 'require_package_fields',
+      severity: 'error',
+      patterns: ['license'],
+      matchedFiles: [],
+      fieldPath: 'license',
+      actualValue: 'UNLICENSED',
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain(
+      'field license is UNLICENSED, does not match required value',
+    );
+  });
+
+  it('renders a forbid_package_fields violation using fieldPath when present', () => {
+    const violation: RuleViolation = {
+      type: 'forbid_package_fields',
+      severity: 'error',
+      patterns: ['scripts.postinstall'],
+      matchedFiles: [],
+      fieldPath: 'scripts.postinstall',
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('field scripts.postinstall is forbidden');
+  });
+
+  it('renders a forbid_package_fields violation falling back to patterns when fieldPath is absent', () => {
+    const violation: RuleViolation = {
+      type: 'forbid_package_fields',
+      severity: 'error',
+      patterns: ['scripts.postinstall'],
+      matchedFiles: [],
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('field scripts.postinstall is forbidden');
+  });
+
+  it('renders an engine_version violation showing installedRange when present', () => {
+    const violation: RuleViolation = {
+      type: 'engine_version',
+      severity: 'error',
+      patterns: [],
+      matchedFiles: [],
+      installedRange: '>=14',
+      requiredRange: '>=18',
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('engines.node is');
+    expect(output).toContain('>=14');
+    expect(output).toContain('required');
+    expect(output).toContain('>=18');
+  });
+
+  it('renders an engine_version violation as "not specified" when installedRange is absent', () => {
+    const violation: RuleViolation = {
+      type: 'engine_version',
+      severity: 'error',
+      patterns: [],
+      matchedFiles: [],
+      requiredRange: '>=18',
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('engines.node not specified');
+    expect(output).toContain('>=18');
+  });
+
+  it('renders a codeowners violation as "not found" when there are no matched files', () => {
+    const violation: RuleViolation = {
+      type: 'codeowners',
+      severity: 'error',
+      patterns: ['CODEOWNERS'],
+      matchedFiles: [],
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('CODEOWNERS not found');
+  });
+
+  it('renders a codeowners violation listing unowned files when matched files are present', () => {
+    const violation: RuleViolation = {
+      type: 'codeowners',
+      severity: 'error',
+      patterns: ['CODEOWNERS'],
+      matchedFiles: ['src/foo.ts', 'src/bar.ts'],
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('2 scanned file(s) have no owner');
+  });
+
+  it('pluralizes the error/warning summary counts when there is more than one of each', () => {
+    const errorViolations: RuleViolation[] = [
+      {
+        type: 'require_files',
+        severity: 'error',
+        patterns: ['a'],
+        matchedFiles: [],
+      },
+      {
+        type: 'require_files',
+        severity: 'error',
+        patterns: ['b'],
+        matchedFiles: [],
+      },
+    ];
+    const aggregated = makeAggregated({
+      ruleViolations: errorViolations,
+      bannedPackageViolations: [
+        { packageName: 'moment', severity: 'warn' },
+        { packageName: 'left-pad', severity: 'warn' },
+      ],
+    });
+    printRules(aggregated);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('2 errors');
+    expect(output).toContain('2 warnings');
+  });
+});
+
+describe('describeViolation', () => {
+  it('falls back to a generic "not present" description for an unrecognized violation type', () => {
+    // Defensive fallback for a violation type outside the known union —
+    // e.g. a newer config schema evaluated against an older build.
+    const violation = {
+      type: 'some_future_rule_type',
+      severity: 'error',
+      patterns: ['whatever'],
+      matchedFiles: [],
+    } as unknown as RuleViolation;
+    expect(describeViolation(violation)).toBe('whatever not present');
+  });
 });
 
 describe('printComplianceVerdict', () => {
+  it('uses the singular "violation" when exactly one mandatory violation is present', () => {
+    const violation: RuleViolation = {
+      type: 'require_files',
+      severity: 'error',
+      patterns: ['.nvmrc'],
+      matchedFiles: [],
+    };
+    const aggregated = makeAggregated({ ruleViolations: [violation] });
+    const compliance = computeCompliance(aggregated);
+    printComplianceVerdict(compliance);
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('1 mandatory violation found');
+    expect(output).not.toContain('violations found');
+  });
+
   it('prints COMPLIANT when there are no mandatory violations', () => {
     const compliance = computeCompliance(makeAggregated());
     expect(() => printComplianceVerdict(compliance)).not.toThrow();
@@ -538,6 +1023,28 @@ describe('printVersus', () => {
       .join('\n');
     expect(output).not.toContain('Button');
     expect(output).not.toContain('Input');
+  });
+
+  it('shows a "no usage detected" note when a versus group has zero total usage', () => {
+    printVersus(
+      makeAggregated({
+        versusResults: [
+          {
+            name: 'ui-kits',
+            packages: ['react', 'vue'],
+            entries: [
+              { packageName: 'react', count: 0, percentage: 0, components: [] },
+              { packageName: 'vue', count: 0, percentage: 0, components: [] },
+            ],
+            totalCount: 0,
+          },
+        ],
+      }),
+    );
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('No usage detected for any package in this group');
   });
 
   it('prints the header with a single space after the emoji, matching every other section header', () => {

--- a/tests/utils/severity-format.test.ts
+++ b/tests/utils/severity-format.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import chalk from 'chalk';
 import {
   severityIcon,
@@ -6,6 +6,7 @@ import {
   formatViolationLine,
   resolveColorLevel,
   stripAnsi,
+  applyColorLevel,
 } from '../../src/utils/severity-format';
 
 describe('severityIcon', () => {
@@ -59,6 +60,72 @@ describe('resolveColorLevel', () => {
 
   it('returns undefined (defer to chalk auto-detection) when nothing is set', () => {
     expect(resolveColorLevel({})).toBeUndefined();
+  });
+});
+
+describe('applyColorLevel', () => {
+  const originalLevel = chalk.level;
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  afterEach(() => {
+    chalk.level = originalLevel;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  });
+
+  it('is a no-op when level is undefined', () => {
+    chalk.level = 2;
+    applyColorLevel(undefined);
+    expect(chalk.level).toBe(2);
+    expect(process.stdout.write).toBe(originalStdoutWrite);
+  });
+
+  it('sets chalk.level without touching stdout/stderr when level is 1', () => {
+    applyColorLevel(1);
+    expect(chalk.level).toBe(1);
+    expect(process.stdout.write).toBe(originalStdoutWrite);
+    expect(process.stderr.write).toBe(originalStderrWrite);
+  });
+
+  it('strips ANSI codes from stdout/stderr writes when level is 0', () => {
+    // applyColorLevel binds the *current* stream.write as the pass-through
+    // target when it installs its wrapper, so the sink must be in place
+    // before calling it.
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    applyColorLevel(0);
+    expect(chalk.level).toBe(0);
+
+    const esc = String.fromCharCode(27);
+    process.stdout.write(`${esc}[31mred${esc}[39m`);
+    process.stderr.write(`${esc}[31merr${esc}[39m`);
+
+    expect(stdoutChunks[0]).toBe('red');
+    expect(stderrChunks[0]).toBe('err');
+  });
+
+  it('passes a non-string chunk through unchanged when level is 0', () => {
+    const stdoutChunks: unknown[] = [];
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    applyColorLevel(0);
+    const buf = Buffer.from('binary chunk');
+    process.stdout.write(buf);
+
+    expect(stdoutChunks[0]).toBe(buf);
   });
 });
 

--- a/tests/utils/write-summary-file.test.ts
+++ b/tests/utils/write-summary-file.test.ts
@@ -158,6 +158,57 @@ describe('writeSummaryFile', () => {
       );
     });
 
+    it('shows a banned package with no message and no trailing dash', () => {
+      const violation: BannedPackageViolation = {
+        packageName: 'moment',
+        severity: 'error',
+      };
+      const content = write(
+        makeAggregated({ bannedPackageViolations: [violation] }),
+      );
+      expect(content).toContain('forbid_packages — moment is forbidden\n');
+    });
+
+    it('shows only a warning count when there are no errors', () => {
+      const violation: RuleViolation = {
+        type: 'require_files',
+        severity: 'warn',
+        patterns: ['.editorconfig'],
+        matchedFiles: [],
+      };
+      const content = write(makeAggregated({ ruleViolations: [violation] }));
+      expect(content).toContain('1 warning');
+      expect(content).not.toContain('error');
+    });
+
+    it('pluralizes the error/warning counts when there is more than one of each', () => {
+      const errors: RuleViolation[] = [
+        {
+          type: 'require_files',
+          severity: 'error',
+          patterns: ['a'],
+          matchedFiles: [],
+        },
+        {
+          type: 'require_files',
+          severity: 'error',
+          patterns: ['b'],
+          matchedFiles: [],
+        },
+      ];
+      const warnings: BannedPackageViolation[] = [
+        { packageName: 'moment', severity: 'warn' },
+        { packageName: 'left-pad', severity: 'warn' },
+      ];
+      const content = write(
+        makeAggregated({
+          ruleViolations: errors,
+          bannedPackageViolations: warnings,
+        }),
+      );
+      expect(content).toContain('2 errors, 2 warnings');
+    });
+
     it('excludes an info-severity banned package violation', () => {
       const violation: BannedPackageViolation = {
         packageName: 'some-pkg',
@@ -260,6 +311,26 @@ describe('writeSummaryFile', () => {
       expect(line).toBe(
         '| 🔴 | `my-internal-pkg` | major 4.2.0 (40 days overdue), deprecated |',
       );
+    });
+
+    it('shows only "deprecated" when a mandatory violation has no upgrade candidates', () => {
+      // worstLevel non-null but upgrades empty is a defensive/edge shape —
+      // exercises the `top` guard independently of the deprecated reason.
+      const deprecatedOnlyBreach = createMockPackage('my-internal-pkg', {
+        releaseAge: createMockReleaseAge({
+          worstLevel: 'major_overdue',
+          severity: 'error',
+          deprecated: '2020-01-01',
+          upgrades: [],
+        }),
+      });
+      const content = write(
+        makeAggregated({ packageDistribution: [deprecatedOnlyBreach] }),
+      );
+      const line = content
+        .split('\n')
+        .find((l) => l.includes('my-internal-pkg'));
+      expect(line).toBe('| 🔴 | `my-internal-pkg` | deprecated |');
     });
 
     it('does not show a banned/restricted package (it is Rules-only, not duplicated here)', () => {


### PR DESCRIPTION
## Summary
- Branch coverage was 74.75% while statements/functions/lines sat at ~87-97% — the gap was concentrated in lock-format fallback paths, CLI print-formatter edge states, and rule-evaluator guard clauses that only had happy-path tests.
- Adds targeted test cases (no source changes) closing those gaps: npm/pnpm/yarn lockfile adapter format fallbacks (v6 deps, pnpm v5/v6-8 formats, legacy dependency-path keys, parse-failure/dedup branches) with new fixtures under `tests/lock-parser/fixtures`; rules edge cases (`engine_version` with no `engines` field, `require_scripts` with no `scripts` field, `codeowners` custom messages and absolute-path handling, `forbid_package_fields` null/object values); CLI `print-*` utils (per-violation-type rendering, singular/plural counts, empty/zero states, unrecognized-mode no-ops); and two previously-untested files got their own suites (`format-utils.test.ts`, `chart-renderer.test.ts`).
- Result: Branches 74.75% → **90.22%** (840/931). Statements/Functions/Lines improved alongside it to 96.08%/98.06%/97.16%.

Note: `pnpm run test:coverage` currently picks up stale test files under `.claude/worktrees/**` (leftover agent worktrees with an outdated `package.json`) and reports spurious failures/dilutes counts — unrelated pre-existing issue. Run coverage with `pnpm exec vitest run --coverage --exclude '**/.claude/**'` to get accurate numbers.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run --coverage --exclude '**/.claude/**'` — 418 tests pass, branches 90.22%
- [x] `pnpm run lint`
- [x] `pnpm run format:ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)