### PR TITLE
fix: component usage aggregation is first-writer-wins by name, mis-attributing shared names

### DIFF
--- a/fixtures/versus/01-collision-classic-button.tsx
+++ b/fixtures/versus/01-collision-classic-button.tsx
@@ -1,0 +1,9 @@
+// Same component name (`Button`) as 02-collision-pulse-button.tsx, imported
+// from a different package. Aggregating both files must keep the two
+// `Button` usages attributed to their own source instead of collapsing
+// into whichever file is processed first.
+import Button from '@acme-ui/classic/Button';
+
+export default function ClassicExample() {
+  return <Button>classic</Button>;
+}

--- a/fixtures/versus/02-collision-pulse-button.tsx
+++ b/fixtures/versus/02-collision-pulse-button.tsx
@@ -1,0 +1,7 @@
+// Same component name (`Button`) as 01-collision-classic-button.tsx,
+// imported from a different package.
+import { Button } from '@acme-ui/pulse';
+
+export default function PulseExample() {
+  return <Button>pulse</Button>;
+}

--- a/src/utils/aggregator-core.ts
+++ b/src/utils/aggregator-core.ts
@@ -52,18 +52,23 @@ export function aggregateReports(
     totalUsagePatterns += report.summary.totalUsagePatterns;
 
     for (const jsx of report.patterns.usage.jsx) {
-      const key = jsx.component;
+      // Keyed by (source, name), not name alone — the same component name
+      // (e.g. `Button`) can be imported from two different packages across
+      // a repo, and a name-only key would collapse them into one entry,
+      // silently attributing every usage to whichever source was seen
+      // first.
+      const source = findComponentSource(
+        jsx.component,
+        report,
+        availablePackages,
+      );
+      const key = `${source}::${jsx.component}`;
       const existing = componentUsageMap.get(key);
 
       if (existing) {
         existing.count++;
         existing.files.add(report.filePath);
       } else {
-        const source = findComponentSource(
-          jsx.component,
-          report,
-          availablePackages,
-        );
         componentUsageMap.set(key, {
           name: jsx.component,
           source,
@@ -80,7 +85,9 @@ export function aggregateReports(
     (a, b) => b.count - a.count,
   );
 
-  const allComponents = Array.from(componentUsageMap.keys()).sort();
+  const allComponents = Array.from(
+    new Set(Array.from(componentUsageMap.values()).map((c) => c.name)),
+  ).sort();
 
   const patternCounts = Array.from(patternCountMap.entries())
     .map(([type, count]) => ({

--- a/tests/utils/aggregator-source-collision.test.ts
+++ b/tests/utils/aggregator-source-collision.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { parseCode } from '../../src/swc-parser';
+import { aggregateReports } from '../../src/utils/aggregator';
+import { HermexConfigSchema } from '../../src/config/schema';
+import type { HermexConfigInput } from '../../src/config/schema';
+import { readFixture } from '../helpers/read-fixture';
+
+/** Parse a partial config through the real schema so all defaults apply. */
+function createConfig(input: HermexConfigInput = {}) {
+  return HermexConfigSchema.parse(input);
+}
+
+const VERSIONS = {
+  '@acme-ui/classic': '5.0.0',
+  '@acme-ui/pulse': '1.0.0',
+};
+
+const VERSUS_CONFIG = createConfig({
+  versus: [
+    {
+      name: 'Classic to Pulse',
+      packages: ['@acme-ui/classic', '@acme-ui/pulse'],
+    },
+  ],
+});
+
+// The same component name imported from two different packages must not
+// be collapsed into a single (name-only) usage entry — that silently
+// attributes every usage to whichever source is aggregated first.
+describe('aggregateReports — component source collisions', () => {
+  it('keeps `Button` usages split by source across two real files, through the full parse pipeline', async () => {
+    const classicCode = await readFixture(
+      'versus/01-collision-classic-button.tsx',
+    );
+    const pulseCode = await readFixture('versus/02-collision-pulse-button.tsx');
+
+    const classicReport = parseCode(
+      classicCode,
+      'versus/01-collision-classic-button.tsx',
+    );
+    const pulseReport = parseCode(
+      pulseCode,
+      'versus/02-collision-pulse-button.tsx',
+    );
+
+    const result = aggregateReports(
+      [classicReport, pulseReport],
+      VERSIONS,
+      VERSUS_CONFIG,
+    );
+
+    // Both sources are distinct components for aggregation purposes, even
+    // though they share the JSX name `Button`.
+    expect(result.totalComponents).toBe(2);
+    expect(result.topComponents).toHaveLength(2);
+    expect(result.topComponents.every((c) => c.name === 'Button')).toBe(true);
+    expect(result.topComponents.map((c) => c.source).sort()).toEqual([
+      '@acme-ui/classic',
+      '@acme-ui/pulse',
+    ]);
+    expect(result.topComponents.every((c) => c.count === 1)).toBe(true);
+
+    const versus = result.versusResults[0];
+    expect(versus.totalCount).toBe(2);
+    const classic = versus.entries.find(
+      (e) => e.packageName === '@acme-ui/classic',
+    );
+    const pulse = versus.entries.find(
+      (e) => e.packageName === '@acme-ui/pulse',
+    );
+    expect(classic?.count).toBe(1);
+    expect(classic?.percentage).toBe(50);
+    expect(pulse?.count).toBe(1);
+    expect(pulse?.percentage).toBe(50);
+
+    const classicDist = result.packageDistribution.find(
+      (p) => p.packageName === '@acme-ui/classic',
+    );
+    const pulseDist = result.packageDistribution.find(
+      (p) => p.packageName === '@acme-ui/pulse',
+    );
+    expect(classicDist?.components).toEqual(['Button']);
+    expect(pulseDist?.components).toEqual(['Button']);
+  });
+
+  it('still merges the same name imported from the same source across files', () => {
+    const code = `import Button from '@acme-ui/classic/Button';\nfunction App() { return <Button />; }`;
+    const reportA = parseCode(code, 'a.tsx');
+    const reportB = parseCode(code, 'b.tsx');
+
+    const result = aggregateReports([reportA, reportB], VERSIONS);
+
+    expect(result.totalComponents).toBe(1);
+    expect(result.topComponents).toHaveLength(1);
+    expect(result.topComponents[0].count).toBe(2);
+    expect(result.topComponents[0].files).toEqual(new Set(['a.tsx', 'b.tsx']));
+  });
+});

--- a/tests/utils/aggregator.test.ts
+++ b/tests/utils/aggregator.test.ts
@@ -91,7 +91,7 @@ describe('aggregateReports — component files', () => {
 
     const result = aggregateReports([reportA, reportB], { react: '18.0.0' });
 
-    expect(result.componentUsage.get('Button')?.files).toEqual(
+    expect(result.componentUsage.get('react::Button')?.files).toEqual(
       new Set(['a.tsx', 'b.tsx']),
     );
   });
@@ -103,7 +103,7 @@ describe('aggregateReports — component files', () => {
 
     const result = aggregateReports([report], { react: '18.0.0' });
 
-    const button = result.componentUsage.get('Button');
+    const button = result.componentUsage.get('react::Button');
     expect(button?.files).toEqual(new Set(['a.tsx']));
     expect(button?.count).toBe(2);
   });


### PR DESCRIPTION
## Summary
- `componentUsageMap` in `src/utils/aggregator-core.ts` was keyed by component name only. When the same name (e.g. `Button`) is imported from two different packages across a repo — the norm during a library migration — whichever file was aggregated first won the `source` forever. Later files with a different import origin only bumped `count`/`files` under the wrong package.
- This silently moved usage between packages and skewed `versus` migration percentages, systematically undercounting whichever package happened to be scanned later — exactly the window where the metric matters most.
- Fix: key the map by `${source}::${name}` instead of `name` alone, computing `source` before the lookup so each `(name, source)` pair gets its own `ComponentUsage` entry. `calculatePackageDistribution` / `versus` already group by `component.source` off the map's *values*, so they pick up the split automatically.
- `allComponents` (a plain component-name list) is decoupled from the internal map key and now dedupes by `.name` directly, since it's meant to represent names, not `(source, name)` pairs.

## Test plan
- [x] `tests/utils/aggregator-source-collision.test.ts` — new fixture-backed regression test running the real parser (`parseCode`) over two new fixtures (`fixtures/versus/01-collision-classic-button.tsx`, `fixtures/versus/02-collision-pulse-button.tsx`, using made-up package names) through `aggregateReports`, asserting `versus`/`packageDistribution`/`topComponents` keep the two `Button` usages split by source. Also covers same-name-same-source still merging correctly.
- [x] Updated two pre-existing `tests/utils/aggregator.test.ts` assertions that looked up `componentUsage.get('Button')` to use the new composite key (`'react::Button'`).
- [x] Verified all 3 updated/new tests fail against the pre-fix code and pass after the fix.
- [x] `npx vitest run` — 499/499 passing.
- [x] `npx tsc --noEmit`, `npx oxlint`, `npx oxfmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)