### PR TITLE
fix: releaseAge root vs tree scope, yarn first-wins, table/summary drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Dependencies
 node_modules/
 
-# Lock files
-package-lock.json
-yarn.lock
+# Lock files (repo root only — nested copies under tests/fixtures/ are
+# intentional test data, not accidental installs, and must stay trackable)
+/package-lock.json
+/yarn.lock
 
 # Keep pnpm-lock.yaml (we're using pnpm)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -263,6 +263,29 @@ If `enforceOn` is omitted, every package's release age counts toward compliance 
 
 `enforceOn` matches are checked against the lockfile directly, not just packages hermex found imported as components — so a CSS-only or side-effect-only dependency (e.g. `import '@my-org/styles/button.css'`) still gets checked and can still fail `hermex comply`, even though it never shows up in component usage.
 
+### Root vs. tree scope
+
+hermex's lockfile parsing always resolves **complete** data for every package, for all three package managers (npm, yarn, pnpm): both the version your root `package.json` resolves to, and every distinct version found anywhere in the lockfile. `scope` then decides which of that data counts toward `comply` — it's a policy choice layered on top of already-complete data, not a limit on what hermex extracts:
+
+```ts
+export default defineConfig({
+  releaseAge: {
+    enabled: true,
+    scope: 'root', // default — only the root-installed version can fail comply
+    // scope: 'tree', // check every resolved copy; fail if any is overdue
+    scopeExceptions: ['@vendor/pinned-*'], // these packages use the OPPOSITE scope
+  },
+});
+```
+
+- **`scope: 'root'`** (default) — only each package's direct/root-installed version is enforced. This matches how npm and pnpm (v9+) lockfiles already resolve dependencies. Nested duplicate copies pulled in by transitive dependencies never independently fail `comply`.
+- **`scope: 'tree'`** — every resolved copy in the lockfile is enforced; `comply` fails if *any* installed copy is overdue.
+- **`scopeExceptions`** — glob patterns (matched like `enforceOn`) naming packages that use the *opposite* of the configured `scope`. Useful when most of your tree should be checked exhaustively but a handful of packages have transitive pins you don't control down to the root, or vice versa.
+
+**Root scope never hides nested duplicates.** When a package has multiple resolved versions and the root copy is compliant, an overdue nested copy still shows up — in both the human `--format human` table and `--summary-file` — as a Notes line beneath the Packages table, not folded into the pass/fail cell. The table itself always shows a single **Installed** version (the exact copy the verdict was measured against — the enforced baseline, which under `scope: 'tree'` may be a nested copy rather than the root version) alongside the **Target** (recommended upgrade); the full list of resolved versions and any non-enforced overdue copies live in Notes, keyed by package name, so it's never ambiguous which installed copy a given overdue count refers to.
+
+For **yarn**, root-version resolution works by reading the root `package.json`'s declared dependency range and matching it exactly against the corresponding entry in the already-parsed `yarn.lock` — yarn.lock itself retains no root/nested distinction, unlike npm's and pnpm's lockfile formats. If `package.json` can't be read, or a package isn't a direct dependency at all (purely transitive), hermex falls back to the highest resolved version found in the lockfile. Pre-v9 pnpm lockfiles (no `importers` field) are always treated as root-only regardless of `scope` — those legacy formats don't retain a root/nested distinction either.
+
 ## Compliance Checking
 
 `hermex scan` is purely informational and always exits `0`. Use `hermex comply` to gate CI on your rules and release-age policy — it runs the same analysis pipeline, reports every violation (it does not stop at the first one), then exits based on the result:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -126,6 +126,15 @@ export const HermexConfigSchema = z.object({
       enforceOn: z.array(z.string()).default([]),
       cacheTtlMs: z.number().int().positive().optional(),
       cacheDisabled: z.boolean().default(false),
+      // 'root' checks only each package's direct/root-installed version;
+      // 'tree' checks every resolved copy in the lockfile, failing if any
+      // is overdue. Nested duplicates are always visible as advisory data
+      // regardless of scope — this only decides what's mandatory (#57).
+      scope: z.enum(['root', 'tree']).default('root'),
+      // Glob-matched (like enforceOn): packages matching here use the
+      // OPPOSITE of `scope`, letting one global policy carve out
+      // exceptions for specific packages.
+      scopeExceptions: z.array(z.string()).default([]),
     })
     .default(() => ({
       enabled: false,
@@ -133,6 +142,8 @@ export const HermexConfigSchema = z.object({
       thresholds: { patch: 30, minor: 45, major: 60 },
       enforceOn: [],
       cacheDisabled: false,
+      scope: 'root' as const,
+      scopeExceptions: [],
     })),
 });
 

--- a/src/lock-parser/index.ts
+++ b/src/lock-parser/index.ts
@@ -1,19 +1,30 @@
 import { NpmLockfileAdapter } from './patterns/npm';
 import { PnpmLockfileAdapter } from './patterns/pnpm';
 import { YarnLockfileAdapter } from './patterns/yarn';
-import type { LockfileAdapter, MultiVersionMap } from './lock-file-adapter';
+import {
+  maxSemver,
+  type LockfileAdapter,
+  type LockfileResolutionMap,
+  type MultiVersionMap,
+} from './lock-file-adapter';
 
