### PR TITLE
fix: canonicalize aliased named imports to their export name

### DIFF
--- a/fixtures/aliasing/01-plain.tsx
+++ b/fixtures/aliasing/01-plain.tsx
@@ -1,0 +1,5 @@
+import { Card } from '@acme-ui/pulse';
+
+export default function PlainCardA() {
+  return <Card>a</Card>;
+}

--- a/fixtures/aliasing/02-alias.tsx
+++ b/fixtures/aliasing/02-alias.tsx
@@ -1,0 +1,5 @@
+import { Card as PulseCard } from '@acme-ui/pulse';
+
+export default function AliasCardB() {
+  return <PulseCard>b</PulseCard>;
+}

--- a/fixtures/aliasing/03-alias-again.tsx
+++ b/fixtures/aliasing/03-alias-again.tsx
@@ -1,0 +1,5 @@
+import { Card as UiCard } from '@acme-ui/pulse';
+
+export default function AliasCardC() {
+  return <UiCard>c</UiCard>;
+}

--- a/fixtures/aliasing/04-plain-again.tsx
+++ b/fixtures/aliasing/04-plain-again.tsx
@@ -1,0 +1,5 @@
+import { Card } from '@acme-ui/pulse';
+
+export default function PlainCardD() {
+  return <Card>d</Card>;
+}

--- a/src/utils/aggregator-core.ts
+++ b/src/utils/aggregator-core.ts
@@ -62,7 +62,20 @@ export function aggregateReports(
         report,
         availablePackages,
       );
