### PR TITLE
feat: repo-scoped rule overrides

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -73,6 +73,54 @@ export default defineConfig({
 
 Output shows a neutral bar split per group — no directional assumption, just usage percentages.
 
+## Overrides — Repo-Scoped Rules
+
+When one shared `hermex.config.ts` is reused across many repos, `overrides`
+lets a subset of them get extra rules without forking the config. Each entry
+checks the *current repo's* `package.json` `name` field against `match`
+(micromatch patterns, same matching engine as `forbid_packages`); when it
+matches, the entry's `rules` are merged into the base `rules` above.
+
+```ts
+export default defineConfig({
+  rules: {
+    require_packages: [{ severity: 'error', patterns: ['typescript'] }],
+  },
+  overrides: [
+    {
+      // whitelist of repos that must depend on @acme/shell — edit this
+      // array to add/remove repos, no other config changes needed
+      match: ['@acme/checkout', '@acme/billing', '@acme/shell-consumer-*'],
+      rules: {
+        require_packages: [
+          {
+            severity: 'error',
+            patterns: ['@acme/shell'],
+            message: '@acme/shell is mandatory for shell-integrated apps',
+          },
+        ],
+      },
+    },
+  ],
+});
+```
+
+A repo whose `package.json` name is `@acme/checkout` gets both
+`require_packages` rules (`typescript` from the base config, `@acme/shell`
+from the override) — rule lists are merged additively, not replaced, so the
+base config's rules always still apply. A repo that doesn't match any
+`match` pattern is completely unaffected; only the base `rules` apply. If
+`package.json` is missing or has no `name`, no overrides can match.
+
+Every rule type is mergeable this way (`detect_files`, `require_files`,
+`forbid_packages`, `require_packages`, `require_scripts`,
+`require_package_fields`, `forbid_package_fields`, `engine_version`). The
+exception is `codeowners`, which only ever holds a single rule — a matching
+override's `codeowners` replaces the base one instead of merging with it.
+
+When more than one override entry matches the same repo, all of them apply,
+in array order.
+
 ## Compliance Rules
 
 ### File Rules

--- a/src/commands/pipeline.ts
+++ b/src/commands/pipeline.ts
@@ -10,6 +10,7 @@ import { findFiles } from '../utils/file-utils';
 import { findAndParseLockfile } from '../lock-parser';
 import { evaluateRules } from '../rules/evaluator';
 import { enrichWithReleaseAge } from '../npm-registry/enricher';
+import { applyOverrides } from '../config/overrides';
 import type { HermexConfig } from '../config/types';
 
 const DECLARATION_FILE_RE = /\.d\.(ts|mts|cts)$/;
@@ -28,6 +29,12 @@ export async function runPipeline(
   spinner: Ora,
   isJson: boolean,
 ): Promise<AggregatedReport | null> {
+  // Repo-scoped rule overrides are resolved here, against the repo actually
+  // being analyzed (process.cwd()) — not in the loader, which only knows
+  // where the config file itself came from and may be pointed elsewhere via
+  // `--config`.
+  const resolvedConfig = applyOverrides(config, process.cwd());
+
   const lockfileResult = findAndParseLockfile(process.cwd());
 
   spinner.succeed(
@@ -37,13 +44,16 @@ export async function runPipeline(
   );
 
   if (spinner.isEnabled) spinner.start('Finding files...');
-  const discovered = await findFiles(config.includes, config.excludes);
+  const discovered = await findFiles(
+    resolvedConfig.includes,
+    resolvedConfig.excludes,
+  );
   const files = discovered.filter((f) => !isDeclarationFile(f));
 
   if (files.length === 0) {
     spinner.fail(
       chalk.red(
-        `No files found matching includes: ${config.includes.join(', ')}`,
+        `No files found matching includes: ${resolvedConfig.includes.join(', ')}`,
       ),
     );
     return null;
@@ -82,15 +92,15 @@ export async function runPipeline(
   const aggregated = aggregateReports(
     reports,
     lockfileResult.versions,
-    config,
+    resolvedConfig,
     lockfileResult.multiVersions,
     lockfileResult.resolutions,
   );
 
   const evaluatorViolations = evaluateRules(
     process.cwd(),
-    config.rules,
-    config.excludes,
+    resolvedConfig.rules,
+    resolvedConfig.excludes,
     files,
   );
   aggregated.ruleViolations = [
@@ -98,12 +108,12 @@ export async function runPipeline(
     ...evaluatorViolations,
   ];
 
-  if (config.releaseAge.enabled) {
+  if (resolvedConfig.releaseAge.enabled) {
     if (spinner.isEnabled)
       spinner.start('Fetching release age from registry...');
     const { enriched, skipped } = await enrichWithReleaseAge(
       aggregated.packageDistribution,
-      config.releaseAge,
+      resolvedConfig.releaseAge,
     );
     aggregated.packageDistribution = enriched;
     spinner.succeed(

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,7 +3,6 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { HermexConfigSchema } from './schema';
 import type { HermexConfig } from './schema';
-import { applyOverrides } from './overrides';
 
 export async function loadConfig(
   cwd: string,
@@ -19,9 +18,8 @@ export async function loadConfig(
 
   if (existsSync(configPath)) {
     const mod = await import(pathToFileURL(configPath).href);
-    const config = HermexConfigSchema.parse(mod.default ?? mod);
-    return applyOverrides(config, cwd);
+    return HermexConfigSchema.parse(mod.default ?? mod);
   }
 
-  return applyOverrides(HermexConfigSchema.parse({}), cwd);
+  return HermexConfigSchema.parse({});
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { HermexConfigSchema } from './schema';
 import type { HermexConfig } from './schema';
+import { applyOverrides } from './overrides';
 
 export async function loadConfig(
   cwd: string,
@@ -18,8 +19,9 @@ export async function loadConfig(
 
   if (existsSync(configPath)) {
     const mod = await import(pathToFileURL(configPath).href);
-    return HermexConfigSchema.parse(mod.default ?? mod);
+    const config = HermexConfigSchema.parse(mod.default ?? mod);
+    return applyOverrides(config, cwd);
   }
 
-  return HermexConfigSchema.parse({});
+  return applyOverrides(HermexConfigSchema.parse({}), cwd);
 }

--- a/src/config/overrides.ts
+++ b/src/config/overrides.ts
@@ -1,0 +1,87 @@
+import micromatch from 'micromatch';
+import { readPackageJson, toArray } from '../rules/shared';
+import type { HermexConfig, RulesConfig } from './schema';
+
+/**
+ * Merges each `overrides` entry whose `match` patterns hit the current
+ * repo's package.json "name" into `rules`. Array-based rules (everything
+ * except `codeowners`) are merged additively — concatenated onto the base
+ * list rather than replacing it — mirroring how a single rule type already
+ * supports multiple simultaneous instances via `RuleConfigOrArraySchema`.
+ * `codeowners` only ever holds one rule, so a matching override replaces
+ * the base entirely.
+ */
+export function applyOverrides(
+  config: HermexConfig,
+  repoPath: string,
+): HermexConfig {
+  if (config.overrides.length === 0) return config;
+
+  const pkg = readPackageJson(repoPath);
+  const repoName = typeof pkg?.name === 'string' ? pkg.name : undefined;
+  if (!repoName) return config;
+
+  const matching = config.overrides.filter((override) =>
+    micromatch.isMatch(repoName, override.match),
+  );
+  if (matching.length === 0) return config;
+
+  const rules: RulesConfig = { ...config.rules };
+
+  for (const override of matching) {
+    const o = override.rules;
+    if (o.detect_files !== undefined) {
+      rules.detect_files = [
+        ...toArray(rules.detect_files),
+        ...toArray(o.detect_files),
+      ];
+    }
+    if (o.require_files !== undefined) {
+      rules.require_files = [
+        ...toArray(rules.require_files),
+        ...toArray(o.require_files),
+      ];
+    }
+    if (o.forbid_packages !== undefined) {
+      rules.forbid_packages = [
+        ...toArray(rules.forbid_packages),
+        ...toArray(o.forbid_packages),
+      ];
+    }
+    if (o.require_packages !== undefined) {
+      rules.require_packages = [
+        ...toArray(rules.require_packages),
+        ...toArray(o.require_packages),
+      ];
+    }
+    if (o.require_scripts !== undefined) {
+      rules.require_scripts = [
+        ...toArray(rules.require_scripts),
+        ...toArray(o.require_scripts),
+      ];
+    }
+    if (o.require_package_fields !== undefined) {
+      rules.require_package_fields = [
+        ...toArray(rules.require_package_fields),
+        ...toArray(o.require_package_fields),
+      ];
+    }
+    if (o.forbid_package_fields !== undefined) {
+      rules.forbid_package_fields = [
+        ...toArray(rules.forbid_package_fields),
+        ...toArray(o.forbid_package_fields),
+      ];
+    }
+    if (o.engine_version !== undefined) {
+      rules.engine_version = [
+        ...toArray(rules.engine_version),
+        ...toArray(o.engine_version),
+      ];
+    }
+    if (o.codeowners !== undefined) {
+      rules.codeowners = o.codeowners;
+    }
+  }
+
+  return { ...config, rules };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -40,6 +40,28 @@ const CodeownersRuleSchema = z.object({
 
 const ThresholdSchema = z.union([z.number(), z.literal(false)]);
 
+const OverrideRulesSchema = z
+  .object({
+    detect_files: RuleConfigOrArraySchema.optional(),
+    require_files: RuleConfigOrArraySchema.optional(),
+    forbid_packages: RuleConfigOrArraySchema.optional(),
+    require_packages: RuleConfigOrArraySchema.optional(),
+    require_scripts: RuleConfigOrArraySchema.optional(),
+    require_package_fields: PackageFieldRuleOrArraySchema.optional(),
+    forbid_package_fields: PackageFieldRuleOrArraySchema.optional(),
+    engine_version: z
+      .union([EngineVersionRuleSchema, z.array(EngineVersionRuleSchema)])
+      .optional(),
+    codeowners: CodeownersRuleSchema.optional(),
+  })
+  .default(() => ({}));
+
+const OverrideSchema = z.object({
+  /** Micromatch patterns checked against the current repo's package.json "name" */
+  match: z.array(z.string()).min(1),
+  rules: OverrideRulesSchema,
+});
+
 // ── Main schema with defaults ──────────────────────────────────────────────────
 
 export const HermexConfigSchema = z.object({
@@ -58,6 +80,14 @@ export const HermexConfigSchema = z.object({
   versus: z
     .array(z.object({ name: z.string(), packages: z.array(z.string()).min(2) }))
     .default([]),
+
+  /**
+   * Repo-scoped rule additions: when the current repo's package.json "name"
+   * matches an entry's `match` patterns, its `rules` are merged (additively)
+   * into the base `rules` below — lets one shared config apply extra rules
+   * to only a subset of repos, e.g. a mandatory dependency for 30 of 150 apps.
+   */
+  overrides: z.array(OverrideSchema).default([]),
 
   rules: z
     .object({
@@ -164,6 +194,7 @@ export type CodeownersRule = z.infer<typeof CodeownersRuleSchema>;
 export type PackagesConfig = HermexConfig['packages'];
 export type VersusConfig = HermexConfig['versus'][number];
 export type RulesConfig = HermexConfig['rules'];
+export type OverrideConfig = HermexConfig['overrides'][number];
 export type OutputConfig = HermexConfig['output'];
 export type ReleaseAgeConfig = HermexConfig['releaseAge'];
 export type ReleaseAgeThresholds = HermexConfig['releaseAge']['thresholds'];

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,6 +10,7 @@ export type {
   PackagesConfig,
   VersusConfig,
   RulesConfig,
+  OverrideConfig,
   OutputConfig,
   ReleaseAgeConfig,
   ReleaseAgeThresholds,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   PackagesConfig,
   VersusConfig,
   RulesConfig,
+  OverrideConfig,
   OutputConfig,
   ReleaseAgeConfig,
   ReleaseAgeThresholds,

--- a/tests/config/overrides.test.ts
+++ b/tests/config/overrides.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { applyOverrides } from '../../src/config/overrides';
+import { HermexConfigSchema } from '../../src/config/schema';
+import type { HermexConfigInput } from '../../src/config/schema';
+
+/** Parse a partial config through the real schema so all defaults apply. */
+function createConfig(input: HermexConfigInput = {}) {
+  return HermexConfigSchema.parse(input);
+}
+
+function makeRepo(name: string, pkg: Record<string, unknown> = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hermex-overrides-test-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, ...pkg }));
+  return dir;
+}
+
+describe('applyOverrides', () => {
+  let dirs: string[];
+
+  beforeAll(() => {
+    dirs = [];
+  });
+
+  afterAll(() => {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function repo(name: string, pkg: Record<string, unknown> = {}): string {
+    const dir = makeRepo(name, pkg);
+    dirs.push(dir);
+    return dir;
+  }
+
+  it('merges an override into base rules when the repo name matches', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['typescript'] }],
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_packages).toEqual([
+      { severity: 'error', patterns: ['typescript'] },
+      { severity: 'error', patterns: ['@acme/shell'] },
+    ]);
+  });
+
+  it('leaves rules untouched when the repo name does not match', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['typescript'] }],
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/marketing-site'));
+
+    expect(result.rules.require_packages).toEqual([
+      { severity: 'error', patterns: ['typescript'] },
+    ]);
+  });
+
+  it('applies every matching override, in order, when more than one matches', () => {
+    const config = createConfig({
+      overrides: [
+        {
+          match: ['@acme/*'],
+          rules: {
+            require_packages: [{ severity: 'warn', patterns: ['eslint'] }],
+          },
+        },
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_packages).toEqual([
+      { severity: 'warn', patterns: ['eslint'] },
+      { severity: 'error', patterns: ['@acme/shell'] },
+    ]);
+  });
+
+  it('matches via glob patterns, not just exact names', () => {
+    const config = createConfig({
+      overrides: [
+        {
+          match: ['@acme/shell-consumer-*'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/shell-consumer-web'));
+
+    expect(result.rules.require_packages).toEqual([
+      { severity: 'error', patterns: ['@acme/shell'] },
+    ]);
+  });
+
+  it('is a no-op when there are no overrides configured', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['typescript'] }],
+      },
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result).toBe(config);
+  });
+
+  it('is a no-op when the repo has no package.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hermex-overrides-test-'));
+    dirs.push(dir);
+    const config = createConfig({
+      overrides: [
+        {
+          match: ['*'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, dir);
+
+    expect(result).toBe(config);
+  });
+
+  it('replaces (not merges) the single-value codeowners rule', () => {
+    const config = createConfig({
+      rules: {
+        codeowners: { severity: 'warn' },
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            codeowners: {
+              severity: 'error',
+              requiredOwners: ['@acme/platform-team'],
+            },
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.codeowners).toEqual({
+      severity: 'error',
+      requiredOwners: ['@acme/platform-team'],
+    });
+  });
+});

--- a/tests/config/overrides.test.ts
+++ b/tests/config/overrides.test.ts
@@ -165,6 +165,242 @@ describe('applyOverrides', () => {
     expect(result).toBe(config);
   });
 
+  it('is a no-op when package.json has no "name" field', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hermex-overrides-test-'));
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ version: '1.0.0' }),
+    );
+    dirs.push(dir);
+    const config = createConfig({
+      overrides: [
+        {
+          match: ['*'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, dir);
+
+    expect(result).toBe(config);
+  });
+
+  it('merges onto a base rule authored as a single object, not an array', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: { severity: 'error', patterns: ['typescript'] },
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_packages).toEqual([
+      { severity: 'error', patterns: ['typescript'] },
+      { severity: 'error', patterns: ['@acme/shell'] },
+    ]);
+  });
+
+  it('merges an override rule authored as an array of multiple rules', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['typescript'] }],
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_packages: [
+              { severity: 'error', patterns: ['@acme/shell'] },
+              { severity: 'warn', patterns: ['@acme/telemetry'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_packages).toEqual([
+      { severity: 'error', patterns: ['typescript'] },
+      { severity: 'error', patterns: ['@acme/shell'] },
+      { severity: 'warn', patterns: ['@acme/telemetry'] },
+    ]);
+  });
+
+  it('merges detect_files', () => {
+    const config = createConfig({
+      rules: {
+        detect_files: [{ severity: 'error', patterns: ['jest.config.*'] }],
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            detect_files: [{ severity: 'warn', patterns: ['.babelrc'] }],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.detect_files).toEqual([
+      { severity: 'error', patterns: ['jest.config.*'] },
+      { severity: 'warn', patterns: ['.babelrc'] },
+    ]);
+  });
+
+  it('merges require_files', () => {
+    const config = createConfig({
+      rules: { require_files: [{ severity: 'error', patterns: ['.nvmrc'] }] },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_files: [{ severity: 'warn', patterns: ['.editorconfig'] }],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_files).toEqual([
+      { severity: 'error', patterns: ['.nvmrc'] },
+      { severity: 'warn', patterns: ['.editorconfig'] },
+    ]);
+  });
+
+  it('merges forbid_packages', () => {
+    const config = createConfig({
+      rules: { forbid_packages: [{ severity: 'error', patterns: ['moment'] }] },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            forbid_packages: [{ severity: 'warn', patterns: ['lodash'] }],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.forbid_packages).toEqual([
+      { severity: 'error', patterns: ['moment'] },
+      { severity: 'warn', patterns: ['lodash'] },
+    ]);
+  });
+
+  it('merges require_scripts', () => {
+    const config = createConfig({
+      rules: { require_scripts: [{ severity: 'error', patterns: ['build'] }] },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_scripts: [{ severity: 'warn', patterns: ['test'] }],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_scripts).toEqual([
+      { severity: 'error', patterns: ['build'] },
+      { severity: 'warn', patterns: ['test'] },
+    ]);
+  });
+
+  it('merges require_package_fields', () => {
+    const config = createConfig({
+      rules: {
+        require_package_fields: [{ severity: 'error', patterns: ['license'] }],
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            require_package_fields: [
+              { severity: 'warn', patterns: ['repository'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.require_package_fields).toEqual([
+      { severity: 'error', patterns: ['license'] },
+      { severity: 'warn', patterns: ['repository'] },
+    ]);
+  });
+
+  it('merges forbid_package_fields', () => {
+    const config = createConfig({
+      rules: {
+        forbid_package_fields: [
+          { severity: 'error', patterns: ['scripts.preinstall'] },
+        ],
+      },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            forbid_package_fields: [
+              { severity: 'warn', patterns: ['scripts.postinstall'] },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.forbid_package_fields).toEqual([
+      { severity: 'error', patterns: ['scripts.preinstall'] },
+      { severity: 'warn', patterns: ['scripts.postinstall'] },
+    ]);
+  });
+
+  it('merges engine_version', () => {
+    const config = createConfig({
+      rules: { engine_version: { severity: 'error', range: '>=18' } },
+      overrides: [
+        {
+          match: ['@acme/checkout'],
+          rules: {
+            engine_version: { severity: 'warn', range: '>=20' },
+          },
+        },
+      ],
+    });
+
+    const result = applyOverrides(config, repo('@acme/checkout'));
+
+    expect(result.rules.engine_version).toEqual([
+      { severity: 'error', range: '>=18' },
+      { severity: 'warn', range: '>=20' },
+    ]);
+  });
+
   it('replaces (not merges) the single-value codeowners rule', () => {
     const config = createConfig({
       rules: {
@@ -189,5 +425,25 @@ describe('applyOverrides', () => {
       severity: 'error',
       requiredOwners: ['@acme/platform-team'],
     });
+  });
+});
+
+describe('overrides schema validation', () => {
+  it('rejects an override with an empty match list', () => {
+    expect(() =>
+      HermexConfigSchema.parse({
+        overrides: [{ match: [], rules: {} }],
+      }),
+    ).toThrow();
+  });
+
+  it('accepts an override with no rules configured (parses to an empty rules object)', () => {
+    const config = createConfig({
+      overrides: [{ match: ['@acme/checkout'] }],
+    });
+
+    expect(config.overrides).toEqual([
+      { match: ['@acme/checkout'], rules: {} },
+    ]);
   });
 });

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -448,4 +448,16 @@ describe('rule overrides (repo-scoped rules)', () => {
     expect(messages).toContain('base rule');
     expect(messages).not.toContain('override rule');
   });
+
+  it('applies overrides when the config is discovered from cwd, not passed via --config', () => {
+    const cwd = join(ROOT, 'tests', 'e2e', 'overrides-fixture'); // has its own hermex.config.ts
+    const result = run(['comply', '--format', 'json'], cwd);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    const messages = parsed.ruleViolations.map(
+      (v: { message?: string }) => v.message,
+    );
+    expect(messages).toContain('base rule');
+    expect(messages).toContain('override rule');
+  });
 });

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -415,3 +415,37 @@ describe('comply command', () => {
     }
   });
 });
+
+describe('rule overrides (repo-scoped rules)', () => {
+  const configPath = join(ROOT, 'tests', 'e2e', 'hermex-overrides.config.ts');
+
+  it('applies the override rule on top of the base rule when the repo package.json name matches', () => {
+    const cwd = join(ROOT, 'tests', 'e2e', 'overrides-fixture'); // package.json name: @acme/checkout
+    const result = run(
+      ['comply', '--config', configPath, '--format', 'json'],
+      cwd,
+    );
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    const messages = parsed.ruleViolations.map(
+      (v: { message?: string }) => v.message,
+    );
+    expect(messages).toContain('base rule');
+    expect(messages).toContain('override rule');
+  });
+
+  it('does not apply the override rule when the repo package.json name does not match', () => {
+    const cwd = join(ROOT, 'tests', 'e2e', 'overrides-fixture-other'); // package.json name: @acme/other-app
+    const result = run(
+      ['comply', '--config', configPath, '--format', 'json'],
+      cwd,
+    );
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    const messages = parsed.ruleViolations.map(
+      (v: { message?: string }) => v.message,
+    );
+    expect(messages).toContain('base rule');
+    expect(messages).not.toContain('override rule');
+  });
+});

--- a/tests/e2e/hermex-overrides.config.ts
+++ b/tests/e2e/hermex-overrides.config.ts
@@ -1,0 +1,25 @@
+export default {
+  rules: {
+    require_packages: [
+      {
+        severity: 'error',
+        patterns: ['some-base-required-pkg'],
+        message: 'base rule',
+      },
+    ],
+  },
+  overrides: [
+    {
+      match: ['@acme/checkout'],
+      rules: {
+        require_packages: [
+          {
+            severity: 'error',
+            patterns: ['@acme/shell'],
+            message: 'override rule',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/e2e/overrides-fixture-other/package.json
+++ b/tests/e2e/overrides-fixture-other/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@acme/other-app"
+}

--- a/tests/e2e/overrides-fixture-other/pnpm-lock.yaml
+++ b/tests/e2e/overrides-fixture-other/pnpm-lock.yaml
@@ -1,0 +1,19 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+
+packages:
+
+  react@18.3.1:
+    resolution: {integrity: sha512-mock}
+    engines: {node: '>=0.10.0'}

--- a/tests/e2e/overrides-fixture-other/src/index.ts
+++ b/tests/e2e/overrides-fixture-other/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = 1;

--- a/tests/e2e/overrides-fixture/hermex.config.ts
+++ b/tests/e2e/overrides-fixture/hermex.config.ts
@@ -1,0 +1,25 @@
+export default {
+  rules: {
+    require_packages: [
+      {
+        severity: 'error',
+        patterns: ['some-base-required-pkg'],
+        message: 'base rule',
+      },
+    ],
+  },
+  overrides: [
+    {
+      match: ['@acme/checkout'],
+      rules: {
+        require_packages: [
+          {
+            severity: 'error',
+            patterns: ['@acme/shell'],
+            message: 'override rule',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/e2e/overrides-fixture/package.json
+++ b/tests/e2e/overrides-fixture/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@acme/checkout"
+}

--- a/tests/e2e/overrides-fixture/pnpm-lock.yaml
+++ b/tests/e2e/overrides-fixture/pnpm-lock.yaml
@@ -1,0 +1,19 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+
+packages:
+
+  react@18.3.1:
+    resolution: {integrity: sha512-mock}
+    engines: {node: '>=0.10.0'}

--- a/tests/e2e/overrides-fixture/src/index.ts
+++ b/tests/e2e/overrides-fixture/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = 1;


### PR DESCRIPTION
## Summary
- Adds an `overrides` config field: entries `{ match, rules }` where `match` (micromatch patterns) is checked against the current repo's `package.json` "name". Matching entries merge their `rules` additively into the base `rules`.
- Lets one shared `hermex.config.ts` add rules (e.g. a mandatory `require_packages` dependency) to only a whitelisted subset of repos, instead of forking the config per repo.
- `require_packages` (already existing) is the "mandatory dependency" rule this pairs with — no changes needed there.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test:ci` (514 tests passing, including new unit tests in `tests/config/overrides.test.ts` and e2e tests in `tests/e2e/cli.test.ts` covering matching/non-matching repos)
- [x] `pnpm run lint` / `pnpm run format:ci`
- [x] Docs updated in `docs/examples.md` with a worked example

🤖 Generated with [Claude Code](https://claude.com/claude-code)