-export type { MultiVersionMap };
-
-export interface VersionConflict {
-  packageName: string;
-  versions: string[];
-}
+export type {
+  MultiVersionMap,
+  LockfileResolutionMap,
+  PackageResolution,
+} from './lock-file-adapter';
 
 export interface LockfileResult {
+  /** Complete per-package resolution data — root version (if determinable) and every resolved copy. */
+  resolutions: LockfileResolutionMap;
+  /**
+   * The single "installed version" per package: `rootVersion` when known,
+   * otherwise the highest semver among `allVersions` (undeterminable root,
+   * e.g. a yarn package with no readable package.json, or a purely
+   * transitive dependency).
+   */
   versions: Record<string, string>;
   multiVersions: MultiVersionMap;
-  versionConflicts: VersionConflict[];
   lockfileType: 'npm' | 'yarn' | 'pnpm' | null;
   lockfilePath: string | null;
   supportedVersions: string[];
@@ -34,19 +45,21 @@ export function findAndParseLockfile(projectPath: string): LockfileResult {
   for (const adapter of LOCKFILE_ADAPTERS) {
     const lockfilePath = adapter.detect(projectPath);
     if (lockfilePath) {
-      const versions = adapter.parse(lockfilePath);
-      const multiVersions = adapter.parseMultiVersion
-        ? adapter.parseMultiVersion(lockfilePath)
-        : {};
+      const resolutions = adapter.resolve(lockfilePath, projectPath);
 
-      const versionConflicts: VersionConflict[] = Object.entries(multiVersions)
-        .filter(([, vers]) => vers.length > 1)
-        .map(([packageName, vers]) => ({ packageName, versions: vers }));
+      const versions: Record<string, string> = {};
+      const multiVersions: MultiVersionMap = {};
+      for (const [packageName, resolution] of Object.entries(resolutions)) {
+        multiVersions[packageName] = resolution.allVersions;
+        const effective =
+          resolution.rootVersion ?? maxSemver(resolution.allVersions);
+        if (effective) versions[packageName] = effective;
+      }
 
       return {
+        resolutions,
         versions,
         multiVersions,
-        versionConflicts,
         lockfileType: adapter.name as 'npm' | 'yarn' | 'pnpm',
         lockfilePath,
         supportedVersions: adapter.supportedVersions,

--- a/src/lock-parser/lock-file-adapter.ts
+++ b/src/lock-parser/lock-file-adapter.ts
@@ -1,13 +1,30 @@
 import fs from 'fs';
+import semver from 'semver';
 
 export type MultiVersionMap = Record<string, string[]>;
+
+export interface PackageResolution {
+  /**
+   * The version resolved for this package's root/direct dependency
+   * declaration. `null` when the package isn't a direct dependency of the
+   * root project (purely transitive), or root resolution genuinely
+   * couldn't be determined (e.g. yarn without a readable package.json).
+   */
+  rootVersion: string | null;
+  /**
+   * Every distinct version resolved anywhere in the lockfile for this
+   * package, sorted. Always includes `rootVersion` when it is non-null.
+   */
+  allVersions: string[];
+}
+
+export type LockfileResolutionMap = Record<string, PackageResolution>;
 
 export interface LockfileAdapter {
   name: string;
   supportedVersions: string[];
   detect(projectPath: string): string | null;
-  parse(lockfilePath: string): Record<string, string>;
-  parseMultiVersion?(lockfilePath: string): MultiVersionMap;
+  resolve(lockfilePath: string, projectPath: string): LockfileResolutionMap;
 }
 
 /**
@@ -30,13 +47,44 @@ export function readAndParseLockfile<T>(
   }
 }
 
-/** Converts `{ pkg: Set<version> }` into a `MultiVersionMap` with sorted, deduplicated version arrays. */
-export function toSortedMultiVersionMap(
-  versionSets: Record<string, Set<string>>,
-): MultiVersionMap {
-  const result: MultiVersionMap = {};
-  for (const [pkg, versions] of Object.entries(versionSets)) {
-    result[pkg] = Array.from(versions).sort();
-  }
-  return result;
+/**
+ * Accumulates per-package resolution data (every resolved version, plus
+ * which one — if any — is the root/direct dependency's version) while an
+ * adapter walks its lockfile in a single pass, then builds the final
+ * `LockfileResolutionMap` with sorted, deduplicated version lists.
+ */
+export function createResolutionAccumulator(): {
+  addVersion(pkgName: string, version: string): void;
+  setRoot(pkgName: string, version: string): void;
+  build(): LockfileResolutionMap;
+} {
+  const versionSets: Record<string, Set<string>> = {};
+  const roots: Record<string, string> = {};
+
+  return {
+    addVersion(pkgName, version) {
+      (versionSets[pkgName] ??= new Set()).add(version);
+    },
+    setRoot(pkgName, version) {
+      roots[pkgName] = version;
+    },
+    build() {
+      const result: LockfileResolutionMap = {};
+      for (const [pkgName, versions] of Object.entries(versionSets)) {
+        result[pkgName] = {
+          rootVersion: roots[pkgName] ?? null,
+          allVersions: Array.from(versions).sort(),
+        };
+      }
+      return result;
+    },
+  };
+}
+
+/** Highest valid semver among `versions`, or `undefined` if none are valid. */
+export function maxSemver(versions: string[]): string | undefined {
+  return versions
+    .filter((v) => semver.valid(v))
+    .sort(semver.compare)
+    .at(-1);
 }

--- a/src/lock-parser/patterns/npm.ts
+++ b/src/lock-parser/patterns/npm.ts
@@ -2,9 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import {
   readAndParseLockfile,
-  toSortedMultiVersionMap,
+  createResolutionAccumulator,
   type LockfileAdapter,
-  type MultiVersionMap,
+  type LockfileResolutionMap,
 } from '../lock-file-adapter';
 
 function canonicalPackageName(pkgPath: string): string {
@@ -28,79 +28,57 @@ export class NpmLockfileAdapter implements LockfileAdapter {
     return fs.existsSync(lockfilePath) ? lockfilePath : null;
   }
 
-  parse(lockFilePath: string): Record<string, string> {
+  resolve(lockFilePath: string): LockfileResolutionMap {
     return readAndParseLockfile(
       lockFilePath,
       (content) => {
         const lockData = JSON.parse(content);
-        const versions: Record<string, string> = {};
+        const acc = createResolutionAccumulator();
+        let sawPackages = false;
 
-        // npm v7+ uses "packages" field (lockfileVersion 2, 3)
+        // npm v7+ uses "packages" field (lockfileVersion 2, 3). Every entry
+        // (any depth) contributes to allVersions; only depth-1 entries (no
+        // nested "node_modules/" in the path) are the root/direct
+        // dependency's resolution.
         if (lockData.packages) {
           Object.entries(lockData.packages).forEach(
             ([pkgPath, pkgData]: [string, any]) => {
               if (!pkgPath || pkgPath === '') return;
+              const version = pkgData?.version;
+              if (!version) return;
 
-              // Only root-level packages (no nested node_modules in path)
-              if (pkgPath.split('node_modules/').length > 2) return;
-
+              sawPackages = true;
               const pkgName = canonicalPackageName(pkgPath);
-              if (pkgData.version) {
-                versions[pkgName] = pkgData.version;
-              }
+              acc.addVersion(pkgName, version);
+
+              const isRoot = pkgPath.split('node_modules/').length <= 2;
+              if (isRoot) acc.setRoot(pkgName, version);
             },
           );
         }
 
-        // npm v6 uses "dependencies" field (fallback)
-        if (lockData.dependencies && Object.keys(versions).length === 0) {
-          function extractVersions(deps: any, prefix = ''): void {
+        // npm v6 uses "dependencies" field (fallback). Keyed strictly by
+        // real package name (not a depth-prefixed compound key) so nested
+        // copies of the same package share one allVersions entry.
+        if (lockData.dependencies && !sawPackages) {
+          function extractVersions(deps: any, depth = 0): void {
             Object.entries(deps).forEach(([name, data]: [string, any]) => {
-              const fullName = prefix ? `${prefix}/${name}` : name;
               if (data.version) {
-                versions[fullName] = data.version;
+                acc.addVersion(name, data.version);
+                if (depth === 0) acc.setRoot(name, data.version);
               }
               if (data.dependencies) {
-                extractVersions(data.dependencies, fullName);
+                extractVersions(data.dependencies, depth + 1);
               }
             });
           }
           extractVersions(lockData.dependencies);
         }
 
-        return versions;
+        return acc.build();
       },
       {},
       'package-lock.json',
-    );
-  }
-
-  parseMultiVersion(lockFilePath: string): MultiVersionMap {
-    return readAndParseLockfile(
-      lockFilePath,
-      (content) => {
-        const lockData = JSON.parse(content);
-        const versionSets: Record<string, Set<string>> = {};
-
-        if (lockData.packages) {
-          Object.entries(lockData.packages).forEach(
-            ([pkgPath, pkgData]: [string, any]) => {
-              if (!pkgPath || pkgPath === '') return;
-
-              const pkgName = canonicalPackageName(pkgPath);
-              const version = (pkgData as any).version;
-              if (!version) return;
-
-              if (!versionSets[pkgName]) versionSets[pkgName] = new Set();
-              versionSets[pkgName].add(version);
-            },
-          );
-        }
-
-        return toSortedMultiVersionMap(versionSets);
-      },
-      {},
-      'package-lock.json (multi-version)',
     );
   }
 }

--- a/src/lock-parser/patterns/pnpm.ts
+++ b/src/lock-parser/patterns/pnpm.ts
@@ -7,9 +7,9 @@ import {
 } from '@pnpm/dependency-path';
 import {
   readAndParseLockfile,
-  toSortedMultiVersionMap,
+  createResolutionAccumulator,
   type LockfileAdapter,
-  type MultiVersionMap,
+  type LockfileResolutionMap,
 } from '../lock-file-adapter';
 
 function parsePackageKey(
@@ -40,107 +40,95 @@ export class PnpmLockfileAdapter implements LockfileAdapter {
     return fs.existsSync(lockfilePath) ? lockfilePath : null;
   }
 
-  parse(lockFilePath: string): Record<string, string> {
+  resolve(lockFilePath: string): LockfileResolutionMap {
     return readAndParseLockfile(
       lockFilePath,
       (content) => {
         const lockData = load(content) as any;
-        const versions: Record<string, string> = {};
+        const acc = createResolutionAccumulator();
 
-        // pnpm v9+ uses "importers" field
-        if (lockData.importers) {
-          const rootImporter = lockData.importers['.'];
-          if (rootImporter) {
-            // Parse dependencies
-            if (rootImporter.dependencies) {
-              for (const [name, data] of Object.entries(
-                rootImporter.dependencies,
-              )) {
-                if (
-                  typeof data === 'object' &&
-                  data !== null &&
-                  'version' in data
-                ) {
-                  versions[name] = removeSuffix((data as any).version);
-                }
-              }
-            }
-            // Parse devDependencies
-            if (rootImporter.devDependencies) {
-              for (const [name, data] of Object.entries(
-                rootImporter.devDependencies,
-              )) {
-                if (
-                  typeof data === 'object' &&
-                  data !== null &&
-                  'version' in data
-                ) {
-                  versions[name] = removeSuffix((data as any).version);
-                }
+        // Every resolved copy anywhere in the lockfile (v6+ flat "packages"
+        // key namespace) — this is allVersions, regardless of scope.
+        if (lockData.packages) {
+          Object.keys(lockData.packages).forEach((key) => {
+            const parsed = parsePackageKey(key);
+            if (!parsed) return;
+            acc.addVersion(parsed.name, parsed.version);
+          });
+        }
+
+        // Root resolution: pnpm v9+ "importers" field is authoritative —
+        // the root workspace importer's own resolved version.
+        let hasImporterRoot = false;
+        const rootImporter = lockData.importers?.['.'];
+        if (rootImporter) {
+          for (const depsField of ['dependencies', 'devDependencies']) {
+            const deps = rootImporter[depsField];
+            if (!deps) continue;
+            for (const [name, data] of Object.entries(deps)) {
+              if (
+                typeof data === 'object' &&
+                data !== null &&
+                'version' in data
+              ) {
+                const version = removeSuffix((data as any).version);
+                acc.setRoot(name, version);
+                acc.addVersion(name, version);
+                hasImporterRoot = true;
               }
             }
           }
         }
 
-        // pnpm v6-8 uses "packages" field
-        if (lockData.packages && Object.keys(versions).length === 0) {
-          Object.keys(lockData.packages).forEach((key) => {
-            // Key format: "/@babel/core/7.22.5" or "/package/1.0.0"
-            const match = key.match(/\/(.+?)\/(\d+\.\d+\.\d+.*?)(?:_|$)/);
-            if (match) {
-              const [, pkgName, version] = match;
-              versions[pkgName] = removeSuffix(version);
-            }
-          });
-        }
-
-        // pnpm v5 uses "dependencies" and "specifiers"
-        if (lockData.dependencies && Object.keys(versions).length === 0) {
-          Object.entries(lockData.dependencies).forEach(
-            ([name, versionSpec]: [string, any]) => {
-              // versionSpec format: "1.0.0" or "link:../package"
-              if (
-                typeof versionSpec === 'string' &&
-                !versionSpec.startsWith('link:')
-              ) {
-                versions[name] = removeSuffix(versionSpec);
-              } else if (
-                typeof versionSpec === 'object' &&
-                versionSpec.version
-              ) {
-                versions[name] = removeSuffix(versionSpec.version);
+        // Legacy pnpm v5/v6-8 lockfiles have no "importers" field at all —
+        // these formats don't retain a root/nested distinction, so whatever
+        // single resolution they produce is treated as root too (accepted
+        // gap, documented).
+        if (!hasImporterRoot) {
+          // pnpm v6-8 uses "packages" field
+          if (lockData.packages) {
+            Object.keys(lockData.packages).forEach((key) => {
+              // Key format: "/@babel/core/7.22.5" or "/package/1.0.0"
+              const match = key.match(/\/(.+?)\/(\d+\.\d+\.\d+.*?)(?:_|$)/);
+              if (match) {
+                const [, pkgName, version] = match;
+                const resolved = removeSuffix(version);
+                acc.setRoot(pkgName, resolved);
+                acc.addVersion(pkgName, resolved);
               }
-            },
-          );
+            });
+          }
+
+          // pnpm v5 uses "dependencies" and "specifiers"
+          if (lockData.dependencies) {
+            Object.entries(lockData.dependencies).forEach(
+              ([name, versionSpec]: [string, any]) => {
+                // versionSpec format: "1.0.0" or "link:../package"
+                let version: string | undefined;
+                if (
+                  typeof versionSpec === 'string' &&
+                  !versionSpec.startsWith('link:')
+                ) {
+                  version = removeSuffix(versionSpec);
+                } else if (
+                  typeof versionSpec === 'object' &&
+                  versionSpec.version
+                ) {
+                  version = removeSuffix(versionSpec.version);
+                }
+                if (version) {
+                  acc.setRoot(name, version);
+                  acc.addVersion(name, version);
+                }
+              },
+            );
+          }
         }
 
-        return versions;
+        return acc.build();
       },
       {},
       'pnpm-lock.yaml',
-    );
-  }
-
-  parseMultiVersion(lockFilePath: string): MultiVersionMap {
-    return readAndParseLockfile(
-      lockFilePath,
-      (content) => {
-        const lockData = load(content) as any;
-        const versionSets: Record<string, Set<string>> = {};
-
-        if (lockData.packages) {
-          Object.keys(lockData.packages).forEach((key) => {
-            const parsed = parsePackageKey(key);
-            if (!parsed) return;
-            if (!versionSets[parsed.name]) versionSets[parsed.name] = new Set();
-            versionSets[parsed.name].add(parsed.version);
-          });
-        }
-
-        return toSortedMultiVersionMap(versionSets);
-      },
-      {},
-      'pnpm-lock.yaml (multi-version)',
     );
   }
 }

--- a/src/lock-parser/patterns/yarn.ts
+++ b/src/lock-parser/patterns/yarn.ts
@@ -3,10 +3,18 @@ import path from 'path';
 import lockfile from '@yarnpkg/lockfile';
 import {
   readAndParseLockfile,
-  toSortedMultiVersionMap,
+  createResolutionAccumulator,
   type LockfileAdapter,
-  type MultiVersionMap,
+  type LockfileResolutionMap,
 } from '../lock-file-adapter';
+import { readPackageJson } from '../../rules/shared';
+
+const ROOT_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
 
 function extractPackageName(key: string): string {
   if (key.startsWith('@')) {
@@ -15,6 +23,32 @@ function extractPackageName(key: string): string {
   }
   const match = key.match(/^([^@]+)@/);
   return match ? match[1] : key;
+}
+
+/**
+ * Merges every declared dependency range from the root package.json into a
+ * single `name -> range` map, so a yarn.lock entry's exact key (`name@range`)
+ * can be matched against it to find the root-resolved version — yarn.lock
+ * itself retains no root/nested distinction, unlike npm's and pnpm's
+ * lockfile formats (#57).
+ */
+function collectRootRanges(
+  pkgJson: Record<string, unknown> | null,
+): Record<string, string> {
+  const ranges: Record<string, string> = {};
+  if (!pkgJson) return ranges;
+
+  for (const field of ROOT_DEPENDENCY_FIELDS) {
+    const deps = pkgJson[field];
+    if (!deps || typeof deps !== 'object') continue;
+    for (const [name, range] of Object.entries(
+      deps as Record<string, unknown>,
+    )) {
+      if (typeof range === 'string') ranges[name] = range;
+    }
+  }
+
+  return ranges;
 }
 
 export class YarnLockfileAdapter implements LockfileAdapter {
@@ -26,7 +60,9 @@ export class YarnLockfileAdapter implements LockfileAdapter {
     return fs.existsSync(lockfilePath) ? lockfilePath : null;
   }
 
-  parse(lockFilePath: string): Record<string, string> {
+  resolve(lockFilePath: string, projectPath: string): LockfileResolutionMap {
+    const rootRanges = collectRootRanges(readPackageJson(projectPath));
+
     return readAndParseLockfile(
       lockFilePath,
       (content) => {
@@ -37,46 +73,26 @@ export class YarnLockfileAdapter implements LockfileAdapter {
           return {};
         }
 
-        const versions: Record<string, string> = {};
+        const acc = createResolutionAccumulator();
 
-        Object.entries(parsed.object).forEach(([key, value]: [string, any]) => {
-          const pkgName = extractPackageName(key);
-
-          if (value.version && !versions[pkgName]) {
-            versions[pkgName] = value.version;
-          }
-        });
-
-        return versions;
-      },
-      {},
-      'yarn.lock',
-    );
-  }
-
-  parseMultiVersion(lockFilePath: string): MultiVersionMap {
-    return readAndParseLockfile(
-      lockFilePath,
-      (content) => {
-        const parsed = lockfile.parse(content);
-
-        if (parsed.type !== 'success') {
-          throw new Error('Failed to parse yarn.lock');
-        }
-
-        const versionSets: Record<string, Set<string>> = {};
-
+        // `@yarnpkg/lockfile`'s parse() has already decoded the lockfile —
+        // we only correlate its already-parsed keys against package.json
+        // ranges here, not re-implementing any lockfile parsing ourselves.
         Object.entries(parsed.object).forEach(([key, value]: [string, any]) => {
           if (!value.version) return;
           const pkgName = extractPackageName(key);
-          if (!versionSets[pkgName]) versionSets[pkgName] = new Set();
-          versionSets[pkgName].add(value.version);
+          acc.addVersion(pkgName, value.version);
+
+          const range = rootRanges[pkgName];
+          if (range && key === `${pkgName}@${range}`) {
+            acc.setRoot(pkgName, value.version);
+          }
         });
 
-        return toSortedMultiVersionMap(versionSets);
+        return acc.build();
       },
       {},
-      'yarn.lock (multi-version)',
+      'yarn.lock',
     );
   }
 }

--- a/src/npm-registry/enricher.ts
+++ b/src/npm-registry/enricher.ts
@@ -47,14 +47,30 @@ function upgradeLevel(
   return null;
 }
 
-function computeReleaseAge(
+interface ReleaseAgeForVersion {
+  upgrades: AvailableUpgrade[];
+  worstLevel: UpgradeLevel | null;
+  pendingUpgrade?: PendingUpgrade;
+  latestVersion?: string;
+  latestReleasedDaysAgo?: number;
+  minCompliantVersion?: string;
+  minCompliantReleasedDaysAgo?: number;
+  minCompliantInWindow: boolean;
+  minCompliantBump?: SemverBump;
+}
+
+/**
+ * Computes everything version-dependent for a single installed version
+ * against the registry's release timeline — no notion of scope, severity,
+ * or deprecation, which are policy/registry facts independent of which
+ * installed copy is being checked (#57).
+ */
+function computeReleaseAgeForVersion(
   installedVersion: string,
   timeMap: Record<string, string>,
-  deprecated: string | undefined,
   thresholds: ReleaseAgeConfig['thresholds'],
   distTags: Record<string, string> | undefined,
-  severity: 'error' | 'warn',
-): ReleaseAgeEntry {
+): ReleaseAgeForVersion {
   const byBump = new Map<SemverBump, { version: string; daysAgo: number }[]>();
   let minCompliantVersion: string | undefined;
   let minCompliantReleasedDaysAgo: number | undefined;
@@ -185,19 +201,126 @@ function computeReleaseAge(
   }
 
   return {
-    installedVersion,
     upgrades: finalUpgrades,
     worstLevel,
     pendingUpgrade,
-    deprecated,
     latestVersion,
     latestReleasedDaysAgo,
     minCompliantVersion,
     minCompliantReleasedDaysAgo,
     minCompliantInWindow: hadInWindowCandidate,
     minCompliantBump,
-    severity,
   };
+}
+
+const LEVEL_RANK: Record<'null' | UpgradeLevel, number> = {
+  null: 0,
+  minor_overdue: 1,
+  major_overdue: 2,
+};
+
+function levelRank(level: UpgradeLevel | null): number {
+  return LEVEL_RANK[level ?? 'null'];
+}
+
+/**
+ * Resolves which of `allVersions` count toward compliance ('root': just
+ * `installedVersion`; 'tree': every resolved copy), evaluates each
+ * candidate independently via `computeReleaseAgeForVersion`, and combines
+ * them into a single verdict — the worst result among the enforced
+ * versions — while still surfacing overdue-but-not-enforced copies via
+ * `advisoryBreaches` regardless of scope (#57).
+ */
+function computeReleaseAge(
+  installedVersion: string,
+  allVersions: string[],
+  timeMap: Record<string, string>,
+  deprecated: string | undefined,
+  thresholds: ReleaseAgeConfig['thresholds'],
+  distTags: Record<string, string> | undefined,
+  severity: 'error' | 'warn',
+  scope: 'root' | 'tree',
+): ReleaseAgeEntry {
+  const candidates =
+    allVersions.length > 0
+      ? Array.from(new Set(allVersions))
+      : [installedVersion];
+  if (!candidates.includes(installedVersion)) candidates.push(installedVersion);
+
+  const enforcedVersions = scope === 'tree' ? candidates : [installedVersion];
+
+  const perVersion = new Map<string, ReleaseAgeForVersion>();
+  for (const version of candidates) {
+    perVersion.set(
+      version,
+      computeReleaseAgeForVersion(version, timeMap, thresholds, distTags),
+    );
+  }
+
+  let baselineVersion = enforcedVersions[0];
+  let baseline = perVersion.get(baselineVersion)!;
+  for (const version of enforcedVersions.slice(1)) {
+    const candidate = perVersion.get(version)!;
+    const candidateRank = levelRank(candidate.worstLevel);
+    const baselineRank = levelRank(baseline.worstLevel);
+    const candidateBreachAge =
+      candidate.upgrades[0]?.breachReleasedDaysAgo ?? 0;
+    const baselineBreachAge = baseline.upgrades[0]?.breachReleasedDaysAgo ?? 0;
+    if (
+      candidateRank > baselineRank ||
+      (candidateRank === baselineRank && candidateBreachAge > baselineBreachAge)
+    ) {
+      baseline = candidate;
+      baselineVersion = version;
+    }
+  }
+
+  const advisoryBreaches: { version: string; level: UpgradeLevel }[] = [];
+  for (const version of candidates) {
+    if (enforcedVersions.includes(version)) continue;
+    const result = perVersion.get(version)!;
+    if (result.worstLevel) {
+      advisoryBreaches.push({ version, level: result.worstLevel });
+    }
+  }
+
+  return {
+    installedVersion: baselineVersion,
+    upgrades: baseline.upgrades,
+    worstLevel: baseline.worstLevel,
+    pendingUpgrade: baseline.pendingUpgrade,
+    deprecated,
+    latestVersion: baseline.latestVersion,
+    latestReleasedDaysAgo: baseline.latestReleasedDaysAgo,
+    minCompliantVersion: baseline.minCompliantVersion,
+    minCompliantReleasedDaysAgo: baseline.minCompliantReleasedDaysAgo,
+    minCompliantInWindow: baseline.minCompliantInWindow,
+    minCompliantBump: baseline.minCompliantBump,
+    severity,
+    scope,
+    evaluatedVersions: candidates.length > 1 ? candidates : undefined,
+    advisoryBreaches:
+      advisoryBreaches.length > 0 ? advisoryBreaches : undefined,
+  };
+}
+
+/**
+ * Resolves the effective scope for a package: `scopeExceptions` (glob,
+ * matched like `enforceOn`) flips the global `scope` default for packages
+ * that need the opposite policy — e.g. tree-wide everywhere except a
+ * package whose transitive pins can't be controlled down to root (#57).
+ */
+export function resolveReleaseAgeScope(
+  packageName: string,
+  config: ReleaseAgeConfig,
+): 'root' | 'tree' {
+  if (
+    config.scopeExceptions.length > 0 &&
+    micromatch.isMatch(packageName, config.scopeExceptions)
+  ) {
+    return config.scope === 'root' ? 'tree' : 'root';
+  }
+  return config.scope;
 }
 
 export async function enrichWithReleaseAge(
@@ -244,13 +367,17 @@ export async function enrichWithReleaseAge(
             ? 'error'
             : 'warn';
 
+        const scope = resolveReleaseAgeScope(pkg.packageName, config);
+
         const entry = computeReleaseAge(
           pkg.version!,
+          pkg.allVersions,
           info.time,
           typeof deprecated === 'string' ? deprecated : undefined,
           config.thresholds,
           info['dist-tags'],
           severity,
+          scope,
         );
 
         return { pkg, entry };

--- a/src/npm-registry/types.ts
+++ b/src/npm-registry/types.ts
@@ -63,6 +63,22 @@ export interface ReleaseAgeEntry {
    * the recommended target when it differs from the breached tier. */
   minCompliantBump?: SemverBump;
   severity: 'error' | 'warn';
+  /**
+   * Which lockfile copies count toward this verdict: 'root' checks only
+   * `installedVersion`; 'tree' checks every resolved copy. Resolved from
+   * `releaseAge.scope`/`scopeExceptions` config (#57).
+   */
+  scope: 'root' | 'tree';
+  /** Every distinct installed version considered — only set when more than one exists. */
+  evaluatedVersions?: string[];
+  /**
+   * Versions from `evaluatedVersions` that breached their own threshold but
+   * are NOT part of this verdict (i.e. not in scope) — e.g. nested
+   * duplicates under `scope: 'root'`. Always computed when there's a
+   * conflict, regardless of scope, so overdue nested copies are never
+   * silently invisible just because they don't block `comply` (#57).
+   */
+  advisoryBreaches?: { version: string; level: UpgradeLevel }[];
 }
 
 export interface RegistryPackageInfo {

--- a/src/utils/print-packages.ts
+++ b/src/utils/print-packages.ts
@@ -70,17 +70,83 @@ export function describeUpgradeTarget(
   return `${top.semverBump} ${top.version} (${overdue})`;
 }
 
+// Prefer a genuinely compliant, still-in-window release as the recommended
+// target — it may sit in a different tier than the one that breached (the
+// breached tier's own newest release can itself be stale). Only when no such
+// target exists does `describeUpgradeTarget` fall back to "no compliant
+// release available". Extracted so both the human table and `--summary-file`
+// derive the recommended target the same way — they diverged on this once
+// before (#57).
+export function resolveCompliantTarget(
+  releaseAge?: ReleaseAgeEntry,
+): { version: string; bump: SemverBump } | undefined {
+  if (!releaseAge?.minCompliantInWindow || !releaseAge.minCompliantVersion) {
+    return undefined;
+  }
+  return {
+    version: releaseAge.minCompliantVersion,
+    bump: releaseAge.minCompliantBump ?? releaseAge.upgrades[0]?.semverBump,
+  };
+}
+
+// Nested lockfile copies that are themselves overdue but aren't part of the
+// enforced verdict (e.g. non-root duplicates under `scope: 'root'`) must
+// stay visible — they don't block `comply`, but silently hiding them would
+// let real problems go unnoticed just because the policy doesn't enforce
+// them. One shared formatter, reused by the human table and
+// `--summary-file`, so the wording can't drift between the two (#57).
+//
+// Doesn't re-list which versions are overdue — `describeBundleImpact`
+// already names every resolved copy right before this in the same note, so
+// repeating a subset of that same list here would just be noise. Carries
+// its own warn icon since, unlike the plain bundle-impact fact, this is
+// itself an actionable finding worth flagging visually.
+export function describeAdvisoryBreaches(
+  releaseAge?: ReleaseAgeEntry,
+): string | undefined {
+  if (!releaseAge?.advisoryBreaches?.length) return undefined;
+  const n = releaseAge.advisoryBreaches.length;
+  return `${severityIcon('warn')} ${n} nested ${n > 1 ? 'copies' : 'copy'} overdue, not enforced but recommended to resolve`;
+}
+
+// The single version a package's compliance verdict was actually measured
+// against — `releaseAge.installedVersion` when release-age ran (which, under
+// `scope: 'tree'`, may be a nested copy rather than the root version), else
+// the plain root-resolved `pkg.version`. Always a single value, never the
+// full `allVersions` list — that ambiguity (which of several installed
+// copies a cell's overdue count refers to) is exactly what #57 flagged.
+export function resolveInstalledVersion(pkg: PackageDistribution): string {
+  return pkg.releaseAge?.installedVersion ?? pkg.version ?? 'N/A';
+}
+
+// Bundle-impact note for a package with more than one resolved lockfile
+// copy — kept separate from the Installed/Target columns (and from
+// describeAdvisoryBreaches) so each concern renders as its own sentence in
+// the notes list, not crammed into a table cell (#57).
+export function describeBundleImpact(
+  pkg: PackageDistribution,
+): string | undefined {
+  if (!pkg.hasVersionConflict) return undefined;
+  return `${pkg.allVersions.length} versions installed (bundle impact): ${pkg.allVersions.join(', ')}`;
+}
+
+// Combines bundle-impact and advisory-breach info into the single note line
+// shown for a package below the table/Packages section — one shared
+// formatter so the human output and `--summary-file` can't drift on wording
+// (#57).
+export function describePackageNotes(
+  pkg: PackageDistribution,
+): string | undefined {
+  const parts = [
+    describeBundleImpact(pkg),
+    describeAdvisoryBreaches(pkg.releaseAge),
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join('. ') : undefined;
+}
+
 export function formatUpgradeCell(releaseAge?: ReleaseAgeEntry): string {
   if (!releaseAge) return '';
-  const {
-    worstLevel,
-    upgrades,
-    severity,
-    pendingUpgrade,
-    minCompliantVersion,
-    minCompliantInWindow,
-    minCompliantBump,
-  } = releaseAge;
+  const { worstLevel, upgrades, severity, pendingUpgrade } = releaseAge;
 
   if (!worstLevel) {
     if (pendingUpgrade) {
@@ -93,21 +159,10 @@ export function formatUpgradeCell(releaseAge?: ReleaseAgeEntry): string {
   if (!top) return severityIcon('success');
 
   const suffix = severity === 'warn' ? chalk.gray(' [not enforced]') : '';
-
-  // Prefer a genuinely compliant, still-in-window release as the recommended
-  // target — it may sit in a different tier than the one that breached (the
-  // breached tier's own newest release can itself be stale). Only when no such
-  // target exists does `describeUpgradeTarget` fall back to "no compliant
-  // release available".
-  const compliantTarget =
-    minCompliantInWindow && minCompliantVersion
-      ? {
-          version: minCompliantVersion,
-          bump: minCompliantBump ?? top.semverBump,
-        }
-      : undefined;
-
-  const description = describeUpgradeTarget(top, compliantTarget);
+  const description = describeUpgradeTarget(
+    top,
+    resolveCompliantTarget(releaseAge),
+  );
 
   // The status reflects severity, not which tier breached: an enforced package
   // fails comply whether the worst breach is minor_overdue or major_overdue
@@ -150,8 +205,13 @@ function printPackagesTable(
   }
 
   const hasReleaseAge = packages.some((p) => p.releaseAge !== undefined);
-  const head = ['Package', 'Version'];
-  if (hasReleaseAge) head.push('Upgrades');
+  // With release age on, "Version" splits into "Installed" (the single
+  // version the verdict was actually measured against) and "Target" (the
+  // recommended upgrade) — cramming a multi-version list and an upgrade
+  // recommendation into one cell was exactly the ambiguity #57 reported.
+  const head = hasReleaseAge
+    ? ['Package', 'Installed', 'Target']
+    : ['Package', 'Version'];
 
   const table = new Table({
     head,
@@ -162,21 +222,33 @@ function printPackagesTable(
   });
 
   packages.forEach((pkg) => {
-    const versionCell = pkg.hasVersionConflict
-      ? chalk.yellow(
-          `⚠ ${pkg.allVersions.join(', ')} (${pkg.allVersions.length} versions — bundle impact)`,
-        )
-      : pkg.version || 'N/A';
-
-    const row = [
-      formatPackageName(pkg, getBannedViolation(pkg, violations)),
-      versionCell,
-    ];
-    if (hasReleaseAge) row.push(formatUpgradeCell(pkg.releaseAge));
+    const row = [formatPackageName(pkg, getBannedViolation(pkg, violations))];
+    if (hasReleaseAge) {
+      row.push(resolveInstalledVersion(pkg), formatUpgradeCell(pkg.releaseAge));
+    } else {
+      row.push(pkg.version || 'N/A');
+    }
     table.push(row);
   });
 
   console.log(table.toString());
+
+  // Bundle-impact (multiple resolved copies) and advisory nested breaches
+  // are per-package context, not part of the pass/fail verdict — printed as
+  // notes below the table rather than inside a cell, so the table itself
+  // stays a clean "installed -> target" comparison (#57).
+  const notes = packages
+    .map((pkg) => ({ pkg, note: describePackageNotes(pkg) }))
+    .filter(
+      (entry): entry is { pkg: PackageDistribution; note: string } =>
+        entry.note !== undefined,
+    );
+  if (notes.length > 0) {
+    console.log(chalk.gray('\nNotes:'));
+    for (const { pkg, note } of notes) {
+      console.log(chalk.gray(`  ${pkg.packageName} — ${note}`));
+    }
+  }
 
   console.log(chalk.gray(`\nTotal: ${formatCount(packages.length)} packages`));
 }

--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -2,7 +2,12 @@ import { writeFileSync } from 'node:fs';
 import type { AggregatedReport } from './aggregator';
 import type { ComplianceResult } from './compliance';
 import { describeViolation, formatRuleType } from './print-rules';
-import { describeUpgradeTarget } from './print-packages';
+import {
+  describePackageNotes,
+  describeUpgradeTarget,
+  resolveCompliantTarget,
+  resolveInstalledVersion,
+} from './print-packages';
 import { severityIcon, stripAnsi } from './severity-format';
 
 function buildRulesSection(aggregated: AggregatedReport): string {
@@ -48,30 +53,55 @@ function buildRulesSection(aggregated: AggregatedReport): string {
   return lines.join('\n') + '\n';
 }
 
-// Built directly from compliance.releaseAgeViolations rather than a
-// separately-derived filter — that's already exactly "release-age packages
-// that are mandatory failures" (src/utils/compliance.ts), so the row list
-// can never drift from the verdict's mandatory-violation count. Banned and
-// deprecated-only/not-enforced packages don't get a row here: banned ones
-// are already shown in Rules as a forbid_packages line, and deprecated-only
-// or not-enforced-overdue packages are info-level, not enforceable (#31).
-function buildPackagesSection(compliance: ComplianceResult): string {
-  if (compliance.releaseAgeViolations.length === 0) return '';
+// The table is built directly from compliance.releaseAgeViolations rather
+// than a separately-derived filter — that's already exactly "release-age
+// packages that are mandatory failures" (src/utils/compliance.ts), so the
+// row list can never drift from the verdict's mandatory-violation count.
+// Banned and deprecated-only/not-enforced packages don't get a row here:
+// banned ones are already shown in Rules as a forbid_packages line, and
+// deprecated-only or not-enforced-overdue packages are info-level, not
+// enforceable (#31).
+//
+// Bundle-impact (multiple resolved copies) and advisory nested breaches are
+// per-package context, not part of the pass/fail verdict — listed as Notes
+// below the table (mirroring the human `--format human` output), not
+// crammed into the Target cell or given their own violation-shaped row,
+// regardless of whether the package is itself a mandatory violation (#57).
+function buildPackagesSection(
+  aggregated: AggregatedReport,
+  compliance: ComplianceResult,
+): string {
+  const mandatory = compliance.releaseAgeViolations;
+  const withNotes = aggregated.packageDistribution.filter(
+    (p) => describePackageNotes(p) !== undefined,
+  );
 
-  const lines: string[] = [
-    '### Packages',
-    '',
-    '| | Package | Issue |',
-    '|---|---|---|',
-  ];
-  for (const pkg of compliance.releaseAgeViolations) {
-    const top = pkg.releaseAge?.upgrades[0];
-    const reasons: string[] = [];
-    if (top) reasons.push(describeUpgradeTarget(top));
-    if (pkg.releaseAge?.deprecated) reasons.push('deprecated');
-    lines.push(
-      `| ${severityIcon('error')} | \`${pkg.packageName}\` | ${reasons.join(', ')} |`,
-    );
+  if (mandatory.length === 0 && withNotes.length === 0) return '';
+
+  const lines: string[] = ['### Packages', ''];
+
+  if (mandatory.length > 0) {
+    lines.push('| | Package | Installed | Target |', '|---|---|---|---|');
+    for (const pkg of mandatory) {
+      const top = pkg.releaseAge?.upgrades[0];
+      const reasons: string[] = [];
+      if (top)
+        reasons.push(
+          describeUpgradeTarget(top, resolveCompliantTarget(pkg.releaseAge)),
+        );
+      if (pkg.releaseAge?.deprecated) reasons.push('deprecated');
+      lines.push(
+        `| ${severityIcon('error')} | \`${pkg.packageName}\` | ${resolveInstalledVersion(pkg)} | ${reasons.join(', ')} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (withNotes.length > 0) {
+    lines.push('Notes:');
+    for (const pkg of withNotes) {
+      lines.push(`- \`${pkg.packageName}\` — ${describePackageNotes(pkg)}`);
+    }
   }
 
   return lines.join('\n') + '\n';
@@ -107,7 +137,7 @@ export function writeSummaryFile(
   const sections = [
     `# ${title}\n`,
     buildRulesSection(aggregated),
-    buildPackagesSection(compliance),
+    buildPackagesSection(aggregated, compliance),
     buildVerdictSection(compliance),
   ].filter((section) => section.length > 0);
 

--- a/tests/helpers/mock-reports.ts
+++ b/tests/helpers/mock-reports.ts
@@ -45,16 +45,21 @@ export function createMockPackage(
   packageName: string,
   overrides: Partial<PackageDistribution> = {},
 ): PackageDistribution {
+  const version = overrides.version !== undefined ? overrides.version : '1.0.0';
   return {
     packageName,
-    version: '1.0.0',
+    version,
     componentCount: 1,
     usageCount: 1,
     percentage: 100,
     components: [],
     internal: false,
     hasVersionConflict: false,
-    allVersions: ['1.0.0'],
+    // Defaults to a single-entry array matching `version` (not a fixed
+    // '1.0.0') so overriding just `version` doesn't silently produce a
+    // package whose only "resolved copy" doesn't match its own installed
+    // version — override `allVersions` explicitly for multi-version tests.
+    allVersions: version ? [version] : [],
     ...overrides,
   };
 }
@@ -71,6 +76,7 @@ export function createMockReleaseAge(
     upgrades: [],
     worstLevel: null,
     severity: 'error',
+    scope: 'root',
     ...overrides,
   };
 }

--- a/tests/lock-parser/fixtures/find-and-parse-yarn/yarn.lock
+++ b/tests/lock-parser/fixtures/find-and-parse-yarn/yarn.lock
@@ -1,0 +1,13 @@
+# yarn lockfile v1
+
+lodash@^3.0.0:
+  version "3.10.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+
+lodash@^4.0.0:
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+
+chalk@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"

--- a/tests/lock-parser/fixtures/yarn-malformed-pkgjson/package.json
+++ b/tests/lock-parser/fixtures/yarn-malformed-pkgjson/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-project",
+  "dependencies": {
+    "chalk": "^5.0.0",
+    "lodash": {
+      "version": "^4.0.0"
+    }
+  }
+}

--- a/tests/lock-parser/fixtures/yarn-with-pkgjson/package.json
+++ b/tests/lock-parser/fixtures/yarn-with-pkgjson/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-project",
+  "dependencies": {
+    "lodash": "^4.0.0"
+  }
+}

--- a/tests/lock-parser/lock-parser.test.ts
+++ b/tests/lock-parser/lock-parser.test.ts
@@ -7,6 +7,11 @@ import { PnpmLockfileAdapter } from '../../src/lock-parser/patterns/pnpm';
 import { NpmLockfileAdapter } from '../../src/lock-parser/patterns/npm';
 import { YarnLockfileAdapter } from '../../src/lock-parser/patterns/yarn';
 import { readAndParseLockfile } from '../../src/lock-parser/lock-file-adapter';
+import {
+  findAndParseLockfile,
+  getPackageVersion,
+  getPackageVersions,
+} from '../../src/lock-parser';
 
 // @yarnpkg/lockfile is a CJS bundle that sets `__esModule: true` and exports a
 // `default` that is NOT the module namespace (it's the Lockfile class). In
@@ -25,24 +30,33 @@ const FIXTURES = join(__dirname, 'fixtures');
 describe('PnpmLockfileAdapter', () => {
   const adapter = new PnpmLockfileAdapter();
 
-  it('parses pnpm v9 lockfile and returns dependency and devDependency versions', () => {
-    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock.yaml'));
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['vitest']).toBe('1.6.0');
+  it('parses pnpm v9 lockfile and returns dependency and devDependency root versions', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'pnpm-lock.yaml'),
+      FIXTURES,
+    );
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+    expect(resolutions['vitest'].rootVersion).toBe('1.6.0');
   });
 
   it('strips the pnpm peer-dependency suffix from a dependency version (#25)', () => {
-    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock.yaml'));
-    expect(versions['react-redux']).toBe('8.0.5');
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'pnpm-lock.yaml'),
+      FIXTURES,
+    );
+    expect(resolutions['react-redux'].rootVersion).toBe('8.0.5');
     // Must be usable by `semver` downstream (the enricher passes this
     // straight into semver.lte/semver.diff) — never the raw peer-suffixed
     // string that crashed release-age enrichment in #25.
-    expect(semver.valid(versions['react-redux'])).toBeTruthy();
+    expect(semver.valid(resolutions['react-redux'].rootVersion!)).toBeTruthy();
   });
 
   it('returns empty object when file does not exist', () => {
-    const versions = adapter.parse(join(FIXTURES, 'nonexistent.yaml'));
-    expect(versions).toEqual({});
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'nonexistent.yaml'),
+      FIXTURES,
+    );
+    expect(resolutions).toEqual({});
   });
 
   it('detect returns the lockfile path when pnpm-lock.yaml is present', () => {
@@ -55,32 +69,26 @@ describe('PnpmLockfileAdapter', () => {
     expect(result).toBeNull();
   });
 
-  it('parseMultiVersion collects all distinct versions per package', () => {
-    const multiVersions = adapter.parseMultiVersion(
+  it('collects all distinct versions per package into allVersions', () => {
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'pnpm-lock.yaml'),
+      FIXTURES,
     );
-    expect(multiVersions['lodash']).toEqual(['3.10.1', '4.17.21']);
-    expect(multiVersions['chalk']).toEqual(['5.3.0']);
-    expect(multiVersions['vitest']).toEqual(['1.6.0']);
-    expect(multiVersions['@scope/pkg']).toEqual(['1.0.0']);
+    expect(resolutions['lodash'].allVersions).toEqual(['3.10.1', '4.17.21']);
+    expect(resolutions['chalk'].allVersions).toEqual(['5.3.0']);
+    expect(resolutions['vitest'].allVersions).toEqual(['1.6.0']);
+    expect(resolutions['@scope/pkg'].allVersions).toEqual(['1.0.0']);
   });
 
-  it('parseMultiVersion returns empty object when file does not exist', () => {
-    const multiVersions = adapter.parseMultiVersion(
-      join(FIXTURES, 'nonexistent.yaml'),
-    );
-    expect(multiVersions).toEqual({});
-  });
-
-  it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
+  it('warns and returns empty object on a corrupt lockfile', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const corrupt = join(FIXTURES, 'corrupt-pnpm-lock.yaml');
     writeFileSync(corrupt, ': not valid yaml: [', 'utf8');
     try {
-      const multiVersions = adapter.parseMultiVersion(corrupt);
-      expect(multiVersions).toEqual({});
+      const resolutions = adapter.resolve(corrupt, FIXTURES);
+      expect(resolutions).toEqual({});
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('pnpm-lock.yaml (multi-version)'),
+        expect.stringContaining('pnpm-lock.yaml'),
       );
     } finally {
       warnSpy.mockRestore();
@@ -88,78 +96,98 @@ describe('PnpmLockfileAdapter', () => {
     }
   });
 
-  it('falls back to the v6-8 "packages" field when there is no "importers" field', () => {
-    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock-v6.yaml'));
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['lodash']).toBe('4.17.21');
-    expect(versions['badkey']).toBeUndefined();
+  it('falls back to the v6-8 "packages" field for root resolution when there is no "importers" field', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'pnpm-lock-v6.yaml'),
+      FIXTURES,
+    );
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+    expect(resolutions['lodash'].rootVersion).toBe('4.17.21');
+    expect(resolutions['badkey']).toBeUndefined();
   });
 
   it('falls back to v5 "dependencies" (string, link:, and object forms) when there is no "importers" or "packages" field', () => {
-    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock-v5.yaml'));
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['vitest']).toBe('1.6.0');
-    expect(versions['local-pkg']).toBeUndefined();
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'pnpm-lock-v5.yaml'),
+      FIXTURES,
+    );
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+    expect(resolutions['vitest'].rootVersion).toBe('1.6.0');
+    expect(resolutions['local-pkg']).toBeUndefined();
   });
 
-  it('parsePackageKey resolves the legacy pnpm v5/v6 slash-separated key format', () => {
-    const multiVersions = adapter.parseMultiVersion(
+  it('parsePackageKey resolves the legacy pnpm v5/v6 slash-separated key format into allVersions', () => {
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'pnpm-lock-legacy.yaml'),
+      FIXTURES,
     );
-    expect(multiVersions['@babel/core']).toEqual(['7.22.5']);
+    expect(resolutions['@babel/core'].allVersions).toEqual(['7.22.5']);
   });
 
-  it('returns no versions when "importers" is present but has no root "." entry', () => {
-    const versions = adapter.parse(
+  it('returns no resolutions when "importers" is present but has no root "." entry, and no "packages"/"dependencies" fallback exists', () => {
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'pnpm-lock-no-root-importer.yaml'),
+      FIXTURES,
     );
-    expect(versions).toEqual({});
+    expect(resolutions).toEqual({});
   });
 
   it('parses an importer that has only "dependencies" (no "devDependencies" key)', () => {
-    const versions = adapter.parse(join(FIXTURES, 'pnpm-lock-deps-only.yaml'));
-    expect(versions['chalk']).toBe('5.3.0');
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'pnpm-lock-deps-only.yaml'),
+      FIXTURES,
+    );
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
   });
 
   it('parses an importer that has only "devDependencies" (no "dependencies" key)', () => {
-    const versions = adapter.parse(
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'pnpm-lock-devdeps-only.yaml'),
+      FIXTURES,
     );
-    expect(versions['vitest']).toBe('1.6.0');
+    expect(resolutions['vitest'].rootVersion).toBe('1.6.0');
   });
 
   it('skips importer dependency/devDependency entries that are not a well-formed {version} object', () => {
-    const versions = adapter.parse(
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'pnpm-lock-malformed-importer.yaml'),
+      FIXTURES,
     );
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['bare-string-dep']).toBeUndefined();
-    expect(versions['no-version-dep']).toBeUndefined();
-    expect(versions['bare-string-dev-dep']).toBeUndefined();
-    expect(versions['no-version-dev-dep']).toBeUndefined();
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+    expect(resolutions['bare-string-dep']).toBeUndefined();
+    expect(resolutions['no-version-dep']).toBeUndefined();
+    expect(resolutions['bare-string-dev-dep']).toBeUndefined();
+    expect(resolutions['no-version-dev-dep']).toBeUndefined();
   });
 
   it('parsePackageKey skips a key that matches neither the modern nor legacy format', () => {
-    const multiVersions = adapter.parseMultiVersion(
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'pnpm-lock-legacy.yaml'),
+      FIXTURES,
     );
-    expect(Object.keys(multiVersions)).not.toContain('invalidkey');
-    expect(Object.keys(multiVersions)).toEqual(['@babel/core']);
+    expect(Object.keys(resolutions)).not.toContain('invalidkey');
+    expect(Object.keys(resolutions)).toEqual(['@babel/core']);
   });
 });
 
 describe('NpmLockfileAdapter', () => {
   const adapter = new NpmLockfileAdapter();
 
-  it('parses npm v3 lockfile and returns package versions', () => {
-    const versions = adapter.parse(join(FIXTURES, 'package-lock.json'));
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['vitest']).toBe('1.6.0');
+  it('parses npm v3 lockfile and returns root package versions', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'package-lock.json'),
+      FIXTURES,
+    );
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+    expect(resolutions['vitest'].rootVersion).toBe('1.6.0');
   });
 
   it('returns empty object when file does not exist', () => {
-    const versions = adapter.parse(join(FIXTURES, 'nonexistent.json'));
-    expect(versions).toEqual({});
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'nonexistent.json'),
+      FIXTURES,
+    );
+    expect(resolutions).toEqual({});
   });
 
   it('detect returns the lockfile path when package-lock.json is present', () => {
@@ -172,53 +200,71 @@ describe('NpmLockfileAdapter', () => {
     expect(result).toBeNull();
   });
 
-  it('falls back to the v6 "dependencies" field (recursing into nested dependencies) when there is no "packages" field', () => {
-    const versions = adapter.parse(join(FIXTURES, 'package-lock-v6.json'));
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['no-version-pkg']).toBeUndefined();
-    expect(versions['parent-pkg']).toBe('1.0.0');
-    expect(versions['parent-pkg/nested-pkg']).toBe('2.0.0');
+  it('falls back to the v6 "dependencies" field (recursing into nested dependencies) when there is no "packages" field, keyed by real package name', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'package-lock-v6.json'),
+      FIXTURES,
+    );
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+    expect(resolutions['no-version-pkg']).toBeUndefined();
+    expect(resolutions['parent-pkg'].rootVersion).toBe('1.0.0');
+    // Nested copies are keyed by their real package name (not a
+    // depth-prefixed compound key like the old "parent-pkg/nested-pkg") so
+    // duplicate copies of the same package always share one allVersions
+    // entry — a latent bug fixed while unifying resolution (#57).
+    expect(resolutions['nested-pkg'].rootVersion).toBeNull();
+    expect(resolutions['nested-pkg'].allVersions).toEqual(['2.0.0']);
+    expect(resolutions['parent-pkg/nested-pkg']).toBeUndefined();
   });
 
-  it('filters out nested node_modules entries and skips packages without a version', () => {
-    const versions = adapter.parse(join(FIXTURES, 'package-lock-nested.json'));
-    expect(versions['foo']).toBe('1.0.0');
-    expect(versions['bar']).toBeUndefined();
-    expect(versions['no-version']).toBeUndefined();
+  it('filters out nested node_modules entries from rootVersion and skips packages without a version', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'package-lock-nested.json'),
+      FIXTURES,
+    );
+    expect(resolutions['foo'].rootVersion).toBe('1.0.0');
+    expect(resolutions['bar'].rootVersion).toBeNull();
+    expect(resolutions['no-version']).toBeUndefined();
   });
 
   it('canonicalPackageName returns the path unchanged when it contains no "node_modules/" segment (e.g. a workspace path)', () => {
-    const versions = adapter.parse(join(FIXTURES, 'package-lock-nested.json'));
-    expect(versions['packages/workspace-a']).toBe('1.0.0');
-  });
-
-  it('parseMultiVersion skips packages entries without a version', () => {
-    const multiVersions = adapter.parseMultiVersion(
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'package-lock-nested.json'),
+      FIXTURES,
     );
-    expect(multiVersions['foo']).toEqual(['1.0.0']);
-    expect(multiVersions['no-version']).toBeUndefined();
+    expect(resolutions['packages/workspace-a'].rootVersion).toBe('1.0.0');
   });
 
-  it('parseMultiVersion collects multiple versions when two different paths canonicalize to the same package name', () => {
+  it('allVersions skips packages entries without a version', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'package-lock-nested.json'),
+      FIXTURES,
+    );
+    expect(resolutions['foo'].allVersions).toEqual(['1.0.0']);
+    expect(resolutions['no-version']).toBeUndefined();
+  });
+
+  it('collects multiple versions when two different paths canonicalize to the same package name', () => {
     // "node_modules/dupe" (1.0.0) and "node_modules/foo/node_modules/dupe"
-    // (2.0.0) both canonicalize to "dupe" — parseMultiVersion (unlike parse)
+    // (2.0.0) both canonicalize to "dupe" — allVersions (unlike rootVersion)
     // doesn't filter out nested node_modules paths, so both must be tracked.
-    const multiVersions = adapter.parseMultiVersion(
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'package-lock-nested.json'),
+      FIXTURES,
     );
-    expect(multiVersions['dupe']).toEqual(['1.0.0', '2.0.0']);
+    expect(resolutions['dupe'].allVersions).toEqual(['1.0.0', '2.0.0']);
+    expect(resolutions['dupe'].rootVersion).toBe('1.0.0');
   });
 
-  it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
+  it('warns and returns empty object on a corrupt lockfile', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const corrupt = join(FIXTURES, 'corrupt-package-lock.json');
     writeFileSync(corrupt, '{ not valid json', 'utf8');
     try {
-      const multiVersions = adapter.parseMultiVersion(corrupt);
-      expect(multiVersions).toEqual({});
+      const resolutions = adapter.resolve(corrupt, FIXTURES);
+      expect(resolutions).toEqual({});
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('package-lock.json (multi-version)'),
+        expect.stringContaining('package-lock.json'),
       );
     } finally {
       warnSpy.mockRestore();
@@ -230,15 +276,15 @@ describe('NpmLockfileAdapter', () => {
 describe('YarnLockfileAdapter', () => {
   const adapter = new YarnLockfileAdapter();
 
-  it('parses yarn v1 lockfile and returns package versions', () => {
-    const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
-    expect(versions['chalk']).toBe('5.3.0');
-    expect(versions['vitest']).toBe('1.6.0');
+  it('parses yarn v1 lockfile and collects all resolved versions', () => {
+    const resolutions = adapter.resolve(join(FIXTURES, 'yarn.lock'), FIXTURES);
+    expect(resolutions['chalk'].allVersions).toEqual(['5.3.0']);
+    expect(resolutions['vitest'].allVersions).toEqual(['1.6.0']);
   });
 
   it('extracts a scoped package name from its key', () => {
-    const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
-    expect(versions['@scope/pkg']).toBe('1.0.0');
+    const resolutions = adapter.resolve(join(FIXTURES, 'yarn.lock'), FIXTURES);
+    expect(resolutions['@scope/pkg'].allVersions).toEqual(['1.0.0']);
   });
 
   it('detect returns the lockfile path when yarn.lock is present', () => {
@@ -263,15 +309,18 @@ describe('YarnLockfileAdapter', () => {
       },
     });
     try {
-      const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
-      expect(versions['@scope-no-slash']).toBe('1.0.0');
-      expect(versions['no-at-sign-key']).toBe('2.0.0');
+      const resolutions = adapter.resolve(
+        join(FIXTURES, 'yarn.lock'),
+        FIXTURES,
+      );
+      expect(resolutions['@scope-no-slash'].allVersions).toEqual(['1.0.0']);
+      expect(resolutions['no-at-sign-key'].allVersions).toEqual(['2.0.0']);
     } finally {
       parseSpy.mockRestore();
     }
   });
 
-  it('parseMultiVersion skips an entry with no version', () => {
+  it('skips an entry with no version', () => {
     const parseSpy = vi.spyOn(lockfileLib, 'parse').mockReturnValue({
       type: 'success',
       object: {
@@ -280,31 +329,75 @@ describe('YarnLockfileAdapter', () => {
       },
     });
     try {
-      const multiVersions = adapter.parseMultiVersion(
+      const resolutions = adapter.resolve(
         join(FIXTURES, 'yarn.lock'),
+        FIXTURES,
       );
-      expect(multiVersions['no-version-pkg']).toBeUndefined();
-      expect(multiVersions['chalk']).toEqual(['5.3.0']);
+      expect(resolutions['no-version-pkg']).toBeUndefined();
+      expect(resolutions['chalk'].allVersions).toEqual(['5.3.0']);
     } finally {
       parseSpy.mockRestore();
     }
   });
 
-  it('parse keeps the first-seen version for a duplicate package name (dedup guard)', () => {
-    // yarn.lock fixture has both `lodash@^3.0.0` (3.10.1) and `lodash@^4.0.0`
-    // (4.17.21) resolving to the same package name "lodash".
-    const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
-    expect(versions['lodash']).toBe('3.10.1');
+  // Root-resolution (#57): yarn.lock retains no root/nested distinction on
+  // its own, so root version is found by matching the root package.json's
+  // declared range string exactly against the lockfile's parsed keys.
+  it('resolves the root version by matching the root package.json range against the lockfile key', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'yarn.lock'),
+      join(FIXTURES, 'yarn-with-pkgjson'),
+    );
+    // yarn-with-pkgjson/package.json declares lodash@^4.0.0, matching the
+    // `lodash@^4.0.0` lockfile key (4.17.21) — NOT the older `lodash@^3.0.0`
+    // entry (3.10.1), even though that one appears first in the lockfile.
+    expect(resolutions['lodash'].rootVersion).toBe('4.17.21');
+    expect(resolutions['lodash'].allVersions).toEqual(['3.10.1', '4.17.21']);
   });
 
-  it('parse warns and returns empty object when the parser reports a non-success result', () => {
+  it('leaves rootVersion null for a package that is not a direct dependency in package.json (purely transitive)', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'yarn.lock'),
+      join(FIXTURES, 'yarn-with-pkgjson'),
+    );
+    // yarn-with-pkgjson/package.json only declares "lodash" — chalk isn't a
+    // direct dependency there, so root can't be determined from it.
+    expect(resolutions['chalk'].rootVersion).toBeNull();
+    expect(resolutions['chalk'].allVersions).toEqual(['5.3.0']);
+  });
+
+  it('leaves rootVersion null for every package when the root package.json is missing or unreadable', () => {
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'yarn.lock'),
+      join(FIXTURES, 'does-not-exist'),
+    );
+    expect(resolutions['lodash'].rootVersion).toBeNull();
+    expect(resolutions['lodash'].allVersions).toEqual(['3.10.1', '4.17.21']);
+  });
+
+  it('skips a package.json dependency value that is not a string range (defensive guard) but still resolves string-valued siblings', () => {
+    // yarn-malformed-pkgjson/package.json declares lodash as a non-string
+    // object value (atypical/malformed) alongside a normal string range for
+    // chalk — the malformed entry must be ignored, not crash resolution.
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'yarn.lock'),
+      join(FIXTURES, 'yarn-malformed-pkgjson'),
+    );
+    expect(resolutions['lodash'].rootVersion).toBeNull();
+    expect(resolutions['chalk'].rootVersion).toBe('5.3.0');
+  });
+
+  it('warns and returns empty object when the parser reports a non-success result', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const parseSpy = vi
       .spyOn(lockfileLib, 'parse')
       .mockReturnValue({ type: 'merge', object: {} });
     try {
-      const versions = adapter.parse(join(FIXTURES, 'yarn.lock'));
-      expect(versions).toEqual({});
+      const resolutions = adapter.resolve(
+        join(FIXTURES, 'yarn.lock'),
+        FIXTURES,
+      );
+      expect(resolutions).toEqual({});
       expect(warnSpy).toHaveBeenCalledWith(
         'Warning: Failed to parse yarn.lock',
       );
@@ -315,49 +408,14 @@ describe('YarnLockfileAdapter', () => {
   });
 
   it('returns empty object when file does not exist', () => {
-    const versions = adapter.parse(join(FIXTURES, 'nonexistent.lock'));
-    expect(versions).toEqual({});
-  });
-
-  it('parseMultiVersion warns and returns empty object when the parser reports a non-success result', () => {
-    // parseMultiVersion's non-success branch throws internally (unlike
-    // parse(), which returns {} directly) — readAndParseLockfile catches
-    // that throw and converts it into the same warn+fallback behavior.
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const parseSpy = vi
-      .spyOn(lockfileLib, 'parse')
-      .mockReturnValue({ type: 'merge', object: {} });
-    try {
-      const multiVersions = adapter.parseMultiVersion(
-        join(FIXTURES, 'yarn.lock'),
-      );
-      expect(multiVersions).toEqual({});
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('yarn.lock (multi-version)'),
-      );
-    } finally {
-      parseSpy.mockRestore();
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('parseMultiVersion collects all distinct versions per package', () => {
-    const multiVersions = adapter.parseMultiVersion(
-      join(FIXTURES, 'yarn.lock'),
-    );
-    expect(multiVersions['lodash']).toEqual(['3.10.1', '4.17.21']);
-    expect(multiVersions['chalk']).toEqual(['5.3.0']);
-    expect(multiVersions['vitest']).toEqual(['1.6.0']);
-  });
-
-  it('parseMultiVersion returns empty object when file does not exist', () => {
-    const multiVersions = adapter.parseMultiVersion(
+    const resolutions = adapter.resolve(
       join(FIXTURES, 'nonexistent.lock'),
+      FIXTURES,
     );
-    expect(multiVersions).toEqual({});
+    expect(resolutions).toEqual({});
   });
 
-  it('parseMultiVersion warns and returns empty object on a corrupt lockfile', () => {
+  it('warns and returns empty object on a corrupt lockfile', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const corrupt = join(FIXTURES, 'corrupt-yarn.lock');
     // @yarnpkg/lockfile's parser is lenient about plain text (it doesn't
@@ -366,15 +424,71 @@ describe('YarnLockfileAdapter', () => {
     // this parser can take several seconds to reject.
     writeFileSync(corrupt, '{{{ not yaml-ish at all }}}', 'utf8');
     try {
-      const multiVersions = adapter.parseMultiVersion(corrupt);
-      expect(multiVersions).toEqual({});
+      const resolutions = adapter.resolve(corrupt, FIXTURES);
+      expect(resolutions).toEqual({});
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('yarn.lock (multi-version)'),
+        expect.stringContaining('yarn.lock'),
       );
     } finally {
       warnSpy.mockRestore();
       rmSync(corrupt);
     }
+  });
+});
+
+describe('findAndParseLockfile', () => {
+  it('derives versions/multiVersions from resolutions, falling back to the highest resolved version when rootVersion is undeterminable', () => {
+    // find-and-parse-yarn/ has a yarn.lock but no package.json, so no
+    // package can have a determinable root — versions must fall back to
+    // maxSemver(allVersions) for every package (#57).
+    const result = findAndParseLockfile(join(FIXTURES, 'find-and-parse-yarn'));
+    expect(result.lockfileType).toBe('yarn');
+    expect(result.resolutions['lodash']).toEqual({
+      rootVersion: null,
+      allVersions: ['3.10.1', '4.17.21'],
+    });
+    expect(result.versions['lodash']).toBe('4.17.21');
+    expect(result.versions['chalk']).toBe('5.3.0');
+    expect(result.multiVersions['lodash']).toEqual(['3.10.1', '4.17.21']);
+  });
+
+  it('uses rootVersion directly (not the fallback) when it is determinable', () => {
+    // yarn-with-pkgjson/ has no lockfile of its own, so point detect()/parse
+    // at the shared yarn.lock fixture directory instead — reuse the FIXTURES
+    // dir directly, which has an npm lockfile too, so assert via the yarn
+    // adapter's own resolve() + the shared derivation logic instead of
+    // findAndParseLockfile (which would pick npm first for FIXTURES).
+    const adapter = new YarnLockfileAdapter();
+    const resolutions = adapter.resolve(
+      join(FIXTURES, 'yarn.lock'),
+      join(FIXTURES, 'yarn-with-pkgjson'),
+    );
+    expect(resolutions['lodash'].rootVersion).toBe('4.17.21');
+  });
+
+  it('throws when no supported lockfile is found', () => {
+    expect(() =>
+      findAndParseLockfile(join(FIXTURES, 'does-not-exist')),
+    ).toThrow('No supported lockfile found');
+  });
+});
+
+describe('getPackageVersion / getPackageVersions', () => {
+  it('getPackageVersion returns the resolved version for a known package', () => {
+    expect(getPackageVersion(FIXTURES, 'chalk')).toBe('5.3.0');
+  });
+
+  it('getPackageVersion returns null for an unknown package', () => {
+    expect(getPackageVersion(FIXTURES, 'does-not-exist-pkg')).toBeNull();
+  });
+
+  it('getPackageVersions returns only the entries that resolved, skipping unknown names', () => {
+    const versions = getPackageVersions(FIXTURES, [
+      'chalk',
+      'vitest',
+      'does-not-exist-pkg',
+    ]);
+    expect(versions).toEqual({ chalk: '5.3.0', vitest: '1.6.0' });
   });
 });
 

--- a/tests/npm-registry/enricher.test.ts
+++ b/tests/npm-registry/enricher.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import semver from 'semver';
-import { enrichWithReleaseAge } from '../../src/npm-registry/enricher';
+import {
+  enrichWithReleaseAge,
+  resolveReleaseAgeScope,
+} from '../../src/npm-registry/enricher';
 import { createMockPackage } from '../helpers/mock-reports';
 
 // Mock the cache module — no network or disk I/O in tests
@@ -18,6 +21,8 @@ const BASE_CONFIG = {
   registry: 'https://registry.npmjs.org',
   thresholds: DEFAULT_THRESHOLDS,
   enforceOn: [],
+  scope: 'root' as const,
+  scopeExceptions: [],
 };
 
 function daysAgo(n: number): string {
@@ -599,5 +604,252 @@ describe('enrichWithReleaseAge — overdue basis uses oldest breach, not newest 
     const major = entry.upgrades.find((u) => u.semverBump === 'major');
     expect(major?.releasedDaysAgo).toBe(5);
     expect(major?.breachReleasedDaysAgo).toBe(400);
+  });
+});
+
+describe('resolveReleaseAgeScope (#57)', () => {
+  it('returns the configured scope when there are no exceptions', () => {
+    expect(
+      resolveReleaseAgeScope('react', { ...BASE_CONFIG, scope: 'root' }),
+    ).toBe('root');
+    expect(
+      resolveReleaseAgeScope('react', { ...BASE_CONFIG, scope: 'tree' }),
+    ).toBe('tree');
+  });
+
+  it('flips root -> tree for a package matching scopeExceptions', () => {
+    const scope = resolveReleaseAgeScope('@vendor/pinned-lib', {
+      ...BASE_CONFIG,
+      scope: 'root',
+      scopeExceptions: ['@vendor/pinned-*'],
+    });
+    expect(scope).toBe('tree');
+  });
+
+  it('flips tree -> root for a package matching scopeExceptions', () => {
+    const scope = resolveReleaseAgeScope('@vendor/pinned-lib', {
+      ...BASE_CONFIG,
+      scope: 'tree',
+      scopeExceptions: ['@vendor/pinned-*'],
+    });
+    expect(scope).toBe('root');
+  });
+
+  it('does not flip a package that does not match scopeExceptions', () => {
+    const scope = resolveReleaseAgeScope('react', {
+      ...BASE_CONFIG,
+      scope: 'tree',
+      scopeExceptions: ['@vendor/pinned-*'],
+    });
+    expect(scope).toBe('tree');
+  });
+});
+
+describe('enrichWithReleaseAge — scope (#57)', () => {
+  // Shared fixture: relative to '1.0.0', both '2.0.0' (400d old) and '3.0.0'
+  // (200d old) are major bumps past the 60-day threshold — so '1.0.0' alone
+  // is major_overdue. Relative to '3.0.0', there's nothing newer at all, so
+  // it's fully compliant. Relative to '2.0.0', only '3.0.0' is newer (also a
+  // major bump, 200d old) — also major_overdue, but less overdue than '1.0.0'.
+  const MULTI_VERSION_TIME = {
+    '1.0.0': daysAgo(900),
+    '2.0.0': daysAgo(400),
+    '3.0.0': daysAgo(200),
+  };
+
+  it('scope: root — a compliant root version does not fail even when a nested copy is overdue, but the nested breach is surfaced as advisory', async () => {
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '3.0.0',
+      allVersions: ['1.0.0', '3.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
+    const entry = enriched[0].releaseAge!;
+    expect(entry.scope).toBe('root');
+    expect(entry.worstLevel).toBeNull();
+    expect(entry.evaluatedVersions).toEqual(['1.0.0', '3.0.0']);
+    expect(entry.advisoryBreaches).toEqual([
+      { version: '1.0.0', level: 'major_overdue' },
+    ]);
+  });
+
+  it('scope: root — an overdue root version fails as usual, and a compliant nested copy is not reported as advisory', async () => {
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '1.0.0',
+      allVersions: ['1.0.0', '3.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
+    const entry = enriched[0].releaseAge!;
+    expect(entry.scope).toBe('root');
+    expect(entry.worstLevel).toBe('major_overdue');
+    expect(entry.advisoryBreaches).toBeUndefined();
+  });
+
+  it('scope: tree — every resolved copy is enforced; the worst breach drives the verdict and nothing is advisory', async () => {
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '3.0.0',
+      allVersions: ['1.0.0', '2.0.0', '3.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], {
+      ...BASE_CONFIG,
+      scope: 'tree',
+    });
+    const entry = enriched[0].releaseAge!;
+    expect(entry.scope).toBe('tree');
+    // '1.0.0' is the most-overdue enforced copy (400d breach) — it becomes
+    // the baseline/installedVersion, not the root '3.0.0' that was passed in.
+    expect(entry.worstLevel).toBe('major_overdue');
+    expect(entry.installedVersion).toBe('1.0.0');
+    expect(entry.advisoryBreaches).toBeUndefined();
+  });
+
+  it('scope: tree — the baseline is reassigned mid-loop to a later candidate with a strictly worse level', async () => {
+    // '3.0.0' (listed first) is fully compliant on its own (nothing newer);
+    // '1.0.0' (listed second) is major_overdue relative to itself — the
+    // baseline must be reassigned away from the first candidate once a
+    // strictly worse one is found later in the array.
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '3.0.0',
+      allVersions: ['3.0.0', '1.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], {
+      ...BASE_CONFIG,
+      scope: 'tree',
+    });
+    const entry = enriched[0].releaseAge!;
+    expect(entry.worstLevel).toBe('major_overdue');
+    expect(entry.installedVersion).toBe('1.0.0');
+  });
+
+  it('scope: tree — a same-rank later candidate with a larger breach age replaces the baseline (tie-break)', async () => {
+    // '2.0.0' (listed first) and '1.0.0' (listed second) are both
+    // major_overdue relative to themselves, but '1.0.0' has been in
+    // violation longer (400d breach vs. 200d) — the tie-break must still
+    // pick the more-overdue one even though it appears later in the array.
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '2.0.0',
+      allVersions: ['2.0.0', '1.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], {
+      ...BASE_CONFIG,
+      scope: 'tree',
+    });
+    const entry = enriched[0].releaseAge!;
+    expect(entry.worstLevel).toBe('major_overdue');
+    expect(entry.installedVersion).toBe('1.0.0');
+    expect(entry.upgrades[0]?.breachReleasedDaysAgo).toBe(400);
+  });
+
+  it('scope: tree — a same-rank later candidate with a SMALLER breach age does not replace the baseline', async () => {
+    // Inverse ordering of the tie-break test above: '1.0.0' (400d breach,
+    // worse) listed first, '2.0.0' (200d breach) listed second — the
+    // baseline must stay on '1.0.0' since the later candidate isn't worse.
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '1.0.0',
+      allVersions: ['1.0.0', '2.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], {
+      ...BASE_CONFIG,
+      scope: 'tree',
+    });
+    const entry = enriched[0].releaseAge!;
+    expect(entry.installedVersion).toBe('1.0.0');
+    expect(entry.upgrades[0]?.breachReleasedDaysAgo).toBe(400);
+  });
+
+  it('scope: root — a mandatory root breach alongside an independently-overdue nested copy reports both', async () => {
+    // '1.0.0' as root is itself major_overdue (mandatory failure), AND
+    // '2.0.0' is ALSO independently overdue relative to itself — both must
+    // surface: the root breach drives worstLevel, the nested breach is
+    // still reported as advisory even though the package already fails.
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '1.0.0',
+      allVersions: ['1.0.0', '2.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      time: MULTI_VERSION_TIME,
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
+    const entry = enriched[0].releaseAge!;
+    expect(entry.scope).toBe('root');
+    expect(entry.worstLevel).toBe('major_overdue');
+    expect(entry.advisoryBreaches).toEqual([
+      { version: '2.0.0', level: 'major_overdue' },
+    ]);
+  });
+
+  it('scope: tree — all-compliant copies produce a clean verdict with no advisory breaches', async () => {
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '2.0.0',
+      allVersions: ['1.0.0', '2.0.0'],
+      hasVersionConflict: true,
+    });
+    mockFetch.mockResolvedValueOnce({
+      name: 'multi-version-lib',
+      // '2.0.0' is only 10d old — well within the 60-day major threshold,
+      // so it's compliant both as its own baseline and as the only newer
+      // candidate relative to '1.0.0'.
+      time: { '1.0.0': daysAgo(500), '2.0.0': daysAgo(10) },
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], {
+      ...BASE_CONFIG,
+      scope: 'tree',
+    });
+    const entry = enriched[0].releaseAge!;
+    expect(entry.worstLevel).toBeNull();
+    expect(entry.advisoryBreaches).toBeUndefined();
+  });
+
+  it('regression: a single-version package under the default root scope gets no evaluatedVersions/advisoryBreaches at all', async () => {
+    const pkg = createMockPackage('react', { version: '18.0.0' });
+    mockFetch.mockResolvedValueOnce({
+      name: 'react',
+      time: { '18.0.0': daysAgo(100), '18.0.1': daysAgo(10) },
+      versions: {},
+    });
+    const { enriched } = await enrichWithReleaseAge([pkg], BASE_CONFIG);
+    const entry = enriched[0].releaseAge!;
+    expect(entry.scope).toBe('root');
+    expect(entry.evaluatedVersions).toBeUndefined();
+    expect(entry.advisoryBreaches).toBeUndefined();
   });
 });

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -6,8 +6,13 @@ import { stripAnsi } from '../../src/utils/severity-format';
 import {
   printPackages,
   describeUpgradeTarget,
+  describeAdvisoryBreaches,
+  describeBundleImpact,
+  describePackageNotes,
   formatPackageName,
   formatUpgradeCell,
+  resolveCompliantTarget,
+  resolveInstalledVersion,
 } from '../../src/utils/print-packages';
 import { enrichWithReleaseAge } from '../../src/npm-registry/enricher';
 import { printComponents } from '../../src/utils/print-components';
@@ -346,6 +351,48 @@ describe('printPackages', () => {
     expect(output).toContain('3.10.1, 4.17.21');
     expect(output).toContain('2 versions');
   });
+
+  // (#57) When release age is enabled, the table splits into an unambiguous
+  // "Installed" column (the single version the verdict was measured
+  // against) and "Target" column, with the bundle-impact/advisory-breach
+  // context printed as a separate Notes line below the table — not crammed
+  // into a cell where it's unclear which installed copy a claim refers to.
+  it('shows Installed/Target columns and a Notes line for a package with an advisory breach', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('multi-version-lib', {
+          hasVersionConflict: true,
+          allVersions: ['1.0.0', '3.0.0'],
+          version: '3.0.0',
+          releaseAge: createMockReleaseAge({
+            scope: 'root',
+            installedVersion: '3.0.0',
+            worstLevel: null,
+            advisoryBreaches: [{ version: '1.0.0', level: 'major_overdue' }],
+          }),
+        }),
+      ],
+    });
+    printPackages(aggregated, 'table');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    expect(output).toContain('Installed');
+    expect(output).toContain('Target');
+    // The table row shows only the single installed baseline, not the list.
+    const tableLines = output.split('\n').filter((l) => l.includes('│'));
+    expect(tableLines.some((l) => l.includes('3.0.0'))).toBe(true);
+    // The full version list and the advisory note live in Notes, not the row.
+    expect(output).toContain('Notes:');
+    expect(output).toContain('multi-version-lib —');
+    expect(output).toContain(
+      '2 versions installed (bundle impact): 1.0.0, 3.0.0',
+    );
+    expect(output).toContain(
+      '1 nested copy overdue, not enforced but recommended to resolve',
+    );
+    expect(output).toContain('🟡');
+  });
 });
 
 describe('formatPackageName', () => {
@@ -504,6 +551,172 @@ describe('describeUpgradeTarget', () => {
   });
 });
 
+describe('resolveCompliantTarget (#57)', () => {
+  it('returns undefined when releaseAge is undefined', () => {
+    expect(resolveCompliantTarget(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when minCompliantInWindow is false', () => {
+    const releaseAge = createMockReleaseAge({
+      minCompliantInWindow: false,
+      minCompliantVersion: '2.0.0',
+    });
+    expect(resolveCompliantTarget(releaseAge)).toBeUndefined();
+  });
+
+  it('returns undefined when minCompliantVersion is missing even if minCompliantInWindow is true', () => {
+    const releaseAge = createMockReleaseAge({ minCompliantInWindow: true });
+    expect(resolveCompliantTarget(releaseAge)).toBeUndefined();
+  });
+
+  it('returns the compliant target with its own bump when set', () => {
+    const releaseAge = createMockReleaseAge({
+      minCompliantInWindow: true,
+      minCompliantVersion: '1.0.0',
+      minCompliantBump: 'major',
+    });
+    expect(resolveCompliantTarget(releaseAge)).toEqual({
+      version: '1.0.0',
+      bump: 'major',
+    });
+  });
+
+  it("falls back to the top upgrade's bump when minCompliantBump is not set", () => {
+    const releaseAge = createMockReleaseAge({
+      minCompliantInWindow: true,
+      minCompliantVersion: '1.0.0',
+      upgrades: [
+        {
+          version: '0.5.7',
+          releasedDaysAgo: 200,
+          breachReleasedDaysAgo: 200,
+          semverBump: 'minor',
+          level: 'minor_overdue',
+          thresholdDays: 45,
+        },
+      ],
+    });
+    expect(resolveCompliantTarget(releaseAge)).toEqual({
+      version: '1.0.0',
+      bump: 'minor',
+    });
+  });
+});
+
+describe('describeAdvisoryBreaches (#57)', () => {
+  it('returns undefined when releaseAge is undefined', () => {
+    expect(describeAdvisoryBreaches(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when advisoryBreaches is empty or missing', () => {
+    expect(describeAdvisoryBreaches(createMockReleaseAge())).toBeUndefined();
+    expect(
+      describeAdvisoryBreaches(createMockReleaseAge({ advisoryBreaches: [] })),
+    ).toBeUndefined();
+  });
+
+  it('uses singular "copy" wording, with a warn icon, for exactly one advisory breach', () => {
+    const text = describeAdvisoryBreaches(
+      createMockReleaseAge({
+        advisoryBreaches: [{ version: '1.4.5', level: 'major_overdue' }],
+      }),
+    );
+    expect(text).toContain('🟡');
+    expect(text).toContain('1 nested copy overdue');
+    expect(text).toContain('not enforced but recommended to resolve');
+    // Versions aren't repeated here — describeBundleImpact already lists
+    // every resolved copy right before this in describePackageNotes (#57).
+    expect(text).not.toContain('1.4.5');
+  });
+
+  it('uses plural "copies" wording for multiple advisory breaches, without re-listing versions', () => {
+    const text = describeAdvisoryBreaches(
+      createMockReleaseAge({
+        advisoryBreaches: [
+          { version: '1.4.5', level: 'major_overdue' },
+          { version: '2.1.9', level: 'major_overdue' },
+        ],
+      }),
+    );
+    expect(text).toContain('2 nested copies overdue');
+    expect(text).not.toContain('1.4.5');
+    expect(text).not.toContain('2.1.9');
+  });
+});
+
+describe('resolveInstalledVersion (#57)', () => {
+  it('uses releaseAge.installedVersion when release age ran', () => {
+    const pkg = createMockPackage('multi-version-lib', {
+      version: '3.0.0',
+      releaseAge: createMockReleaseAge({ installedVersion: '1.0.0' }),
+    });
+    // Under tree scope the enforced baseline can be a nested copy, not the
+    // root version — resolveInstalledVersion must reflect THAT, not pkg.version.
+    expect(resolveInstalledVersion(pkg)).toBe('1.0.0');
+  });
+
+  it('falls back to pkg.version when release age did not run', () => {
+    const pkg = createMockPackage('react', { version: '18.0.0' });
+    expect(resolveInstalledVersion(pkg)).toBe('18.0.0');
+  });
+
+  it('falls back to "N/A" when neither is available', () => {
+    const pkg = createMockPackage('react', { version: null });
+    expect(resolveInstalledVersion(pkg)).toBe('N/A');
+  });
+});
+
+describe('describeBundleImpact (#57)', () => {
+  it('returns undefined when there is no version conflict', () => {
+    const pkg = createMockPackage('react', { hasVersionConflict: false });
+    expect(describeBundleImpact(pkg)).toBeUndefined();
+  });
+
+  it('lists every resolved version when there is a conflict', () => {
+    const pkg = createMockPackage('lodash', {
+      hasVersionConflict: true,
+      allVersions: ['3.10.1', '4.17.21'],
+    });
+    const text = describeBundleImpact(pkg);
+    expect(text).toContain('2 versions installed (bundle impact)');
+    expect(text).toContain('3.10.1, 4.17.21');
+  });
+});
+
+describe('describePackageNotes (#57)', () => {
+  it('returns undefined when there is neither a conflict nor an advisory breach', () => {
+    const pkg = createMockPackage('react');
+    expect(describePackageNotes(pkg)).toBeUndefined();
+  });
+
+  it('combines bundle-impact and advisory-breach text when both apply', () => {
+    const pkg = createMockPackage('multi-version-lib', {
+      hasVersionConflict: true,
+      allVersions: ['1.0.0', '3.0.0'],
+      releaseAge: createMockReleaseAge({
+        advisoryBreaches: [{ version: '1.0.0', level: 'major_overdue' }],
+      }),
+    });
+    const text = describePackageNotes(pkg)!;
+    expect(text).toContain(
+      '2 versions installed (bundle impact): 1.0.0, 3.0.0',
+    );
+    expect(text).toContain(
+      '🟡 1 nested copy overdue, not enforced but recommended to resolve',
+    );
+  });
+
+  it('shows only the bundle-impact note when there is no advisory breach', () => {
+    const pkg = createMockPackage('lodash', {
+      hasVersionConflict: true,
+      allVersions: ['3.10.1', '4.17.21'],
+    });
+    expect(describePackageNotes(pkg)).toBe(
+      '2 versions installed (bundle impact): 3.10.1, 4.17.21',
+    );
+  });
+});
+
 describe('formatUpgradeCell — stale 0.x minor line beneath a compliant newer major (user report)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -532,6 +745,8 @@ describe('formatUpgradeCell — stale 0.x minor line beneath a compliant newer m
       registry: 'https://registry.npmjs.org',
       thresholds: { patch: 30, minor: 45, major: 60 },
       enforceOn: [],
+      scope: 'root',
+      scopeExceptions: [],
     });
 
     const cell = formatUpgradeCell(enriched[0].releaseAge);

--- a/tests/utils/write-summary-file.test.ts
+++ b/tests/utils/write-summary-file.test.ts
@@ -11,6 +11,7 @@ import {
   writeSummaryFile,
   DEFAULT_SUMMARY_TITLE,
 } from '../../src/utils/write-summary-file';
+import { formatUpgradeCell } from '../../src/utils/print-packages';
 import {
   createMockPackage,
   createMockReleaseAge,
@@ -280,9 +281,9 @@ describe('writeSummaryFile', () => {
         makeAggregated({ packageDistribution: [overdueError] }),
       );
       expect(content).toContain('### Packages');
-      expect(content).toContain('| | Package | Issue |');
+      expect(content).toContain('| | Package | Installed | Target |');
       expect(content).toContain(
-        '| 🔴 | `my-internal-pkg` | major 4.2.0 (40 days overdue) |',
+        '| 🔴 | `my-internal-pkg` | 1.0.0 | major 4.2.0 (40 days overdue) |',
       );
     });
 
@@ -309,7 +310,7 @@ describe('writeSummaryFile', () => {
         .split('\n')
         .find((l) => l.includes('my-internal-pkg'));
       expect(line).toBe(
-        '| 🔴 | `my-internal-pkg` | major 4.2.0 (40 days overdue), deprecated |',
+        '| 🔴 | `my-internal-pkg` | 1.0.0 | major 4.2.0 (40 days overdue), deprecated |',
       );
     });
 
@@ -330,7 +331,7 @@ describe('writeSummaryFile', () => {
       const line = content
         .split('\n')
         .find((l) => l.includes('my-internal-pkg'));
-      expect(line).toBe('| 🔴 | `my-internal-pkg` | deprecated |');
+      expect(line).toBe('| 🔴 | `my-internal-pkg` | 1.0.0 | deprecated |');
     });
 
     it('does not show a banned/restricted package (it is Rules-only, not duplicated here)', () => {
@@ -378,6 +379,152 @@ describe('writeSummaryFile', () => {
       );
       expect(content).toContain('### Packages\n');
       expect(content).not.toContain('(issues only)');
+    });
+
+    // Regression test for #57 P3: the summary path used to call
+    // describeUpgradeTarget(top) with no second argument, so it never saw
+    // the cross-tier compliant target the human table (formatUpgradeCell)
+    // already recommended — reporting "no compliant release available" even
+    // when a genuinely compliant release plainly existed in a different tier.
+    it('recommends the cross-tier compliant target, not "no compliant release available" (#57 regression)', () => {
+      const pkg = createMockPackage('some-lib', {
+        releaseAge: createMockReleaseAge({
+          worstLevel: 'minor_overdue',
+          severity: 'error',
+          minCompliantInWindow: true,
+          minCompliantVersion: '1.0.0',
+          minCompliantBump: 'major',
+          upgrades: [
+            {
+              version: '0.5.7',
+              releasedDaysAgo: 200,
+              breachReleasedDaysAgo: 200,
+              semverBump: 'minor',
+              level: 'minor_overdue',
+              thresholdDays: 45,
+            },
+          ],
+        }),
+      });
+      const content = write(makeAggregated({ packageDistribution: [pkg] }));
+      expect(content).toContain('major 1.0.0 (155 days overdue)');
+      expect(content).not.toContain('no compliant release available');
+    });
+
+    // Golden equivalence test: the human table (formatUpgradeCell) and the
+    // summary file (buildPackagesSection) must derive the same recommended
+    // upgrade description from the same ReleaseAgeEntry — they diverged on
+    // this once before (#57) because only one call site passed the
+    // compliantTarget argument.
+    it('agrees with formatUpgradeCell on the recommended upgrade description', () => {
+      const releaseAge = createMockReleaseAge({
+        worstLevel: 'minor_overdue',
+        severity: 'error',
+        minCompliantInWindow: true,
+        minCompliantVersion: '1.0.0',
+        minCompliantBump: 'major',
+        upgrades: [
+          {
+            version: '0.5.7',
+            releasedDaysAgo: 200,
+            breachReleasedDaysAgo: 200,
+            semverBump: 'minor',
+            level: 'minor_overdue',
+            thresholdDays: 45,
+          },
+        ],
+      });
+      const pkg = createMockPackage('some-lib', { releaseAge });
+      const content = write(makeAggregated({ packageDistribution: [pkg] }));
+
+      const tableCell = formatUpgradeCell(releaseAge);
+      // formatUpgradeCell is "<icon> <description>[suffix]" — extract just
+      // the description text and confirm the summary row contains the exact
+      // same substring, not a re-derived (and potentially divergent) one.
+      const description = tableCell.replace(/^\S+\s/, '');
+      expect(content).toContain(description);
+    });
+
+    // Notes (#57): a package that's compliant at the enforced scope but has
+    // an overdue nested copy the scope doesn't enforce must still surface in
+    // the summary — as a Notes line, using the exact same wording the human
+    // table shows — not be silently omitted just because it never reaches
+    // compliance.releaseAgeViolations, and not given its own violation-shaped
+    // table row (it isn't one).
+    it('shows a compliant-but-advisory package as a Notes line, with no Packages table', () => {
+      const advisoryOnly = createMockPackage('multi-version-lib', {
+        hasVersionConflict: true,
+        allVersions: ['1.0.0', '3.0.0'],
+        releaseAge: createMockReleaseAge({
+          worstLevel: null,
+          severity: 'error',
+          scope: 'root',
+          advisoryBreaches: [{ version: '1.0.0', level: 'major_overdue' }],
+        }),
+      });
+      const content = write(
+        makeAggregated({ packageDistribution: [advisoryOnly] }),
+      );
+      expect(content).toContain('### Packages');
+      // Compliant packages never get a violation-shaped table row.
+      expect(content).not.toContain('| | Package | Installed | Target |');
+      expect(content).toContain('Notes:');
+      const line = content
+        .split('\n')
+        .find((l) => l.includes('multi-version-lib'));
+      expect(line).toContain('- `multi-version-lib` —');
+      expect(line).toContain(
+        '2 versions installed (bundle impact): 1.0.0, 3.0.0',
+      );
+      expect(line).toContain(
+        '🟡 1 nested copy overdue, not enforced but recommended to resolve',
+      );
+      // Notes-only packages must never count toward the mandatory verdict.
+      expect(content).toContain('### 🟢 COMPLIANT');
+      expect(content).not.toContain('NOT COMPLIANT');
+    });
+
+    // (#57) A package can be a MANDATORY failure (root itself is overdue)
+    // while ALSO carrying an independently-overdue nested copy — the
+    // mandatory row shows the Installed/Target facts only; the nested-copy
+    // context appears in the separate Notes list, not crammed onto the row.
+    it('shows a package that is a mandatory violation AND has an advisory breach on both the table row and in Notes', () => {
+      const both = createMockPackage('multi-version-lib', {
+        hasVersionConflict: true,
+        allVersions: ['1.0.0', '2.0.0'],
+        releaseAge: createMockReleaseAge({
+          worstLevel: 'major_overdue',
+          severity: 'error',
+          scope: 'root',
+          installedVersion: '1.0.0',
+          upgrades: [
+            {
+              version: '2.0.0',
+              releasedDaysAgo: 10,
+              breachReleasedDaysAgo: 400,
+              semverBump: 'major',
+              level: 'major_overdue',
+              thresholdDays: 60,
+            },
+          ],
+          advisoryBreaches: [{ version: '2.0.0', level: 'major_overdue' }],
+        }),
+      });
+      const content = write(makeAggregated({ packageDistribution: [both] }));
+      const tableLine = content.split('\n').find((l) => l.startsWith('| 🔴 |'));
+      expect(tableLine).toBe(
+        '| 🔴 | `multi-version-lib` | 1.0.0 | major 2.0.0 (340 days overdue) |',
+      );
+      const noteLine = content
+        .split('\n')
+        .find((l) => l.startsWith('- `multi-version-lib`'));
+      expect(noteLine).toContain(
+        '2 versions installed (bundle impact): 1.0.0, 2.0.0',
+      );
+      expect(noteLine).toContain(
+        '🟡 1 nested copy overdue, not enforced but recommended to resolve',
+      );
+      expect(content).toContain('NOT COMPLIANT');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #57. `releaseAge` mixed three separate problems, each producing confusing or inconsistent `comply` results:

- **Yarn's version picker was effectively tree-min.** `YarnLockfileAdapter.parse()` took whichever lockfile entry it happened to encounter first, which for typical yarn.lock ordering (older ranges declared before newer ones) picked something close to the oldest nested duplicate rather than the root-declared version. npm and pnpm (v9+) already resolved root-only.
- **The human table and `--summary-file` could disagree on the same violation.** PR #54 taught the table to recommend a cross-tier compliant release instead of "no compliant release available," but that logic was only wired into `formatUpgradeCell`, not the summary path.
- **Multi-version packages gave no indication of which installed copy a verdict was measured against** — especially confusing when several duplicate versions were installed.

## Changes

- Unified lockfile resolution across npm/yarn/pnpm behind a single `resolve()` per adapter, always returning both a root version and every resolved copy (`{ rootVersion, allVersions }`). Yarn's root version is now found by matching the root `package.json`'s declared range against the parsed lockfile entry — not by taking whichever entry appears first.
- Added configurable `releaseAge.scope: 'root' | 'tree'` (default `root`) plus glob-based `scopeExceptions`, layered on top of the now-always-complete lockfile data. Root scope never hides nested duplicates — an overdue nested copy the scope doesn't enforce still shows up as an advisory Note, it just doesn't fail `comply`.
- Fixed the table/summary drift by extracting `resolveCompliantTarget` and reusing it in both `formatUpgradeCell` and `buildPackagesSection`, so they can't diverge again.
- Split the human table's Upgrades cell into explicit **Installed** / **Target** columns (Installed reflects the actual enforced baseline, which can be a nested copy under tree scope, not just the root version) and moved bundle-impact / advisory-breach context into a **Notes** section below the table — mirrored identically in `--summary-file`.
- Fixed an unrelated `.gitignore` bug found along the way: `yarn.lock`/`package-lock.json` were unanchored and matched at any depth, silently swallowing nested test fixtures. Anchored to repo root (`/yarn.lock`, `/package-lock.json`).
- Documented the new scope option in `docs/examples.md`.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:ci` — clean
- [x] `pnpm run test:ci` — 473/473 passing
- [x] Manual verification: reproduced the issue's repro shape (root scope shows a nested overdue copy as advisory without failing comply; tree scope + `scopeExceptions` escalates it to mandatory; human table and `--summary-file` agree on both the Installed baseline and Target recommendation for the same package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)