-      const key = `${source}::${jsx.component}`;
+      // For a named/aliased import, `jsx.component` is the local JSX
+      // identifier (e.g. `ArcCard`), not the package's actual export name
+      // (e.g. `Card`) — resolve back to the canonical export so the same
+      // export used under different local aliases aggregates as one
+      // component instead of fragmenting into several. Default imports have
+      // no canonical export name (the module path is the real identity), so
+      // they never have an `aliased` entry and pass through unchanged.
+      const aliasedImport = report.patterns.imports.aliased.find(
+        (imp) => imp.local === jsx.component,
+      );
+      const canonicalName = aliasedImport
+        ? aliasedImport.imported
+        : jsx.component;
+      const key = `${source}::${canonicalName}`;
       const existing = componentUsageMap.get(key);
 
       if (existing) {
@@ -70,7 +83,7 @@ export function aggregateReports(
         existing.files.add(report.filePath);
       } else {
         componentUsageMap.set(key, {
-          name: jsx.component,
+          name: canonicalName,
           source,
           count: 1,
           files: new Set([report.filePath]),

--- a/tests/utils/aggregator-alias-fixture.test.ts
+++ b/tests/utils/aggregator-alias-fixture.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { parseCode } from '../../src/swc-parser';
+import { aggregateReports } from '../../src/utils/aggregator';
+import { readFixture } from '../helpers/read-fixture';
+
+const VERSIONS = { '@acme-ui/pulse': '1.0.0' };
+
+const FIXTURE_FILES = [
+  'aliasing/01-plain.tsx',
+  'aliasing/02-alias.tsx',
+  'aliasing/03-alias-again.tsx',
+  'aliasing/04-plain-again.tsx',
+];
+
+// Regression test: a single package export (`Card`) imported under a plain
+// name in some files and under different local aliases in others must
+// aggregate as one component, not fragment into one entry per alias.
+describe('aggregateReports — aliased import canonicalization, through the full parse pipeline', () => {
+  it('reports one Card component used 4 times, not three fragmented components', async () => {
+    const reports = await Promise.all(
+      FIXTURE_FILES.map(async (path) => {
+        const code = await readFixture(path);
+        return parseCode(code, path);
+      }),
+    );
+
+    const result = aggregateReports(reports, VERSIONS);
+
+    expect(result.totalComponents).toBe(1);
+    expect(result.topComponents).toHaveLength(1);
+
+    const card = result.topComponents[0];
+    expect(card.name).toBe('Card');
+    expect(card.source).toBe('@acme-ui/pulse');
+    expect(card.count).toBe(4);
+    expect(card.files).toEqual(new Set(FIXTURE_FILES));
+
+    const dist = result.packageDistribution.find(
+      (p) => p.packageName === '@acme-ui/pulse',
+    );
+    expect(dist?.componentCount).toBe(1);
+    expect(dist?.usageCount).toBe(4);
+    expect(dist?.components).toEqual(['Card']);
+
+    // Neither local alias leaks into the reported identity.
+    expect(result.allComponents).not.toContain('PulseCard');
+    expect(result.allComponents).not.toContain('UiCard');
+  });
+});

--- a/tests/utils/aggregator.test.ts
+++ b/tests/utils/aggregator.test.ts
@@ -35,6 +35,24 @@ function reportWithNamedImport(name: string, source: string) {
   return report;
 }
 
+/**
+ * Create a report with an aliased named import (`import { X as Y }`) and a
+ * JSX usage under the local alias, matching what the real parser records.
+ */
+function reportWithAliasedImport(
+  imported: string,
+  local: string,
+  source: string,
+) {
+  const report = createMockReport();
+  report.summary.totalImports = 1;
+  report.summary.totalUsagePatterns = 1;
+  report.patterns.imports.named.push({ name: imported, source });
+  report.patterns.imports.aliased.push({ imported, local, source });
+  report.patterns.usage.jsx.push(jsxUsage(local));
+  return report;
+}
+
 describe('aggregateReports — empty input', () => {
   it('returns zeroed counts for empty reports array', () => {
     const result = aggregateReports([]);
@@ -106,6 +124,95 @@ describe('aggregateReports — component files', () => {
     const button = result.componentUsage.get('react::Button');
     expect(button?.files).toEqual(new Set(['a.tsx']));
     expect(button?.count).toBe(2);
+  });
+});
+
+// Regression tests: an aliased named import (`import { X as Y }`) must
+// aggregate under the package's real export name, not the local JSX
+// identifier — otherwise one export fragments into several "components".
+describe('aggregateReports — aliased import canonicalization', () => {
+  it('merges a plain import and an aliased import of the same export into one component', () => {
+    const plain = reportWithNamedImport('Card', '@acme-ui/pulse');
+    plain.filePath = 'a.tsx';
+    const aliased = reportWithAliasedImport(
+      'Card',
+      'ArcCard',
+      '@acme-ui/pulse',
+    );
+    aliased.filePath = 'b.tsx';
+
+    const result = aggregateReports([plain, aliased], {
+      '@acme-ui/pulse': '1.0.0',
+    });
+
+    expect(result.totalComponents).toBe(1);
+    expect(result.topComponents).toHaveLength(1);
+    expect(result.topComponents[0].name).toBe('Card');
+    expect(result.topComponents[0].source).toBe('@acme-ui/pulse');
+    expect(result.topComponents[0].count).toBe(2);
+    expect(result.topComponents[0].files).toEqual(new Set(['a.tsx', 'b.tsx']));
+  });
+
+  it('merges two different aliases of the same export into one component', () => {
+    const aliasA = reportWithAliasedImport('Card', 'ArcCard', '@acme-ui/pulse');
+    aliasA.filePath = 'a.tsx';
+    const aliasB = reportWithAliasedImport('Card', 'UiCard', '@acme-ui/pulse');
+    aliasB.filePath = 'b.tsx';
+
+    const result = aggregateReports([aliasA, aliasB], {
+      '@acme-ui/pulse': '1.0.0',
+    });
+
+    expect(result.topComponents).toHaveLength(1);
+    expect(result.topComponents[0].name).toBe('Card');
+    expect(result.topComponents[0].count).toBe(2);
+    expect(result.allComponents).toEqual(['Card']);
+  });
+
+  it('reflects the canonical name, not the alias, in package distribution', () => {
+    const aliased = reportWithAliasedImport(
+      'Card',
+      'ArcCard',
+      '@acme-ui/pulse',
+    );
+
+    const result = aggregateReports([aliased], { '@acme-ui/pulse': '1.0.0' });
+
+    const dist = result.packageDistribution.find(
+      (p) => p.packageName === '@acme-ui/pulse',
+    );
+    expect(dist?.components).toEqual(['Card']);
+    expect(dist?.componentCount).toBe(1);
+  });
+
+  it('does not canonicalize a default import (no canonical export name exists)', () => {
+    const report = createMockReport();
+    report.summary.totalImports = 1;
+    report.summary.totalUsagePatterns = 1;
+    report.patterns.imports.default.push({
+      name: 'Foo',
+      source: '@acme-ui/pulse/Button',
+    });
+    report.patterns.usage.jsx.push(jsxUsage('Foo'));
+
+    const result = aggregateReports([report], { '@acme-ui/pulse': '1.0.0' });
+
+    expect(result.topComponents[0].name).toBe('Foo');
+  });
+
+  it('leaves namespace member usage (e.g. `Ui.Card`) as its existing dotted identity, unaffected by alias canonicalization', () => {
+    const report = createMockReport();
+    report.summary.totalImports = 1;
+    report.summary.totalUsagePatterns = 1;
+    report.patterns.imports.namespace.push({
+      name: 'Ui',
+      source: '@acme-ui/pulse',
+    });
+    report.patterns.usage.jsx.push(jsxUsage('Ui.Card'));
+
+    const result = aggregateReports([report], { '@acme-ui/pulse': '1.0.0' });
+
+    expect(result.topComponents[0].name).toBe('Ui.Card');
   });
 });
 


### PR DESCRIPTION
## Summary
- Component identity was taken from the local JSX identifier rather than the imported export name. When a named import is aliased (`import { Card as ArcCard } from '@acme-ui/pulse'`), usage was reported under the local alias `ArcCard`, which isn't part of the package's public API — it's just a local variable name.
- A single package export could therefore fragment into several distinct "components", inflating `componentCount` and listing names in `versus[].components` / `packages[].components` that don't exist in the package.
- Fix: in `src/utils/aggregator-core.ts`, resolve the local JSX identifier back to its canonical imported name (via `report.patterns.imports.aliased`) before building the `(source, name)` aggregation key introduced for the prior source-collision fix. Two different aliases of the same export — or a plain import alongside an aliased one — now collapse into a single component entry with combined counts.
- Default imports are untouched (no canonical export name exists — the module path is the real identity — and they never have an `aliased` entry to match against). Namespace member usage (`Ui.Card`) is a separate code path and is unaffected.

## Test plan
- [x] `tests/utils/aggregator.test.ts` — new `aliased import canonicalization` describe block: plain + aliased usages of the same export merge; two different aliases of the same export merge; package distribution reflects the canonical name; default imports are not canonicalized; namespace member usage stays as its existing dotted identity.
- [x] `tests/utils/aggregator-alias-fixture.test.ts` — fixture-backed regression test running the real parser over 4 new fixtures (`fixtures/aliasing/01-plain.tsx` … `04-plain-again.tsx`, mirroring the issue's repro with made-up package names) through `aggregateReports`, asserting one `Card` component with count 4, not three fragmented components.
- [x] Verified all 4 new/updated assertions fail against the pre-fix code and pass after the fix.
- [x] `npx vitest run` — 505/505 passing.
- [x] `npx tsc --noEmit`, `npx oxlint`, `npx oxfmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)