### PR TITLE
feat: expose official compliance status in scan/comply JSON (#55)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -277,6 +277,30 @@ hermex comply
 
 `warn` and `info`-severity violations are always reported but never fail the build — only `error`-severity violations are mandatory. `hermex comply` respects `output.format: 'json'` the same way `scan` does, so CI pipelines can parse the full report while still relying on the exit code as the pass/fail signal.
 
+### Reading compliance from the JSON
+
+Both `hermex scan --format json` and `hermex comply --format json` emit a top-level `compliance` block — the **canonical, machine-readable verdict**. Read `compliance.status` rather than re-deriving a status from `packages` / `ruleViolations`, which is easy to get subtly wrong (e.g. treating a non-enforced overdue package or a not-yet-due pending upgrade as a failure).
+
+```jsonc
+"compliance": {
+  "status": "compliant",   // "compliant" | "warning" | "non-compliant"
+  "compliant": true,        // mirrors the `comply` exit code (0 ⇔ true)
+  "counts": {
+    "errorRuleViolations": 0,
+    "errorBannedPackageViolations": 0,
+    "releaseAgeViolations": 0,        // enforced (severity 'error') + overdue
+    "warningRuleViolations": 0,
+    "warningBannedPackageViolations": 0
+  }
+}
+```
+
+- **`non-compliant`** — at least one mandatory (`error`) violation. Exactly `compliant === false`; the condition `comply` exits `1` on.
+- **`warning`** — passes `comply` (exit `0`), but a `warn`-severity **rule** or **banned-package** violation is present. A non-enforced (`severity: 'warn'`) overdue release-age package or a not-yet-due `pendingUpgrade` is advisory data — it is **not** a warning and does **not** demote `compliant` → `warning`.
+- **`compliant`** — no mandatory violations and nothing flagged at `warn`.
+
+`status: 'warning'` never changes the exit code — it exists so dashboards and sheet syncs can surface a three-state signal that still agrees with `comply` on pass/fail.
+
 ### CI Job Summary / PR Comment
 
 `--summary-file <path>` writes a concise, ANSI-free markdown summary (title, rules, flagged packages, verdict) to `<path>`, suitable for posting as a GitHub Actions job summary or a PR comment — the same file can be reused verbatim for both surfaces, no need to generate it twice:

--- a/src/commands/comply.ts
+++ b/src/commands/comply.ts
@@ -84,7 +84,7 @@ export async function executeComply(
     const compliance = computeCompliance(aggregated);
 
     if (isJson) {
-      printJson(aggregated);
+      printJson(aggregated, compliance);
     } else {
       printRules(aggregated);
       if (config.releaseAge.enabled) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export type {
 export type { VersusResult, VersusEntry } from './utils/versus';
 export type { RuleViolation } from './rules/evaluator';
 export type { BannedPackageViolation } from './utils/package-rules';
+export type { ComplianceStatus } from './utils/compliance';
 
 /** Shape of a single entry in `components` — same as `ComponentUsage`, but with `files` as an array (JSON has no `Set`) */
 export interface HermexScanComponent extends Omit<
@@ -62,4 +63,21 @@ export interface HermexScanResult {
   versus: import('./utils/versus').VersusResult[];
   ruleViolations: import('./rules/evaluator').RuleViolation[];
   bannedPackageViolations: import('./utils/package-rules').BannedPackageViolation[];
+  /**
+   * The official compliance verdict — read `status` instead of re-deriving
+   * one from `packages`/`ruleViolations` (#55). `compliant` mirrors the
+   * `comply` exit code; `status: 'warning'` (warn-severity rules/banned
+   * packages) does not change it.
+   */
+  compliance: {
+    status: import('./utils/compliance').ComplianceStatus;
+    compliant: boolean;
+    counts: {
+      errorRuleViolations: number;
+      errorBannedPackageViolations: number;
+      releaseAgeViolations: number;
+      warningRuleViolations: number;
+      warningBannedPackageViolations: number;
+    };
+  };
 }

--- a/src/utils/compliance.ts
+++ b/src/utils/compliance.ts
@@ -3,11 +3,27 @@ import type { RuleViolation } from '../rules/evaluator';
 import type { BannedPackageViolation } from './package-rules';
 import type { PackageDistribution } from './package-distribution';
 
+/**
+ * The canonical, three-state compliance verdict hermex publishes so
+ * downstream consumers (sheet sync, CI dashboards) don't have to invent
+ * their own mapping over the raw JSON and disagree with `comply` (#55):
+ *
+ * - `non-compliant` — has at least one mandatory (error) violation; exactly
+ *   `compliant === false`, the same condition `comply` exits non-zero on.
+ * - `warning` — passes `comply`, but the policy author flagged something at
+ *   `warn` severity: a warn-severity rule or banned-package violation.
+ * - `compliant` — no mandatory violations and nothing flagged at `warn`.
+ */
+export type ComplianceStatus = 'compliant' | 'warning' | 'non-compliant';
+
 export interface ComplianceResult {
   compliant: boolean;
+  status: ComplianceStatus;
   errorRuleViolations: RuleViolation[];
   errorBannedPackageViolations: BannedPackageViolation[];
   releaseAgeViolations: PackageDistribution[];
+  warningRuleViolations: RuleViolation[];
+  warningBannedPackageViolations: BannedPackageViolation[];
 }
 
 /**
@@ -16,6 +32,14 @@ export interface ComplianceResult {
  * threshold at all (worstLevel is non-null) — both 'minor_overdue' and
  * 'major_overdue' fail comply for an enforced package; only severity
  * decides mandatory vs advisory, not which tier breached (#28).
+ *
+ * The `warning` tier is deliberately narrow: it covers only warn-severity
+ * *rule* and *banned-package* violations — signals the policy author opted
+ * into. A non-enforced (severity 'warn') overdue release-age package or a
+ * not-yet-due `pendingUpgrade` is advisory data, not a warning, and must not
+ * on its own demote `compliant` → `warning`. Consumers that treated any
+ * non-blocking outdated row as Warning disagreed with `comply`; reading
+ * `status` here is the fix (#55).
  */
 export function computeCompliance(
   aggregated: AggregatedReport,
@@ -29,14 +53,31 @@ export function computeCompliance(
     (p) =>
       p.releaseAge?.severity === 'error' && p.releaseAge?.worstLevel !== null,
   );
+  const warningRuleViolations = aggregated.ruleViolations.filter(
+    (v) => v.severity === 'warn',
+  );
+  const warningBannedPackageViolations =
+    aggregated.bannedPackageViolations.filter((v) => v.severity === 'warn');
+
+  const compliant =
+    errorRuleViolations.length === 0 &&
+    errorBannedPackageViolations.length === 0 &&
+    releaseAgeViolations.length === 0;
+
+  const status: ComplianceStatus = !compliant
+    ? 'non-compliant'
+    : warningRuleViolations.length > 0 ||
+        warningBannedPackageViolations.length > 0
+      ? 'warning'
+      : 'compliant';
 
   return {
-    compliant:
-      errorRuleViolations.length === 0 &&
-      errorBannedPackageViolations.length === 0 &&
-      releaseAgeViolations.length === 0,
+    compliant,
+    status,
     errorRuleViolations,
     errorBannedPackageViolations,
     releaseAgeViolations,
+    warningRuleViolations,
+    warningBannedPackageViolations,
   };
 }

--- a/src/utils/print-json.ts
+++ b/src/utils/print-json.ts
@@ -1,7 +1,24 @@
 import type { AggregatedReport } from './aggregator';
+import type { ComplianceResult } from './compliance';
+import { computeCompliance } from './compliance';
 import { getVersion } from './version';
 
-export function printJson(aggregated: AggregatedReport): void {
+/**
+ * Emits the scan/comply JSON. The `compliance` block is the official,
+ * machine-readable verdict — `status` (`compliant` | `warning` |
+ * `non-compliant`) plus the per-bucket counts that explain it — so consumers
+ * read one canonical field instead of re-deriving a status from `packages` /
+ * `ruleViolations` and drifting from `comply` (#55). `compliant` mirrors the
+ * CLI exit code (0 ⇔ true); `status: 'warning'` never changes that exit code.
+ *
+ * `compliance` defaults to `computeCompliance(aggregated)` so `scan --format
+ * json` carries the same verdict as `comply`; callers that already computed
+ * it (comply) pass it through to avoid recomputing.
+ */
+export function printJson(
+  aggregated: AggregatedReport,
+  compliance: ComplianceResult = computeCompliance(aggregated),
+): void {
   const result = {
     version: getVersion(),
     summary: {
@@ -19,6 +36,19 @@ export function printJson(aggregated: AggregatedReport): void {
     versus: aggregated.versusResults,
     ruleViolations: aggregated.ruleViolations,
     bannedPackageViolations: aggregated.bannedPackageViolations,
+    compliance: {
+      status: compliance.status,
+      compliant: compliance.compliant,
+      counts: {
+        errorRuleViolations: compliance.errorRuleViolations.length,
+        errorBannedPackageViolations:
+          compliance.errorBannedPackageViolations.length,
+        releaseAgeViolations: compliance.releaseAgeViolations.length,
+        warningRuleViolations: compliance.warningRuleViolations.length,
+        warningBannedPackageViolations:
+          compliance.warningBannedPackageViolations.length,
+      },
+    },
   };
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
 }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -91,6 +91,13 @@ describe('CLI smoke tests', () => {
     expect(parsed).toHaveProperty('components');
     expect(parsed).toHaveProperty('patterns');
     expect(parsed.summary).toHaveProperty('filesAnalyzed');
+    // scan --format json carries the same official compliance verdict as
+    // comply, so consumers get a canonical status off either command (#55).
+    expect(parsed).toHaveProperty('compliance');
+    expect(parsed.compliance).toHaveProperty('status');
+    expect(['compliant', 'warning', 'non-compliant']).toContain(
+      parsed.compliance.status,
+    );
   });
 
   it('skips .d.ts files instead of reporting them as parse errors (#22)', () => {
@@ -227,6 +234,54 @@ describe('comply command', () => {
     expect(parsed).toHaveProperty('ruleViolations');
     expect(parsed.ruleViolations).toHaveLength(1);
     expect(parsed.ruleViolations[0].severity).toBe('error');
+  });
+
+  it("json output carries the official compliance verdict: 'non-compliant' on an error rule, matching the exit code (#55)", () => {
+    const configPath = join(
+      ROOT,
+      'tests',
+      'e2e',
+      'hermex-comply-json.config.ts',
+    );
+    const result = run(['comply', '--config', configPath]);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.compliance.status).toBe('non-compliant');
+    expect(parsed.compliance.compliant).toBe(false);
+    expect(parsed.compliance.counts.errorRuleViolations).toBe(1);
+  });
+
+  it("json output reports status 'warning' for a warn-severity rule while still exiting 0 — the key #55 case consumers mis-mapped", () => {
+    const configPath = join(
+      ROOT,
+      'tests',
+      'e2e',
+      'hermex-comply-warning.config.ts',
+    );
+    const result = run(['comply', '--config', configPath]);
+    // A warn-severity rule is advisory: comply still passes (exit 0)...
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    // ...but the official status distinguishes it from a clean 'compliant'.
+    expect(parsed.compliance.status).toBe('warning');
+    expect(parsed.compliance.compliant).toBe(true);
+    expect(parsed.compliance.counts.warningRuleViolations).toBe(1);
+  });
+
+  it("json output reports status 'compliant' when the only signals are info/advisory, not 'warning' (#55)", () => {
+    // hermex-comply-pass has only an info detect_files rule (matches
+    // fixtures/hermex.config.ts), so nothing is at error or warn severity.
+    const configPath = join(
+      ROOT,
+      'tests',
+      'e2e',
+      'hermex-comply-pass.config.ts',
+    );
+    const result = run(['comply', '--config', configPath, '--format', 'json']);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.compliance.status).toBe('compliant');
+    expect(parsed.compliance.compliant).toBe(true);
   });
 
   it('runs the full pipeline and reports all violations, not just the first', () => {

--- a/tests/e2e/hermex-comply-warning.config.ts
+++ b/tests/e2e/hermex-comply-warning.config.ts
@@ -1,0 +1,11 @@
+// A warn-severity rule that will be violated (no .editorconfig in fixtures):
+// passes `comply` (exit 0) but the official JSON status must be 'warning',
+// not 'compliant' and not 'non-compliant' (#55).
+export default {
+  rules: {
+    require_files: [{ severity: 'warn', patterns: ['.editorconfig'] }],
+  },
+  output: {
+    format: 'json',
+  },
+};

--- a/tests/utils/compliance.test.ts
+++ b/tests/utils/compliance.test.ts
@@ -149,3 +149,133 @@ describe('computeCompliance', () => {
     expect(result.compliant).toBe(true);
   });
 });
+
+describe('computeCompliance — status (#55)', () => {
+  it("status is 'compliant' when there are no violations of any kind", () => {
+    const result = computeCompliance(makeAggregated());
+    expect(result.status).toBe('compliant');
+    expect(result.compliant).toBe(true);
+  });
+
+  it("status is 'non-compliant' when an error-severity rule violation is present", () => {
+    const violation: RuleViolation = {
+      type: 'require_files',
+      severity: 'error',
+      patterns: ['.nvmrc'],
+      matchedFiles: [],
+    };
+    const result = computeCompliance(
+      makeAggregated({ ruleViolations: [violation] }),
+    );
+    expect(result.status).toBe('non-compliant');
+    expect(result.compliant).toBe(false);
+  });
+
+  it("status is 'non-compliant' when an enforced package is overdue, regardless of any warn-severity rules present", () => {
+    const pkg = createMockPackage('@my-org/internal', {
+      releaseAge: createMockReleaseAge({
+        worstLevel: 'major_overdue',
+        severity: 'error',
+      }),
+    });
+    const warnRule: RuleViolation = {
+      type: 'require_files',
+      severity: 'warn',
+      patterns: ['.editorconfig'],
+      matchedFiles: [],
+    };
+    const result = computeCompliance(
+      makeAggregated({
+        packageDistribution: [pkg],
+        ruleViolations: [warnRule],
+      }),
+    );
+    // Error trumps warn — an error-level release-age breach is non-compliant,
+    // never merely a warning, even with warn-severity rules also present.
+    expect(result.status).toBe('non-compliant');
+  });
+
+  it("status is 'warning' when only a warn-severity rule violation is present", () => {
+    const violation: RuleViolation = {
+      type: 'require_files',
+      severity: 'warn',
+      patterns: ['.editorconfig'],
+      matchedFiles: [],
+    };
+    const result = computeCompliance(
+      makeAggregated({ ruleViolations: [violation] }),
+    );
+    expect(result.status).toBe('warning');
+    expect(result.compliant).toBe(true);
+    expect(result.warningRuleViolations).toEqual([violation]);
+  });
+
+  it("status is 'warning' when only a warn-severity banned package violation is present", () => {
+    const violation: BannedPackageViolation = {
+      packageName: 'lodash',
+      severity: 'warn',
+    };
+    const result = computeCompliance(
+      makeAggregated({ bannedPackageViolations: [violation] }),
+    );
+    expect(result.status).toBe('warning');
+    expect(result.compliant).toBe(true);
+    expect(result.warningBannedPackageViolations).toEqual([violation]);
+  });
+
+  it("status stays 'compliant' for the #55 search-page shape: info signal + non-enforced overdues + pending-only, no warn/error rules", () => {
+    // Reproduces the exact mix the issue reports as wrongly demoted to
+    // Warning by consumers: an `info` detect_files signal (Orbis), overdue
+    // react-* at severity 'warn' (not enforced), and pending-only @guestyci/*
+    // entries (worstLevel null). None of these are warn-severity *rules* or
+    // *banned* packages, so the official status must remain 'compliant'.
+    const infoSignal: RuleViolation = {
+      type: 'detect_files',
+      severity: 'info',
+      patterns: ['orbis.config.*'],
+      matchedFiles: ['orbis.config.ts'],
+    };
+    const nonEnforcedOverdue = createMockPackage('react-instantsearch', {
+      releaseAge: createMockReleaseAge({
+        worstLevel: 'major_overdue',
+        severity: 'warn',
+      }),
+    });
+    const anotherNonEnforcedOverdue = createMockPackage('react-router-dom', {
+      releaseAge: createMockReleaseAge({
+        worstLevel: 'minor_overdue',
+        severity: 'warn',
+      }),
+    });
+    const pendingOnly = createMockPackage('@guestyci/arc', {
+      releaseAge: createMockReleaseAge({
+        worstLevel: null,
+        severity: 'error',
+        pendingUpgrade: {
+          version: '2.0.0',
+          semverBump: 'major',
+          releasedDaysAgo: 3,
+          thresholdDays: 30,
+          daysRemaining: 27,
+        },
+      }),
+    });
+
+    const result = computeCompliance(
+      makeAggregated({
+        ruleViolations: [infoSignal],
+        packageDistribution: [
+          nonEnforcedOverdue,
+          anotherNonEnforcedOverdue,
+          pendingOnly,
+        ],
+      }),
+    );
+
+    expect(result.status).toBe('compliant');
+    expect(result.compliant).toBe(true);
+    expect(result.warningRuleViolations).toHaveLength(0);
+    expect(result.warningBannedPackageViolations).toHaveLength(0);
+    expect(result.releaseAgeViolations).toHaveLength(0);
+  });
+});

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -1219,11 +1219,99 @@ describe('printJson', () => {
       'versus',
       'ruleViolations',
       'bannedPackageViolations',
+      'compliance',
     ]);
     expect(parsed.summary.filesAnalyzed).toBe(5);
     expect(parsed.summary.totalImports).toBe(10);
     expect(parsed.summary.totalComponents).toBe(3);
     expect(parsed.summary.totalUsagePatterns).toBe(7);
+  });
+
+  it('emits the official compliance verdict (status + counts) so consumers need not re-derive it (#55)', () => {
+    printJson(makeAggregated());
+
+    const written = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(written);
+
+    expect(parsed.compliance).toEqual({
+      status: 'compliant',
+      compliant: true,
+      counts: {
+        errorRuleViolations: 0,
+        errorBannedPackageViolations: 0,
+        releaseAgeViolations: 0,
+        warningRuleViolations: 0,
+        warningBannedPackageViolations: 0,
+      },
+    });
+  });
+
+  it("reports compliance status 'warning' for warn-severity rules but keeps compliant true (#55)", () => {
+    const aggregated = makeAggregated({
+      ruleViolations: [
+        {
+          type: 'require_files',
+          severity: 'warn',
+          patterns: ['.editorconfig'],
+          matchedFiles: [],
+        },
+      ],
+    });
+    printJson(aggregated);
+
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(parsed.compliance.status).toBe('warning');
+    expect(parsed.compliance.compliant).toBe(true);
+    expect(parsed.compliance.counts.warningRuleViolations).toBe(1);
+  });
+
+  it("keeps compliance status 'compliant' for non-enforced overdue and pending-only packages (#55)", () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('react-router-dom', {
+          releaseAge: createMockReleaseAge({
+            worstLevel: 'major_overdue',
+            severity: 'warn',
+          }),
+        }),
+        createMockPackage('@guestyci/arc', {
+          releaseAge: createMockReleaseAge({
+            worstLevel: null,
+            severity: 'error',
+          }),
+        }),
+      ],
+    });
+    printJson(aggregated);
+
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(parsed.compliance.status).toBe('compliant');
+    expect(parsed.compliance.compliant).toBe(true);
+  });
+
+  it('passes an explicitly provided compliance result straight through (#55)', () => {
+    const aggregated = makeAggregated();
+    printJson(aggregated, {
+      compliant: false,
+      status: 'non-compliant',
+      errorRuleViolations: [
+        {
+          type: 'require_files',
+          severity: 'error',
+          patterns: ['.nvmrc'],
+          matchedFiles: [],
+        },
+      ],
+      errorBannedPackageViolations: [],
+      releaseAgeViolations: [],
+      warningRuleViolations: [],
+      warningBannedPackageViolations: [],
+    });
+
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(parsed.compliance.status).toBe('non-compliant');
+    expect(parsed.compliance.compliant).toBe(false);
+    expect(parsed.compliance.counts.errorRuleViolations).toBe(1);
   });
 
   it('serializes component file sets as arrays', () => {


### PR DESCRIPTION
Fixes #55.

## Problem

`computeCompliance` / `hermex comply` is correct, but the scan/comply JSON exposed **no** compliance verdict — only the raw `packages` / `ruleViolations` / `bannedPackageViolations`. Every consumer (e.g. `guestyorg/hermex-scans` sheet sync) had to re-invent a three-state status over that raw data, and got it wrong: any non-blocking outdated row — a non-enforced (`severity: warn`) overdue package like `react-*`, or a not-yet-due pending upgrade (`worstLevel: null`) — was mapped to **Warning**, disagreeing with `comply`. Because hermex published no canonical verdict, no hermex test could catch the mismatch.

## Fix

Emit an official, machine-readable `compliance` block in the JSON (both `scan --format json` and `comply --format json`) so consumers read one canonical field:

```jsonc
"compliance": {
  "status": "compliant",   // "compliant" | "warning" | "non-compliant"
  "compliant": true,        // mirrors the comply exit code (0 ⇔ true)
  "counts": {
    "errorRuleViolations": 0,
    "errorBannedPackageViolations": 0,
    "releaseAgeViolations": 0,
    "warningRuleViolations": 0,
    "warningBannedPackageViolations": 0
  }
}
```

The `warning` tier is deliberately narrow — **only** warn-severity *rule* and *banned-package* violations demote to it. Non-enforced overdue release-age packages and pending-only entries are advisory and **never** demote `compliant → warning`, exactly matching `comply`. `status: 'warning'` never changes the exit code.

## Changes

- `src/utils/compliance.ts` — add `ComplianceStatus` + warning buckets to `ComplianceResult`
- `src/utils/print-json.ts` — emit the `compliance` block (defaults to `computeCompliance`, so `scan` carries the same verdict as `comply`)
- `src/index.ts` — extend the public `HermexScanResult` type, export `ComplianceStatus`
- `docs/examples.md` — document reading `compliance.status`

## Tests

- **Unit** — new `status` suite in `compliance.test.ts`, including the exact #55 `search-page` shape (info Orbis signal + `react-*` non-enforced overdue + `@guestyci/*` pending-only ⇒ stays `compliant`); `print-utils.test.ts` asserts the JSON block shape.
- **E2E** (`tests/e2e/cli.test.ts`) — drives the real built CLI through all three critical paths: error rule ⇒ `non-compliant` + exit 1; warn rule (new fixture) ⇒ `warning` + exit 0; info-only ⇒ `compliant` + exit 0; and confirms `scan --format json` carries the verdict too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)