### PR TITLE
fix: JSX in attribute values is never visited (#64)

### DIFF
--- a/fixtures/patterns/09-jsx-in-attributes.tsx
+++ b/fixtures/patterns/09-jsx-in-attributes.tsx
@@ -1,0 +1,84 @@
+// Example library imports - JSX nested inside attribute values
+import Child from "@design-system/foundation/child";
+import CaseChild from "@design-system/foundation/case-child";
+import CaseCond from "@design-system/foundation/case-cond";
+import CaseMap from "@design-system/foundation/case-map";
+import CaseVar from "@design-system/foundation/case-var";
+import CaseReturn from "@design-system/foundation/case-return";
+import CaseAttr from "@design-system/foundation/case-attr";
+import CaseAttrSelfClosing from "@design-system/foundation/case-attr-self-closing";
+import CaseAttrCond from "@design-system/foundation/case-attr-cond";
+import CaseAttrHost from "@design-system/foundation/case-attr-host";
+import CaseAttrFragment from "@design-system/foundation/case-attr-fragment";
+import CaseBoth from "@design-system/foundation/case-both";
+import CaseUnused from "@design-system/foundation/case-unused";
+
+/**
+ * PATTERN 9: JSX NESTED IN ATTRIBUTE VALUES
+ * Complexity: 4/10
+ *
+ * Regression fixture for https://github.com/Gallevy/hermex/issues/64
+ *
+ * The AST visitor must descend into JSXOpeningElement.attributes so that
+ * components rendered inside prop values (title=, subtitle=, icon=, ...)
+ * are counted the same way as components rendered as children.
+ */
+
+export function JsxInAttributesExample({ cond }: { cond: boolean }) {
+  return (
+    <div>
+      {/* child element - detected before the fix */}
+      <div>
+        <CaseChild>x</CaseChild>
+      </div>
+
+      {/* conditional child - detected before the fix */}
+      {cond && <CaseCond>x</CaseCond>}
+
+      {/* child via .map() - detected before the fix */}
+      {[1].map((i) => (
+        <CaseMap key={i} />
+      ))}
+
+      {/* variable-assigned - detected before the fix */}
+      {(() => {
+        const el = <CaseVar />;
+        return <div>{el}</div>;
+      })()}
+
+      {/* direct return - detected before the fix */}
+      {(() => {
+        return <CaseReturn>x</CaseReturn>;
+      })()}
+
+      {/* prop value - NOT detected before the fix */}
+      <Child subtitle={<CaseAttr>x</CaseAttr>} />
+
+      {/* prop value, self-closing - NOT detected before the fix */}
+      <Child subtitle={<CaseAttrSelfClosing />} />
+
+      {/* prop value, conditional - NOT detected before the fix */}
+      <Child subtitle={cond && <CaseAttrCond />} />
+
+      {/* prop value on a host element - NOT detected before the fix */}
+      <div title={<CaseAttrHost />}>x</div>
+
+      {/* prop value, fragment-wrapped - NOT detected before the fix */}
+      <Child
+        subtitle={
+          <>
+            <CaseAttrFragment />
+          </>
+        }
+      />
+
+      {/* both positions in the same file - the child usage alone made this pass before the fix */}
+      <div>
+        <CaseBoth />
+        <Child subtitle={<CaseBoth />} />
+      </div>
+
+      {/* imported, never used - correctly absent either way */}
+    </div>
+  );
+}

--- a/src/swc-parser/core/visitor.ts
+++ b/src/swc-parser/core/visitor.ts
@@ -69,6 +69,7 @@ export function visitNode(
 
     case 'JSXOpeningElement':
       analyzeJSXOpeningElement(node, state, context.parent);
+      visitChildren(node, state, { ...context, parent: node });
       break;
 
     case 'ArrayExpression':

--- a/tests/swc-parser/patterns/jsx-in-attributes-fixture.test.ts
+++ b/tests/swc-parser/patterns/jsx-in-attributes-fixture.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, test, expect } from 'vitest';
+import { parseCode } from '../../../src/swc-parser';
+import { readFixture } from '../../helpers/read-fixture';
+
+// Fixture-level regression test for https://github.com/Gallevy/hermex/issues/64
+// Mirrors the position matrix from the issue: components rendered inside
+// JSX attribute values must be tracked exactly like components rendered
+// as children.
+describe('Parser - JSX in attributes fixture', () => {
+  let code: string;
+
+  beforeAll(async () => {
+    code = await readFixture('patterns/09-jsx-in-attributes.tsx');
+  });
+
+  test('detects components used exclusively in prop positions', () => {
+    const report = parseCode(code, '09-jsx-in-attributes.tsx');
+    const components = report.patterns.usage.jsx.map((u) => u.component);
+
+    expect(components).toContain('CaseAttr');
+    expect(components).toContain('CaseAttrSelfClosing');
+    expect(components).toContain('CaseAttrCond');
+    expect(components).toContain('CaseAttrHost');
+    expect(components).toContain('CaseAttrFragment');
+  });
+
+  test('still detects components used in the pre-existing child positions', () => {
+    const report = parseCode(code, '09-jsx-in-attributes.tsx');
+    const components = report.patterns.usage.jsx.map((u) => u.component);
+
+    expect(components).toContain('CaseChild');
+    expect(components).toContain('CaseCond');
+    expect(components).toContain('CaseMap');
+    expect(components).toContain('CaseVar');
+    expect(components).toContain('CaseReturn');
+  });
+
+  test('a component used in both a child and a prop position is tracked exactly once', () => {
+    const report = parseCode(code, '09-jsx-in-attributes.tsx');
+    const bothEntries = report.patterns.usage.jsx.filter(
+      (u) => u.component === 'CaseBoth',
+    );
+
+    expect(bothEntries).toHaveLength(1);
+  });
+
+  test('a component imported but never rendered stays untracked', () => {
+    const report = parseCode(code, '09-jsx-in-attributes.tsx');
+    const components = report.patterns.usage.jsx.map((u) => u.component);
+
+    expect(components).not.toContain('CaseUnused');
+  });
+
+  test('all case components are reflected in the flat components list', () => {
+    const report = parseCode(code, '09-jsx-in-attributes.tsx');
+
+    // report.components lists every imported component, used or not, so
+    // this only confirms the import side; usage is asserted above.
+    expect(report.components).toContain('CaseAttr');
+    expect(report.components).toContain('CaseUnused');
+  });
+});

--- a/tests/swc-parser/patterns/jsx-unit.test.ts
+++ b/tests/swc-parser/patterns/jsx-unit.test.ts
@@ -157,9 +157,7 @@ describe('Parser - JSX nested inside attribute values (issue #64)', () => {
 
     const report = parseCode(code, 'file.tsx');
 
-    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
-      'Attr',
-    );
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain('Attr');
   });
 
   test('a conditionally-rendered component in a prop value is tracked', () => {
@@ -167,9 +165,7 @@ describe('Parser - JSX nested inside attribute values (issue #64)', () => {
 
     const report = parseCode(code, 'file.tsx');
 
-    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
-      'Attr',
-    );
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain('Attr');
   });
 
   test('a component in a prop value on an unknown host element is tracked', () => {
@@ -177,9 +173,7 @@ describe('Parser - JSX nested inside attribute values (issue #64)', () => {
 
     const report = parseCode(code, 'file.tsx');
 
-    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
-      'Attr',
-    );
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain('Attr');
   });
 
   test('a fragment-wrapped component in a prop value is tracked', () => {
@@ -187,9 +181,7 @@ describe('Parser - JSX nested inside attribute values (issue #64)', () => {
 
     const report = parseCode(code, 'file.tsx');
 
-    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
-      'Attr',
-    );
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain('Attr');
   });
 
   test('a component used only in a prop position is not double-counted when also used as a child elsewhere', () => {

--- a/tests/swc-parser/patterns/jsx-unit.test.ts
+++ b/tests/swc-parser/patterns/jsx-unit.test.ts
@@ -135,3 +135,81 @@ describe('Parser - JSX usage', () => {
     );
   });
 });
+
+// Regression tests for https://github.com/Gallevy/hermex/issues/64
+// JSX nested inside a prop value was never visited, so components used
+// exclusively in attribute positions were dropped from usage tracking.
+describe('Parser - JSX nested inside attribute values (issue #64)', () => {
+  const CHILD_PREAMBLE = `import { Child } from '@ui/components';\n`;
+
+  test('a component in a prop value is tracked', () => {
+    const code = `${CHILD_PREAMBLE}import { Attr } from '@ui/components';\nfunction App() { return <Child subtitle={<Attr>x</Attr>} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const components = report.patterns.usage.jsx.map((u) => u.component);
+    expect(components).toContain('Child');
+    expect(components).toContain('Attr');
+  });
+
+  test('a self-closing component in a prop value is tracked', () => {
+    const code = `${CHILD_PREAMBLE}import { Attr } from '@ui/components';\nfunction App() { return <Child subtitle={<Attr />} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
+      'Attr',
+    );
+  });
+
+  test('a conditionally-rendered component in a prop value is tracked', () => {
+    const code = `${CHILD_PREAMBLE}import { Attr } from '@ui/components';\nfunction App() { return <Child subtitle={cond && <Attr />} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
+      'Attr',
+    );
+  });
+
+  test('a component in a prop value on an unknown host element is tracked', () => {
+    const code = `import { Attr } from '@ui/components';\nfunction App() { return <div title={<Attr />}>x</div>; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
+      'Attr',
+    );
+  });
+
+  test('a fragment-wrapped component in a prop value is tracked', () => {
+    const code = `${CHILD_PREAMBLE}import { Attr } from '@ui/components';\nfunction App() { return <Child subtitle={<><Attr /></>} />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    expect(report.patterns.usage.jsx.map((u) => u.component)).toContain(
+      'Attr',
+    );
+  });
+
+  test('a component used only in a prop position is not double-counted when also used as a child elsewhere', () => {
+    const code = `${CHILD_PREAMBLE}import { Both } from '@ui/components';\nfunction App() { return <div><Both /><Child subtitle={<Both />} /></div>; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    const bothEntries = report.patterns.usage.jsx.filter(
+      (u) => u.component === 'Both',
+    );
+    expect(bothEntries).toHaveLength(1);
+  });
+
+  test('a component imported but never rendered (including in props) stays untracked', () => {
+    const code = `${CHILD_PREAMBLE}import { Unused } from '@ui/components';\nfunction App() { return <Child />; }`;
+
+    const report = parseCode(code, 'file.tsx');
+
+    expect(report.patterns.usage.jsx.map((u) => u.component)).not.toContain(
+      'Unused',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `JSXOpeningElement` was the only case in `visitNode`'s switch that returned without calling `visitChildren`, so JSX nested inside a prop value (`<Child subtitle={<Attr/>} />`) was never traversed and its component was invisible to the analyzer.
- This undercounted `components`, `patterns.usage.jsx`, and — most importantly — `versus[].entries[].count` / percentages, since components passed as props (`title=`, `subtitle=`, `icon=`, ...) are common in list/table/layout code.
- Fix: recurse with `visitChildren` from the `JSXOpeningElement` case, same as every other analyzed node type.

## Test plan
- [x] Added 6 inline unit tests in `tests/swc-parser/patterns/jsx-unit.test.ts` covering the position matrix from the issue (prop value, self-closing, conditional, host element, fragment-wrapped, dual child+prop usage, unused import stays untracked).
- [x] Added fixture `fixtures/patterns/09-jsx-in-attributes.tsx` mirroring the issue's 12-case repro, plus `tests/swc-parser/patterns/jsx-in-attributes-fixture.test.ts` exercising it end to end through `parseCode`.
- [x] Verified new tests fail against the pre-fix code (6 failures) and pass after the fix.
- [x] `npx vitest run` — 497/497 passing.
- [x] `npx tsc --noEmit` and `npx oxlint` clean.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)