### PR TITLE
fix: unify package inventory so every rule sees the same package list (#75)

### DIFF
--- a/docs-templates/__examples.md
+++ b/docs-templates/__examples.md
@@ -139,11 +139,14 @@ export default defineConfig({
 });
 ```
 
-`forbid_packages` matches a package that is either imported in your scanned source **or** declared in
-`package.json` under `dependencies`, `devDependencies`, `peerDependencies` or `optionalDependencies`.
-Build-only tooling that is never imported — something run via `npx`, an npm script or a git hook — is
-covered, so there is no need to spell it out as `forbid_package_fields: ['dependencies.x', 'devDependencies.x']`.
-Packages excluded by `packages.ignore` are never flagged.
+`forbid_packages` matches any package your repo owns — one that is imported in your scanned source,
+declared in `package.json` (`dependencies`, `devDependencies`, `peerDependencies` or
+`optionalDependencies`), **or** recorded as a direct dependency by your lockfile. Build-only tooling
+that is never imported — something run via `npx`, an npm script or a git hook — is covered, so there is
+no need to spell it out as `forbid_package_fields: ['dependencies.x', 'devDependencies.x']`.
+
+Purely transitive dependencies are never flagged: they arrive through another package, so removing one
+isn't something your repo can do. Packages excluded by `packages.ignore` are never flagged either.
 
 Every banned package appears in the Rules and Compliance sections. Those with measured usage also get a
 `[BANNED]` or `[RESTRICTED]` badge in the packages table; a declared-but-unused package has no row there.

--- a/docs-templates/__examples.md
+++ b/docs-templates/__examples.md
@@ -52,6 +52,10 @@ export default defineConfig({
 
 Internal packages show an `[int]` badge in the packages table.
 
+`ignore` is a *reporting* filter, not an uninstall: an ignored package is left out of the packages
+table and is never flagged by `forbid_packages`, but it still counts as installed for
+`require_packages` — otherwise ignoring a package would make a rule that requires it start failing.
+
 ## Versus — Migration Tracking
 
 Track usage split between competing packages:

--- a/docs-templates/__examples.md
+++ b/docs-templates/__examples.md
@@ -135,7 +135,14 @@ export default defineConfig({
 });
 ```
 
-Banned packages get a `[BANNED]` or `[RESTRICTED]` badge in the packages table and appear in the Compliance section.
+`forbid_packages` matches a package that is either imported in your scanned source **or** declared in
+`package.json` under `dependencies`, `devDependencies`, `peerDependencies` or `optionalDependencies`.
+Build-only tooling that is never imported — something run via `npx`, an npm script or a git hook — is
+covered, so there is no need to spell it out as `forbid_package_fields: ['dependencies.x', 'devDependencies.x']`.
+Packages excluded by `packages.ignore` are never flagged.
+
+Every banned package appears in the Rules and Compliance sections. Those with measured usage also get a
+`[BANNED]` or `[RESTRICTED]` badge in the packages table; a declared-but-unused package has no row there.
 
 ### Script and Field Requirements
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -245,7 +245,14 @@ export default defineConfig({
 });
 ```
 
-Banned packages get a `[BANNED]` or `[RESTRICTED]` badge in the packages table and appear in the Compliance section.
+`forbid_packages` matches a package that is either imported in your scanned source **or** declared in
+`package.json` under `dependencies`, `devDependencies`, `peerDependencies` or `optionalDependencies`.
+Build-only tooling that is never imported — something run via `npx`, an npm script or a git hook — is
+covered, so there is no need to spell it out as `forbid_package_fields: ['dependencies.x', 'devDependencies.x']`.
+Packages excluded by `packages.ignore` are never flagged.
+
+Every banned package appears in the Rules and Compliance sections. Those with measured usage also get a
+`[BANNED]` or `[RESTRICTED]` badge in the packages table; a declared-but-unused package has no row there.
 
 ### CODEOWNERS Rule
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -52,6 +52,10 @@ export default defineConfig({
 
 Internal packages show an `[int]` badge in the packages table.
 
+`ignore` is a *reporting* filter, not an uninstall: an ignored package is left out of the packages
+table and is never flagged by `forbid_packages`, but it still counts as installed for
+`require_packages` — otherwise ignoring a package would make a rule that requires it start failing.
+
 ## Versus — Migration Tracking
 
 Track usage split between competing packages:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -249,11 +249,14 @@ export default defineConfig({
 });
 ```
 
-`forbid_packages` matches a package that is either imported in your scanned source **or** declared in
-`package.json` under `dependencies`, `devDependencies`, `peerDependencies` or `optionalDependencies`.
-Build-only tooling that is never imported — something run via `npx`, an npm script or a git hook — is
-covered, so there is no need to spell it out as `forbid_package_fields: ['dependencies.x', 'devDependencies.x']`.
-Packages excluded by `packages.ignore` are never flagged.
+`forbid_packages` matches any package your repo owns — one that is imported in your scanned source,
+declared in `package.json` (`dependencies`, `devDependencies`, `peerDependencies` or
+`optionalDependencies`), **or** recorded as a direct dependency by your lockfile. Build-only tooling
+that is never imported — something run via `npx`, an npm script or a git hook — is covered, so there is
+no need to spell it out as `forbid_package_fields: ['dependencies.x', 'devDependencies.x']`.
+
+Purely transitive dependencies are never flagged: they arrive through another package, so removing one
+isn't something your repo can do. Packages excluded by `packages.ignore` are never flagged either.
 
 Every banned package appears in the Rules and Compliance sections. Those with measured usage also get a
 `[BANNED]` or `[RESTRICTED]` badge in the packages table; a declared-but-unused package has no row there.

--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hermex-fixtures",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Fixture manifest. Paired with pnpm-lock.yaml so the fixtures cover every package-inventory axis: declared+installed+used (@design-system/foundation, react), declared+installed but never imported (moment — the forbid_packages case from #75), declared but not installed (eslint — a manifest/lockfile mismatch, which forbid_packages flags but require_packages does not accept as satisfied), a root dependency the lockfile knows about but this manifest omits (react-dom), and installed transitively only (js-tokens).",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "echo fixture-build",
+    "test": "echo fixture-test"
+  },
+  "dependencies": {
+    "@design-system/foundation": "^2.0.0",
+    "react": "^18.3.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0",
+    "moment": "^2.29.4"
+  }
+}

--- a/fixtures/pnpm-lock.yaml
+++ b/fixtures/pnpm-lock.yaml
@@ -17,6 +17,10 @@ importers:
       react-dom:
         specifier: ^18.3.0
         version: 18.3.1
+    devDependencies:
+      moment:
+        specifier: ^2.29.4
+        version: 2.29.4
 
 packages:
 
@@ -31,3 +35,15 @@ packages:
     resolution: {integrity: sha512-mock}
     peerDependencies:
       react: ^18.3.1
+
+  # Declared in package.json (devDependencies) and installed, but never
+  # imported by any fixture source file — the #75 case: invisible to import
+  # analysis, still forbidden by fixtures/hermex.config.ts.
+  moment@2.29.4:
+    resolution: {integrity: sha512-mock}
+
+  # Present only under `packages` and never in `importers`, i.e. pulled in by
+  # another dependency. Purely transitive: nothing this repo declares, so
+  # forbid_packages must not flag it.
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-mock}

--- a/src/commands/pipeline.ts
+++ b/src/commands/pipeline.ts
@@ -9,6 +9,7 @@ import { printErrors } from '../utils/print-errors';
 import { findFiles } from '../utils/file-utils';
 import { findAndParseLockfile } from '../lock-parser';
 import { evaluateRules } from '../rules/evaluator';
+import { collectDeclaredPackages } from '../rules/shared';
 import { enrichWithReleaseAge } from '../npm-registry/enricher';
 import { applyOverrides } from '../config/overrides';
 import type { HermexConfig } from '../config/types';
@@ -36,6 +37,7 @@ export async function runPipeline(
   const resolvedConfig = applyOverrides(config, process.cwd());
 
   const lockfileResult = findAndParseLockfile(process.cwd());
+  const declaredPackages = collectDeclaredPackages(process.cwd());
 
   spinner.succeed(
     chalk.blue(
@@ -95,6 +97,7 @@ export async function runPipeline(
     resolvedConfig,
     lockfileResult.multiVersions,
     lockfileResult.resolutions,
+    declaredPackages,
   );
 
   const evaluatorViolations = evaluateRules(

--- a/src/rules/__type-tests__/off-severity.type-test.ts
+++ b/src/rules/__type-tests__/off-severity.type-test.ts
@@ -42,7 +42,7 @@ evaluateEngineVersion('.', resolvedRules);
 evaluateCodeowners('.', resolvedRules, []);
 evaluateRules('.', resolvedRules, []);
 detectBannedPackages([], resolvedConfig);
-detectRequiredPackages([], {}, resolvedConfig);
+detectRequiredPackages([], resolvedConfig);
 
 // Per-boundary checks: an unresolved RulesConfig/HermexConfig (which may
 // still contain 'off' or bare-object rule fields) must be rejected at every
@@ -64,4 +64,4 @@ evaluateRules('.', wideRules, []);
 // @ts-expect-error — detectBannedPackages must require ResolvedHermexConfig
 detectBannedPackages([], wideConfig);
 // @ts-expect-error — detectRequiredPackages must require ResolvedHermexConfig
-detectRequiredPackages([], {}, wideConfig);
+detectRequiredPackages([], wideConfig);

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -91,7 +91,11 @@ export function collectDeclaredPackages(repoPath: string): DeclaredPackages {
   const pkg = readPackageJson(repoPath);
   if (!pkg) return {};
 
-  const declared: DeclaredPackages = {};
+  // Null prototype: dependency names come from an untrusted manifest, and a
+  // key like `__proto__` on a plain object literal would hit the prototype
+  // setter instead of creating an own property — silently dropping the
+  // package here, and mutating the object's prototype.
+  const declared: DeclaredPackages = Object.create(null) as DeclaredPackages;
   for (const field of DEPENDENCY_FIELDS) {
     const bucket = pkg[field];
     // The manifest is untyped user input — a malformed bucket (a string, an
@@ -99,7 +103,8 @@ export function collectDeclaredPackages(repoPath: string): DeclaredPackages {
     if (typeof bucket !== 'object' || bucket === null || Array.isArray(bucket))
       continue;
     for (const name of Object.keys(bucket)) {
-      (declared[name] ??= []).push(field);
+      declared[name] ??= [];
+      declared[name].push(field);
     }
   }
   return declared;

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -1,6 +1,10 @@
 import { globSync } from 'glob';
 import fs from 'fs';
 import path from 'path';
+import type {
+  DeclaredPackages,
+  DependencyBucket,
+} from '../utils/package-inventory';
 
 export interface RuleViolation {
   type:
@@ -69,32 +73,34 @@ export function readPackageJson(
   }
 }
 
-const DEPENDENCY_FIELDS = [
+const DEPENDENCY_FIELDS: DependencyBucket[] = [
   'dependencies',
   'devDependencies',
   'peerDependencies',
   'optionalDependencies',
-] as const;
+];
 
 /**
- * Every package name the repo itself declares in `package.json`, deduped
- * across all four dependency buckets. Distinct from the lockfile `versions`
- * map, which also contains every transitive dependency — this is only what
- * the repo can actually add or remove, which is what a "this package is
- * forbidden here" rule should act on (#75).
+ * The *declared* axis of the package inventory: every package this repo
+ * lists in `package.json`, with the bucket(s) that declare it.
+ *
+ * Distinct from the lockfile, which also contains every transitive
+ * dependency — this is only what the repo can actually add or remove.
  */
-export function collectDeclaredPackages(repoPath: string): string[] {
+export function collectDeclaredPackages(repoPath: string): DeclaredPackages {
   const pkg = readPackageJson(repoPath);
-  if (!pkg) return [];
+  if (!pkg) return {};
 
-  const names = new Set<string>();
+  const declared: DeclaredPackages = {};
   for (const field of DEPENDENCY_FIELDS) {
     const bucket = pkg[field];
     // The manifest is untyped user input — a malformed bucket (a string, an
     // array, null) must not take the whole scan down.
     if (typeof bucket !== 'object' || bucket === null || Array.isArray(bucket))
       continue;
-    for (const name of Object.keys(bucket)) names.add(name);
+    for (const name of Object.keys(bucket)) {
+      (declared[name] ??= []).push(field);
+    }
   }
-  return [...names];
+  return declared;
 }

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -68,3 +68,33 @@ export function readPackageJson(
     return null;
   }
 }
+
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+/**
+ * Every package name the repo itself declares in `package.json`, deduped
+ * across all four dependency buckets. Distinct from the lockfile `versions`
+ * map, which also contains every transitive dependency — this is only what
+ * the repo can actually add or remove, which is what a "this package is
+ * forbidden here" rule should act on (#75).
+ */
+export function collectDeclaredPackages(repoPath: string): string[] {
+  const pkg = readPackageJson(repoPath);
+  if (!pkg) return [];
+
+  const names = new Set<string>();
+  for (const field of DEPENDENCY_FIELDS) {
+    const bucket = pkg[field];
+    // The manifest is untyped user input — a malformed bucket (a string, an
+    // array, null) must not take the whole scan down.
+    if (typeof bucket !== 'object' || bucket === null || Array.isArray(bucket))
+      continue;
+    for (const name of Object.keys(bucket)) names.add(name);
+  }
+  return [...names];
+}

--- a/src/utils/aggregator-core.ts
+++ b/src/utils/aggregator-core.ts
@@ -39,6 +39,7 @@ export function aggregateReports(
   config?: ResolvedHermexConfig,
   multiVersions: MultiVersionMap = {},
   resolutions: LockfileResolutionMap = {},
+  declaredPackages: string[] = [],
 ): AggregatedReport {
   const componentUsageMap = new Map<string, ComponentUsage>();
   let totalImports = 0;
@@ -125,6 +126,7 @@ export function aggregateReports(
   const bannedPackageViolations = detectBannedPackages(
     packageDistribution,
     config,
+    declaredPackages,
   );
 
   const requiredPackageViolations = detectRequiredPackages(

--- a/src/utils/aggregator-core.ts
+++ b/src/utils/aggregator-core.ts
@@ -10,6 +10,11 @@ import {
   calculatePackageDistribution,
   findComponentSource,
 } from './package-distribution';
+import type {
+  DeclaredPackages,
+  PackageInventoryEntry,
+} from './package-inventory';
+import { buildPackageInventory } from './package-inventory';
 import type { BannedPackageViolation } from './package-rules';
 import { detectBannedPackages, detectRequiredPackages } from './package-rules';
 import type { PatternCount } from './pattern-counter';
@@ -26,6 +31,8 @@ export interface AggregatedReport {
   componentUsage: Map<string, ComponentUsage>;
   topComponents: ComponentUsage[];
   allComponents: string[];
+  /** Every package known to this run, on all three axes — the list every rule and view below is derived from. */
+  packageInventory: PackageInventoryEntry[];
   packageDistribution: PackageDistribution[];
   versusResults: VersusResult[];
   ruleViolations: RuleViolation[];
@@ -39,7 +46,7 @@ export function aggregateReports(
   config?: ResolvedHermexConfig,
   multiVersions: MultiVersionMap = {},
   resolutions: LockfileResolutionMap = {},
-  declaredPackages: string[] = [],
+  declaredPackages: DeclaredPackages = {},
 ): AggregatedReport {
   const componentUsageMap = new Map<string, ComponentUsage>();
   let totalImports = 0;
@@ -111,12 +118,20 @@ export function aggregateReports(
     }))
     .sort((a, b) => b.count - a.count);
 
-  const packageDistribution = calculatePackageDistribution(
-    componentUsageMap,
+  // Built once, here: every package rule and every reported view below
+  // reads this same list, differing only in which axis it selects.
+  const packageInventory = buildPackageInventory({
     versions,
-    config,
     multiVersions,
     resolutions,
+    declared: declaredPackages,
+    componentUsage: componentUsageMap,
+    config,
+  });
+
+  const packageDistribution = calculatePackageDistribution(
+    packageInventory,
+    config,
   );
 
   const versusResults = calculateVersusResults(
@@ -124,14 +139,12 @@ export function aggregateReports(
     config?.versus ?? [],
   );
   const bannedPackageViolations = detectBannedPackages(
-    packageDistribution,
+    packageInventory,
     config,
-    declaredPackages,
   );
 
   const requiredPackageViolations = detectRequiredPackages(
-    packageDistribution,
-    versions,
+    packageInventory,
     config,
   );
 
@@ -144,6 +157,7 @@ export function aggregateReports(
     componentUsage: componentUsageMap,
     topComponents,
     allComponents,
+    packageInventory,
     packageDistribution,
     versusResults,
     ruleViolations: requiredPackageViolations,

--- a/src/utils/aggregator.ts
+++ b/src/utils/aggregator.ts
@@ -1,5 +1,6 @@
 export * from './aggregator-core';
 export * from './package-distribution';
+export * from './package-inventory';
 export * from './package-rules';
 export * from './pattern-counter';
 export * from './versus';

--- a/src/utils/package-distribution.ts
+++ b/src/utils/package-distribution.ts
@@ -3,7 +3,7 @@ import type { UsageReport } from '../swc-parser';
 import type { ResolvedHermexConfig } from '../config/types';
 import type { ReleaseAgeEntry } from '../npm-registry/types';
 import type { PackageInventoryEntry } from './package-inventory';
-import { isUsed } from './package-inventory';
+import { isInstalled, isUsed } from './package-inventory';
 
 export type { ComponentUsage } from './package-inventory';
 
@@ -112,8 +112,13 @@ export function calculatePackageDistribution(
     .filter((entry) => {
       if (entry.ignored) return false;
       if (isUsed(entry)) return true;
+      // Installed-only: a package that is merely *declared* (in package.json
+      // but absent from the lockfile) has no resolved version to compare a
+      // release date against, so surfacing it here would add a versionless
+      // row to the packages table that release-age enrichment then skips.
       return (
         enforcesUnusedPackages &&
+        isInstalled(entry) &&
         micromatch.isMatch(entry.packageName, enforceOnPatterns)
       );
     })

--- a/src/utils/package-distribution.ts
+++ b/src/utils/package-distribution.ts
@@ -1,15 +1,11 @@
 import micromatch from 'micromatch';
 import type { UsageReport } from '../swc-parser';
-import type { HermexConfig } from '../config/types';
-import type { LockfileResolutionMap, MultiVersionMap } from '../lock-parser';
+import type { ResolvedHermexConfig } from '../config/types';
 import type { ReleaseAgeEntry } from '../npm-registry/types';
+import type { PackageInventoryEntry } from './package-inventory';
+import { isUsed } from './package-inventory';
 
-export interface ComponentUsage {
-  name: string;
-  source: string;
-  count: number;
-  files: Set<string>;
-}
+export type { ComponentUsage } from './package-inventory';
 
 export interface PackageDistribution {
   packageName: string;
@@ -89,150 +85,51 @@ export function findComponentSource(
   return 'unknown';
 }
 
-function getPackageVersion(
-  packageName: string,
-  versions: Record<string, string>,
-): string | null {
-  if (versions[packageName]) return versions[packageName];
-
-  if (packageName.includes('/')) {
-    const parts = packageName.split('/');
-    if (packageName.startsWith('@') && parts.length > 2) {
-      const basePackage = `${parts[0]}/${parts[1]}`;
-      if (versions[basePackage]) return versions[basePackage];
-    }
-    if (!packageName.startsWith('@') && parts.length > 1) {
-      if (versions[parts[0]]) return versions[parts[0]];
-    }
-  }
-
-  return null;
-}
-
-// Same base-package fallback as getPackageVersion (a subpath import like
-// `@scope/pkg/sub` resolves to `@scope/pkg`'s data), but reading the true
-// root/direct-dependency version from the lockfile layer's resolutions
-// rather than the `rootVersion ?? maxSemver(allVersions)` fallback baked
-// into `versions`. `null` here (as opposed to `versions` being silently
-// absent) is the signal `scope: 'root'` needs to correctly decline to
-// enforce a package that was never a direct dependency in the first place.
-function getRootVersion(
-  packageName: string,
-  resolutions: LockfileResolutionMap,
-): string | null {
-  if (resolutions[packageName]) return resolutions[packageName].rootVersion;
-
-  if (packageName.includes('/')) {
-    const parts = packageName.split('/');
-    if (packageName.startsWith('@') && parts.length > 2) {
-      const basePackage = `${parts[0]}/${parts[1]}`;
-      if (resolutions[basePackage]) return resolutions[basePackage].rootVersion;
-    }
-    if (!packageName.startsWith('@') && parts.length > 1) {
-      if (resolutions[parts[0]]) return resolutions[parts[0]].rootVersion;
-    }
-  }
-
-  return null;
-}
-
+/**
+ * The reported view of the package inventory: what the packages table, the
+ * JSON `packages[]` array and release-age enrichment operate on.
+ *
+ * Selects the *used* axis — a package with no measured usage has nothing to
+ * report a percentage or component list for. The one exception is
+ * `releaseAge.enforceOn`: a dependency can be installed and explicitly
+ * enforced yet never imported as a component (a CSS/side-effect-only import
+ * like `import '@acme-ui/pulse-styles/button.css'` has no specifiers, so the
+ * usage scan never sees it), and dropping it here would silently exempt it
+ * from compliance. Those are surfaced with zero usage/component counts.
+ * Scoped to `enforceOn` matches rather than the whole inventory so a default
+ * (empty) `enforceOn` does not fire a registry lookup for every transitive
+ * dependency.
+ */
 export function calculatePackageDistribution(
-  componentUsageMap: Map<string, ComponentUsage>,
-  versions: Record<string, string>,
-  config?: HermexConfig,
-  multiVersions: MultiVersionMap = {},
-  resolutions: LockfileResolutionMap = {},
+  inventory: PackageInventoryEntry[],
+  config?: ResolvedHermexConfig,
 ): PackageDistribution[] {
-  const ignorePatterns = config?.packages.ignore ?? [];
-  const internalPatterns = config?.packages.internal ?? [];
-
-  const packageMap = new Map<string, PackageDistribution>();
-
-  for (const component of componentUsageMap.values()) {
-    if (component.source === 'unknown' || component.source === 'local')
-      continue;
-
-    if (
-      ignorePatterns.length > 0 &&
-      micromatch.isMatch(component.source, ignorePatterns)
-    ) {
-      continue;
-    }
-
-    const existing = packageMap.get(component.source);
-    if (existing) {
-      existing.componentCount++;
-      existing.usageCount += component.count;
-      existing.components.push(component.name);
-    } else {
-      const isInternal =
-        internalPatterns.length > 0
-          ? micromatch.isMatch(component.source, internalPatterns)
-          : false;
-
-      const allVersions = multiVersions[component.source] ?? [];
-      const hasVersionConflict = allVersions.length > 1;
-
-      packageMap.set(component.source, {
-        packageName: component.source,
-        version: getPackageVersion(component.source, versions),
-        rootVersion: getRootVersion(component.source, resolutions),
-        componentCount: 1,
-        usageCount: component.count,
-        percentage: 0,
-        components: [component.name],
-        internal: isInternal,
-        hasVersionConflict,
-        allVersions,
-      });
-    }
-  }
-
-  // A dependency can be installed and listed in the lockfile yet never
-  // imported as a component — e.g. a CSS/side-effect-only import like
-  // `import '@acme-ui/pulse-styles/button.css'` has no specifiers, so the
-  // usage scan above never sees it. That makes it invisible to releaseAge
-  // even when it's explicitly enforced. Surface any lockfile package that
-  // matches `releaseAge.enforceOn` so compliance can still see it, with
-  // zero usage/component counts. Scoped to enforceOn matches (not
-  // the whole lockfile) to avoid firing a registry lookup for every
-  // transitive dependency when enforceOn is left at its default `[]`.
   const enforceOnPatterns = config?.releaseAge.enforceOn ?? [];
-  if (config?.releaseAge.enabled && enforceOnPatterns.length > 0) {
-    for (const packageName of Object.keys(versions)) {
-      if (packageMap.has(packageName)) continue;
-      if (!micromatch.isMatch(packageName, enforceOnPatterns)) continue;
-      if (
-        ignorePatterns.length > 0 &&
-        micromatch.isMatch(packageName, ignorePatterns)
-      ) {
-        continue;
-      }
+  const enforcesUnusedPackages =
+    (config?.releaseAge.enabled ?? false) && enforceOnPatterns.length > 0;
 
-      const isInternal =
-        internalPatterns.length > 0
-          ? micromatch.isMatch(packageName, internalPatterns)
-          : false;
+  const distribution = inventory
+    .filter((entry) => {
+      if (entry.ignored) return false;
+      if (isUsed(entry)) return true;
+      return (
+        enforcesUnusedPackages &&
+        micromatch.isMatch(entry.packageName, enforceOnPatterns)
+      );
+    })
+    .map((entry) => ({
+      packageName: entry.packageName,
+      version: entry.version,
+      rootVersion: entry.rootVersion,
+      componentCount: entry.componentCount,
+      usageCount: entry.usageCount,
+      percentage: 0,
+      components: entry.components,
+      internal: entry.internal,
+      hasVersionConflict: entry.hasVersionConflict,
+      allVersions: entry.allVersions,
+    }));
 
-      const allVersions = multiVersions[packageName] ?? [];
-      const hasVersionConflict = allVersions.length > 1;
-
-      packageMap.set(packageName, {
-        packageName,
-        version: getPackageVersion(packageName, versions),
-        rootVersion: getRootVersion(packageName, resolutions),
-        componentCount: 0,
-        usageCount: 0,
-        percentage: 0,
-        components: [],
-        internal: isInternal,
-        hasVersionConflict,
-        allVersions,
-      });
-    }
-  }
-
-  const distribution = Array.from(packageMap.values());
   const totalExternalUsage = distribution.reduce(
     (sum, pkg) => sum + pkg.usageCount,
     0,
@@ -243,5 +140,7 @@ export function calculatePackageDistribution(
       totalExternalUsage > 0 ? (pkg.usageCount / totalExternalUsage) * 100 : 0;
   }
 
+  // The inventory is already usage-ordered; re-sorting keeps this view
+  // self-contained rather than silently depending on that.
   return distribution.sort((a, b) => b.usageCount - a.usageCount);
 }

--- a/src/utils/package-inventory.ts
+++ b/src/utils/package-inventory.ts
@@ -72,6 +72,18 @@ export interface BuildInventoryInput {
  */
 const NON_PACKAGE_SOURCES = new Set(['local', 'unknown']);
 
+/**
+ * Compiles a glob list once and reuses it. `micromatch.isMatch` re-parses its
+ * patterns on every call, which is fine for a handful of packages but not
+ * when the inventory spans an entire lockfile (thousands of entries × every
+ * configured pattern).
+ */
+function createGlobMatcher(patterns: string[]): (name: string) => boolean {
+  if (patterns.length === 0) return () => false;
+  const matchers = patterns.map((pattern) => micromatch.matcher(pattern));
+  return (name) => matchers.some((match) => match(name));
+}
+
 function getPackageVersion(
   packageName: string,
   versions: Record<string, string>,
@@ -142,8 +154,8 @@ export function buildPackageInventory(
     config,
   } = input;
 
-  const ignorePatterns = config?.packages.ignore ?? [];
-  const internalPatterns = config?.packages.internal ?? [];
+  const isIgnored = createGlobMatcher(config?.packages.ignore ?? []);
+  const isInternal = createGlobMatcher(config?.packages.internal ?? []);
 
   // Fold component usage up to one record per package first — several
   // components can come from the same source.
@@ -189,14 +201,8 @@ export function buildPackageInventory(
       rootVersion: getRootVersion(packageName, resolutions),
       allVersions,
       hasVersionConflict: allVersions.length > 1,
-      internal:
-        internalPatterns.length > 0
-          ? micromatch.isMatch(packageName, internalPatterns)
-          : false,
-      ignored:
-        ignorePatterns.length > 0
-          ? micromatch.isMatch(packageName, ignorePatterns)
-          : false,
+      internal: isInternal(packageName),
+      ignored: isIgnored(packageName),
       usageCount: packageUsage?.usageCount ?? 0,
       componentCount: packageUsage?.componentCount ?? 0,
       components: packageUsage?.components ?? [],
@@ -235,7 +241,21 @@ export function isInstalled(
  * Packages this repo owns — the ones it can actually add or remove. Excludes
  * purely transitive dependencies (nothing the repo can do about those short
  * of dropping the parent) and anything under `packages.ignore`.
+ *
+ * "Declared" is taken from two independent sources: `package.json`, and the
+ * lockfile's own record of the root project's direct dependencies (pnpm's
+ * `importers`, npm's root `packages` entry, yarn's ranges read back from the
+ * manifest). They normally agree, and either one alone is enough — so a repo
+ * whose manifest cannot be read still gets its direct dependencies checked,
+ * and a manifest entry missing from the lockfile is still checked too.
+ *
+ * The used axis is included because a package can be imported without being
+ * declared anywhere (a phantom dependency), and that is still the repo's to
+ * remove.
  */
 export function isOwnedByRepo(entry: PackageInventoryEntry): boolean {
-  return !entry.ignored && (isDeclared(entry) || isUsed(entry));
+  return (
+    !entry.ignored &&
+    (isDeclared(entry) || isInstalled(entry, 'root') || isUsed(entry))
+  );
 }

--- a/src/utils/package-inventory.ts
+++ b/src/utils/package-inventory.ts
@@ -1,0 +1,241 @@
+import micromatch from 'micromatch';
+import type { ResolvedHermexConfig } from '../config/types';
+import type { LockfileResolutionMap, MultiVersionMap } from '../lock-parser';
+
+/** A `package.json` field that declares dependencies. */
+export type DependencyBucket =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'peerDependencies'
+  | 'optionalDependencies';
+
+/** Package name → the manifest buckets that declare it. */
+export type DeclaredPackages = Record<string, DependencyBucket[]>;
+
+export interface ComponentUsage {
+  name: string;
+  source: string;
+  count: number;
+  files: Set<string>;
+}
+
+/**
+ * One package, with every axis hermex knows about it. A package can be
+ * present on any combination of the three:
+ *
+ * - **declared** — listed in this repo's `package.json` (`declaredIn`).
+ * - **installed** — present in the lockfile, as a direct dependency
+ *   (`rootVersion`) and/or as one or more resolved copies (`allVersions`).
+ *   This is the `root` vs `tree` distinction `releaseAge.scope` already
+ *   exposes to users.
+ * - **used** — imported by scanned source (`usageCount` > 0).
+ *
+ * A transitive dependency is installed but neither declared nor used; a
+ * build tool run via `npx` is declared and installed but not used; a phantom
+ * dependency is used but neither declared nor installed.
+ */
+export interface PackageInventoryEntry {
+  packageName: string;
+  /** Manifest buckets declaring this package; empty when undeclared. */
+  declaredIn: DependencyBucket[];
+  /** Effective installed version — `rootVersion` when known, else the highest resolved copy. `null` when not installed. */
+  version: string | null;
+  /** Version of the direct/root dependency declaration; `null` when the package is purely transitive. */
+  rootVersion: string | null;
+  /** Every resolved copy in the lockfile — the `tree` axis. */
+  allVersions: string[];
+  hasVersionConflict: boolean;
+  /** Matches `packages.internal`. */
+  internal: boolean;
+  /** Matches `packages.ignore`. Kept in the inventory rather than filtered out at construction so each consumer can decide — the packages table and forbid rules skip these, `require_packages` deliberately does not. */
+  ignored: boolean;
+  usageCount: number;
+  componentCount: number;
+  components: string[];
+}
+
+export interface BuildInventoryInput {
+  /** Effective installed version per package, from the lockfile layer. */
+  versions?: Record<string, string>;
+  multiVersions?: MultiVersionMap;
+  resolutions?: LockfileResolutionMap;
+  /** Manifest declarations, from `collectDeclaredPackages`. */
+  declared?: DeclaredPackages;
+  /** Component usage keyed by `source::component`, from the aggregator. */
+  componentUsage?: Map<string, ComponentUsage>;
+  config?: ResolvedHermexConfig;
+}
+
+/**
+ * Sources that are not packages at all — a relative import, or one that
+ * could not be resolved against any known package name.
+ */
+const NON_PACKAGE_SOURCES = new Set(['local', 'unknown']);
+
+function getPackageVersion(
+  packageName: string,
+  versions: Record<string, string>,
+): string | null {
+  if (versions[packageName]) return versions[packageName];
+
+  if (packageName.includes('/')) {
+    const parts = packageName.split('/');
+    if (packageName.startsWith('@') && parts.length > 2) {
+      const basePackage = `${parts[0]}/${parts[1]}`;
+      if (versions[basePackage]) return versions[basePackage];
+    }
+    if (!packageName.startsWith('@') && parts.length > 1) {
+      if (versions[parts[0]]) return versions[parts[0]];
+    }
+  }
+
+  return null;
+}
+
+// Same base-package fallback as getPackageVersion (a subpath import like
+// `@scope/pkg/sub` resolves to `@scope/pkg`'s data), but reading the true
+// root/direct-dependency version from the lockfile layer's resolutions
+// rather than the `rootVersion ?? maxSemver(allVersions)` fallback baked
+// into `versions`. `null` here (as opposed to `versions` being silently
+// absent) is the signal `scope: 'root'` needs to correctly decline to
+// enforce a package that was never a direct dependency in the first place.
+function getRootVersion(
+  packageName: string,
+  resolutions: LockfileResolutionMap,
+): string | null {
+  if (resolutions[packageName]) return resolutions[packageName].rootVersion;
+
+  if (packageName.includes('/')) {
+    const parts = packageName.split('/');
+    if (packageName.startsWith('@') && parts.length > 2) {
+      const basePackage = `${parts[0]}/${parts[1]}`;
+      if (resolutions[basePackage]) return resolutions[basePackage].rootVersion;
+    }
+    if (!packageName.startsWith('@') && parts.length > 1) {
+      if (resolutions[parts[0]]) return resolutions[parts[0]].rootVersion;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The single list of packages every downstream consumer reads.
+ *
+ * Before this existed, each feature answered "what packages are in this
+ * repo?" for itself — the packages table and `forbid_packages` from import
+ * analysis, `require_packages` from the lockfile, `forbid_package_fields`
+ * from the manifest — so a package could be visible to one rule and
+ * invisible to another (#75). Merging the three axes once, here, means the
+ * features differ only in which axis they *select*, not in what they can
+ * see.
+ */
+export function buildPackageInventory(
+  input: BuildInventoryInput = {},
+): PackageInventoryEntry[] {
+  const {
+    versions = {},
+    multiVersions = {},
+    resolutions = {},
+    declared = {},
+    componentUsage,
+    config,
+  } = input;
+
+  const ignorePatterns = config?.packages.ignore ?? [];
+  const internalPatterns = config?.packages.internal ?? [];
+
+  // Fold component usage up to one record per package first — several
+  // components can come from the same source.
+  const usage = new Map<
+    string,
+    { usageCount: number; componentCount: number; components: string[] }
+  >();
+  for (const component of componentUsage?.values() ?? []) {
+    if (NON_PACKAGE_SOURCES.has(component.source)) continue;
+
+    const existing = usage.get(component.source);
+    if (existing) {
+      existing.usageCount += component.count;
+      existing.componentCount++;
+      existing.components.push(component.name);
+    } else {
+      usage.set(component.source, {
+        usageCount: component.count,
+        componentCount: 1,
+        components: [component.name],
+      });
+    }
+  }
+
+  // Used packages first so the inventory (and every view derived from it)
+  // stays usage-ordered; declared-only and transitive packages follow.
+  const names = new Set<string>([
+    ...usage.keys(),
+    ...Object.keys(declared),
+    ...Object.keys(versions),
+    ...Object.keys(resolutions),
+  ]);
+
+  const entries: PackageInventoryEntry[] = [];
+  for (const packageName of names) {
+    const packageUsage = usage.get(packageName);
+    const allVersions = multiVersions[packageName] ?? [];
+
+    entries.push({
+      packageName,
+      declaredIn: declared[packageName] ?? [],
+      version: getPackageVersion(packageName, versions),
+      rootVersion: getRootVersion(packageName, resolutions),
+      allVersions,
+      hasVersionConflict: allVersions.length > 1,
+      internal:
+        internalPatterns.length > 0
+          ? micromatch.isMatch(packageName, internalPatterns)
+          : false,
+      ignored:
+        ignorePatterns.length > 0
+          ? micromatch.isMatch(packageName, ignorePatterns)
+          : false,
+      usageCount: packageUsage?.usageCount ?? 0,
+      componentCount: packageUsage?.componentCount ?? 0,
+      components: packageUsage?.components ?? [],
+    });
+  }
+
+  // Stable sort — equal usage keeps insertion order, so the usage-ranked
+  // head is deterministic and the tail stays in discovery order.
+  return entries.sort((a, b) => b.usageCount - a.usageCount);
+}
+
+/** Declared in this repo's `package.json`, in any dependency bucket. */
+export function isDeclared(entry: PackageInventoryEntry): boolean {
+  return entry.declaredIn.length > 0;
+}
+
+/** Imported by scanned source. */
+export function isUsed(entry: PackageInventoryEntry): boolean {
+  return entry.usageCount > 0;
+}
+
+/**
+ * Present in the lockfile. `root` counts only direct dependencies; `tree`
+ * counts any resolved copy, including purely transitive ones — the same
+ * axis `releaseAge.scope` exposes.
+ */
+export function isInstalled(
+  entry: PackageInventoryEntry,
+  scope: 'root' | 'tree' = 'tree',
+): boolean {
+  if (scope === 'root') return entry.rootVersion !== null;
+  return entry.version !== null || entry.allVersions.length > 0;
+}
+
+/**
+ * Packages this repo owns — the ones it can actually add or remove. Excludes
+ * purely transitive dependencies (nothing the repo can do about those short
+ * of dropping the parent) and anything under `packages.ignore`.
+ */
+export function isOwnedByRepo(entry: PackageInventoryEntry): boolean {
+  return !entry.ignored && (isDeclared(entry) || isUsed(entry));
+}

--- a/src/utils/package-rules.ts
+++ b/src/utils/package-rules.ts
@@ -11,8 +11,9 @@ export interface BannedPackageViolation {
 }
 
 /**
- * Selects the packages this repo owns — declared in `package.json` and/or
- * imported by scanned source (`isOwnedByRepo`).
+ * Selects the packages this repo owns (`isOwnedByRepo`): declared in
+ * `package.json`, recorded as a direct dependency by the lockfile, and/or
+ * imported by scanned source.
  *
  * Matching usage alone was the bug behind #75: the usage axis is built from
  * component imports, so build-only tooling — invoked via `npx`, an npm

--- a/src/utils/package-rules.ts
+++ b/src/utils/package-rules.ts
@@ -1,7 +1,8 @@
 import micromatch from 'micromatch';
 import type { ResolvedHermexConfig } from '../config/types';
 import type { RuleViolation } from '../rules/evaluator';
-import type { PackageDistribution } from './package-distribution';
+import type { PackageInventoryEntry } from './package-inventory';
+import { isInstalled, isOwnedByRepo, isUsed } from './package-inventory';
 
 export interface BannedPackageViolation {
   packageName: string;
@@ -10,44 +11,33 @@ export interface BannedPackageViolation {
 }
 
 /**
- * @param distribution - Packages discovered through import/usage analysis.
- * @param declaredPackages - Package names declared in `package.json` (see
- *   `collectDeclaredPackages`). Checked in addition to `distribution` because
- *   the distribution is built from component usage alone, so build-only
- *   tooling — invoked via `npx`, scripts or git hooks and never imported —
- *   would otherwise pass a forbid rule that names it outright (#75).
+ * Selects the packages this repo owns — declared in `package.json` and/or
+ * imported by scanned source (`isOwnedByRepo`).
+ *
+ * Matching usage alone was the bug behind #75: the usage axis is built from
+ * component imports, so build-only tooling — invoked via `npx`, an npm
+ * script or a git hook, and never imported — was invisible to a rule that
+ * named it outright. Purely transitive dependencies stay out of scope: the
+ * repo cannot remove one without dropping its parent, so flagging it would
+ * report a violation nobody can fix.
  */
 export function detectBannedPackages(
-  distribution: PackageDistribution[],
+  inventory: PackageInventoryEntry[],
   config?: ResolvedHermexConfig,
-  declaredPackages: string[] = [],
 ): BannedPackageViolation[] {
   const forbidRules = config?.rules.forbid_packages ?? [];
   if (forbidRules.length === 0) {
     return [];
   }
 
-  const ignorePatterns = config?.packages.ignore ?? [];
-
-  // Distribution names first, in their existing (usage-ranked) order, so
-  // adding declared packages never reorders the violations already reported.
-  const candidates = new Set(distribution.map((pkg) => pkg.packageName));
-  for (const name of declaredPackages) {
-    if (candidates.has(name)) continue;
-    // `calculatePackageDistribution` already applies `packages.ignore` to
-    // everything it emits; apply it here too so an ignored package does not
-    // become newly visible just by being declared.
-    if (ignorePatterns.length > 0 && micromatch.isMatch(name, ignorePatterns))
-      continue;
-    candidates.add(name);
-  }
-
   const violations: BannedPackageViolation[] = [];
-  for (const packageName of candidates) {
+  for (const entry of inventory) {
+    if (!isOwnedByRepo(entry)) continue;
+
     for (const rule of forbidRules) {
-      if (micromatch.isMatch(packageName, rule.patterns)) {
+      if (micromatch.isMatch(entry.packageName, rule.patterns)) {
         violations.push({
-          packageName,
+          packageName: entry.packageName,
           severity: rule.severity,
           message: rule.message,
         });
@@ -58,24 +48,31 @@ export function detectBannedPackages(
   return violations;
 }
 
+/**
+ * Selects the *installed* axis (plus used, to cover a phantom dependency
+ * that is imported without being in the lockfile).
+ *
+ * Deliberately not `isOwnedByRepo`: "required" means the package must be
+ * available to the code, so a transitive copy satisfies it, and a name in
+ * `packages.ignore` — excluded from *reporting*, not uninstalled — must not
+ * suddenly count as missing. Being declared but absent from the lockfile,
+ * on the other hand, is a genuinely unsatisfied requirement.
+ */
 export function detectRequiredPackages(
-  distribution: PackageDistribution[],
-  versions: Record<string, string>,
+  inventory: PackageInventoryEntry[],
   config?: ResolvedHermexConfig,
 ): RuleViolation[] {
   const requireRules = config?.rules.require_packages ?? [];
   if (requireRules.length === 0) return [];
 
-  // All package names available: from lockfile versions + from import distribution
-  const installedNames = new Set([
-    ...Object.keys(versions),
-    ...distribution.map((p) => p.packageName),
-  ]);
+  const installedNames = inventory
+    .filter((entry) => isInstalled(entry) || isUsed(entry))
+    .map((entry) => entry.packageName);
 
   const violations: RuleViolation[] = [];
   for (const rule of requireRules) {
     const satisfied = rule.patterns.some((p) =>
-      [...installedNames].some((name) => micromatch.isMatch(name, p)),
+      installedNames.some((name) => micromatch.isMatch(name, p)),
     );
     if (!satisfied) {
       violations.push({

--- a/src/utils/package-rules.ts
+++ b/src/utils/package-rules.ts
@@ -9,21 +9,45 @@ export interface BannedPackageViolation {
   message?: string;
 }
 
+/**
+ * @param distribution - Packages discovered through import/usage analysis.
+ * @param declaredPackages - Package names declared in `package.json` (see
+ *   `collectDeclaredPackages`). Checked in addition to `distribution` because
+ *   the distribution is built from component usage alone, so build-only
+ *   tooling — invoked via `npx`, scripts or git hooks and never imported —
+ *   would otherwise pass a forbid rule that names it outright (#75).
+ */
 export function detectBannedPackages(
   distribution: PackageDistribution[],
   config?: ResolvedHermexConfig,
+  declaredPackages: string[] = [],
 ): BannedPackageViolation[] {
   const forbidRules = config?.rules.forbid_packages ?? [];
   if (forbidRules.length === 0) {
     return [];
   }
 
+  const ignorePatterns = config?.packages.ignore ?? [];
+
+  // Distribution names first, in their existing (usage-ranked) order, so
+  // adding declared packages never reorders the violations already reported.
+  const candidates = new Set(distribution.map((pkg) => pkg.packageName));
+  for (const name of declaredPackages) {
+    if (candidates.has(name)) continue;
+    // `calculatePackageDistribution` already applies `packages.ignore` to
+    // everything it emits; apply it here too so an ignored package does not
+    // become newly visible just by being declared.
+    if (ignorePatterns.length > 0 && micromatch.isMatch(name, ignorePatterns))
+      continue;
+    candidates.add(name);
+  }
+
   const violations: BannedPackageViolation[] = [];
-  for (const pkg of distribution) {
+  for (const packageName of candidates) {
     for (const rule of forbidRules) {
-      if (micromatch.isMatch(pkg.packageName, rule.patterns)) {
+      if (micromatch.isMatch(packageName, rule.patterns)) {
         violations.push({
-          packageName: pkg.packageName,
+          packageName,
           severity: rule.severity,
           message: rule.message,
         });

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -528,3 +528,78 @@ describe('rule severity "off" authored directly in the base config (no overrides
     expect(parsed.compliance.status).toBe('compliant');
   });
 });
+
+// End-to-end coverage of the package inventory's axes. These run the real
+// CLI against fixtures/package.json + fixtures/pnpm-lock.yaml, which are
+// built so each axis has a package of its own — the wiring in
+// src/commands/pipeline.ts (reading the manifest, threading it into the
+// aggregator) exists only in the spawned process, so unit tests cannot
+// reach it.
+describe('package inventory axes (end to end)', () => {
+  const inventoryConfig = (name: string) =>
+    join(ROOT, 'tests', 'e2e', `hermex-inventory-${name}.config.ts`);
+
+  it('forbids a package declared in package.json but never imported (#75)', () => {
+    const result = run(['comply', '--config', inventoryConfig('declared')]);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.bannedPackageViolations).toEqual([
+      { packageName: 'moment', severity: 'error', message: 'Use date-fns' },
+    ]);
+    expect(parsed.compliance.status).toBe('non-compliant');
+  });
+
+  it('reports that declared-but-unimported package without inventing a packages[] row for it', () => {
+    const result = run(['comply', '--config', inventoryConfig('declared')]);
+    const parsed = JSON.parse(result.stdout);
+    // Proves the match came from the declared axis: it has no measured
+    // usage, so it is absent from the reported distribution.
+    expect(
+      parsed.packages.map((p: { packageName: string }) => p.packageName),
+    ).not.toContain('moment');
+  });
+
+  it('names the forbidden package in the human-readable Rules table', () => {
+    const result = run(['comply']); // fixtures/hermex.config.ts forbids moment
+    expect(result.status).toBe(1);
+    expect(result.stdout).toMatch(/forbid_packages/);
+    expect(result.stdout).toMatch(/moment is forbidden/);
+  });
+
+  it('does not forbid a purely transitive dependency the repo cannot remove', () => {
+    const result = run(['comply', '--config', inventoryConfig('transitive')]);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.bannedPackageViolations).toEqual([]);
+    expect(parsed.compliance.status).toBe('compliant');
+  });
+
+  it('forbids a package that is imported without being declared', () => {
+    const result = run(['comply', '--config', inventoryConfig('undeclared')]);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.bannedPackageViolations).toHaveLength(1);
+    expect(parsed.bannedPackageViolations[0].packageName).toBe('react-dom');
+  });
+
+  it('packages.ignore drops a package from forbid_packages while it still satisfies require_packages', () => {
+    const result = run(['comply', '--config', inventoryConfig('ignored')]);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.bannedPackageViolations).toEqual([]);
+    expect(parsed.ruleViolations).toEqual([]);
+  });
+
+  it('a declared but uninstalled package is forbiddable yet does not satisfy require_packages', () => {
+    const result = run(['comply', '--config', inventoryConfig('uninstalled')]);
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    // forbid_packages reads the declared axis — eslint is in package.json.
+    expect(parsed.bannedPackageViolations).toHaveLength(1);
+    expect(parsed.bannedPackageViolations[0].packageName).toBe('eslint');
+    // require_packages reads the installed axis — eslint is not in the
+    // lockfile, so the requirement is genuinely unsatisfied.
+    expect(parsed.ruleViolations).toHaveLength(1);
+    expect(parsed.ruleViolations[0].type).toBe('require_packages');
+  });
+});

--- a/tests/e2e/hermex-inventory-declared.config.ts
+++ b/tests/e2e/hermex-inventory-declared.config.ts
@@ -1,0 +1,12 @@
+// `moment` is in fixtures/package.json devDependencies and in the fixture
+// lockfile, but no fixture source file imports it — the #75 case.
+export default {
+  rules: {
+    forbid_packages: [
+      { severity: 'error', patterns: ['moment'], message: 'Use date-fns' },
+    ],
+  },
+  output: {
+    format: 'json',
+  },
+};

--- a/tests/e2e/hermex-inventory-ignored.config.ts
+++ b/tests/e2e/hermex-inventory-ignored.config.ts
@@ -1,0 +1,15 @@
+// `packages.ignore` is a reporting filter, not an uninstall: the ignored
+// package must drop out of forbid_packages *and* still satisfy
+// require_packages, which reads the installed axis.
+export default {
+  packages: {
+    ignore: ['moment'],
+  },
+  rules: {
+    forbid_packages: [{ severity: 'error', patterns: ['moment'] }],
+    require_packages: [{ severity: 'error', patterns: ['moment'] }],
+  },
+  output: {
+    format: 'json',
+  },
+};

--- a/tests/e2e/hermex-inventory-transitive.config.ts
+++ b/tests/e2e/hermex-inventory-transitive.config.ts
@@ -1,0 +1,11 @@
+// `js-tokens` exists only under the fixture lockfile's `packages` key, never
+// in `importers` — a purely transitive dependency. The repo cannot remove it,
+// so forbid_packages must not flag it.
+export default {
+  rules: {
+    forbid_packages: [{ severity: 'error', patterns: ['js-tokens'] }],
+  },
+  output: {
+    format: 'json',
+  },
+};

--- a/tests/e2e/hermex-inventory-undeclared.config.ts
+++ b/tests/e2e/hermex-inventory-undeclared.config.ts
@@ -1,0 +1,13 @@
+// `react-dom` is imported by a fixture source file (for a non-JSX call, so
+// the usage axis never sees it) and is a root dependency in the fixture
+// lockfile, but is deliberately absent from fixtures/package.json. The
+// lockfile's own record of direct dependencies is enough to make it this
+// repo's to remove, so it stays forbiddable.
+export default {
+  rules: {
+    forbid_packages: [{ severity: 'error', patterns: ['react-dom'] }],
+  },
+  output: {
+    format: 'json',
+  },
+};

--- a/tests/e2e/hermex-inventory-uninstalled.config.ts
+++ b/tests/e2e/hermex-inventory-uninstalled.config.ts
@@ -1,0 +1,13 @@
+// `eslint` is declared in fixtures/package.json but absent from the fixture
+// lockfile. The two rules read different axes, so the same package is
+// forbiddable (declared) while failing to satisfy a requirement (not
+// installed).
+export default {
+  rules: {
+    forbid_packages: [{ severity: 'error', patterns: ['eslint'] }],
+    require_packages: [{ severity: 'error', patterns: ['eslint'] }],
+  },
+  output: {
+    format: 'json',
+  },
+};

--- a/tests/helpers/mock-reports.ts
+++ b/tests/helpers/mock-reports.ts
@@ -1,5 +1,8 @@
 import type { UsageReport } from '../../src/swc-parser/types';
-import type { PackageDistribution } from '../../src/utils/aggregator';
+import type {
+  PackageDistribution,
+  PackageInventoryEntry,
+} from '../../src/utils/aggregator';
 import type { ReleaseAgeEntry } from '../../src/npm-registry/types';
 
 /**
@@ -65,6 +68,34 @@ export function createMockPackage(
     // package whose only "resolved copy" doesn't match its own installed
     // version — override `allVersions` explicitly for multi-version tests.
     allVersions: version ? [version] : [],
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a minimal PackageInventoryEntry — by default a package that is
+ * declared, installed as a direct dependency, and used once, i.e. present
+ * on all three axes. Override to test a single axis in isolation (e.g.
+ * `{ usageCount: 0, componentCount: 0 }` for declared-but-never-imported,
+ * or `{ declaredIn: [], rootVersion: null }` for purely transitive).
+ */
+export function createMockInventoryEntry(
+  packageName: string,
+  overrides: Partial<PackageInventoryEntry> = {},
+): PackageInventoryEntry {
+  const version = overrides.version !== undefined ? overrides.version : '1.0.0';
+  return {
+    packageName,
+    declaredIn: ['dependencies'],
+    version,
+    rootVersion: version,
+    allVersions: version ? [version] : [],
+    hasVersionConflict: false,
+    internal: false,
+    ignored: false,
+    usageCount: 1,
+    componentCount: 1,
+    components: [],
     ...overrides,
   };
 }

--- a/tests/rules/declared-packages.test.ts
+++ b/tests/rules/declared-packages.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { collectDeclaredPackages } from '../../src/rules/shared';
+
+let tempDir: string;
+
+/** Writes a package.json into a fresh temp dir and returns that dir. */
+function withManifest(content: string): string {
+  const dir = mkdtempSync(join(tempDir, 'repo-'));
+  writeFileSync(join(dir, 'package.json'), content);
+  return dir;
+}
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'hermex-declared-test-'));
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('collectDeclaredPackages', () => {
+  it('collects names from all four dependency buckets', () => {
+    const dir = withManifest(
+      JSON.stringify({
+        dependencies: { react: '^18.0.0' },
+        devDependencies: { vitest: '^4.0.0' },
+        peerDependencies: { 'react-dom': '^18.0.0' },
+        optionalDependencies: { fsevents: '^2.3.0' },
+      }),
+    );
+
+    expect(collectDeclaredPackages(dir).sort()).toEqual([
+      'fsevents',
+      'react',
+      'react-dom',
+      'vitest',
+    ]);
+  });
+
+  it('reports a package listed in two buckets exactly once', () => {
+    const dir = withManifest(
+      JSON.stringify({
+        peerDependencies: { react: '^18.0.0' },
+        devDependencies: { react: '^18.0.0' },
+      }),
+    );
+
+    expect(collectDeclaredPackages(dir)).toEqual(['react']);
+  });
+
+  it('returns an empty array when the manifest declares no dependencies', () => {
+    const dir = withManifest(JSON.stringify({ name: 'test-project' }));
+
+    expect(collectDeclaredPackages(dir)).toEqual([]);
+  });
+
+  it('returns an empty array when package.json is missing', () => {
+    const dir = mkdtempSync(join(tempDir, 'empty-'));
+
+    expect(collectDeclaredPackages(dir)).toEqual([]);
+  });
+
+  it('returns an empty array when package.json is not valid JSON', () => {
+    const dir = withManifest('{ not json');
+
+    expect(collectDeclaredPackages(dir)).toEqual([]);
+  });
+
+  it('skips a malformed bucket without dropping the well-formed ones', () => {
+    const dir = withManifest(
+      JSON.stringify({
+        dependencies: 'oops',
+        peerDependencies: ['react'],
+        devDependencies: { vitest: '^4.0.0' },
+      }),
+    );
+
+    expect(collectDeclaredPackages(dir)).toEqual(['vitest']);
+  });
+});

--- a/tests/rules/declared-packages.test.ts
+++ b/tests/rules/declared-packages.test.ts
@@ -71,6 +71,19 @@ describe('collectDeclaredPackages', () => {
     expect(collectDeclaredPackages(dir)).toEqual({});
   });
 
+  // A manifest is untrusted input: on a plain object literal, a `__proto__`
+  // key would hit the prototype setter rather than creating an own property.
+  it('handles a dependency named __proto__ without dropping it or mutating a prototype', () => {
+    const dir = withManifest(
+      '{"dependencies":{"__proto__":"1.0.0","react":"^18.0.0"}}',
+    );
+
+    const declared = collectDeclaredPackages(dir);
+
+    expect(Object.keys(declared).sort()).toEqual(['__proto__', 'react']);
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
   it('skips a malformed bucket without dropping the well-formed ones', () => {
     const dir = withManifest(
       JSON.stringify({

--- a/tests/rules/declared-packages.test.ts
+++ b/tests/rules/declared-packages.test.ts
@@ -32,15 +32,15 @@ describe('collectDeclaredPackages', () => {
       }),
     );
 
-    expect(collectDeclaredPackages(dir).sort()).toEqual([
-      'fsevents',
-      'react',
-      'react-dom',
-      'vitest',
-    ]);
+    expect(collectDeclaredPackages(dir)).toEqual({
+      react: ['dependencies'],
+      vitest: ['devDependencies'],
+      'react-dom': ['peerDependencies'],
+      fsevents: ['optionalDependencies'],
+    });
   });
 
-  it('reports a package listed in two buckets exactly once', () => {
+  it('records every bucket declaring a package listed more than once', () => {
     const dir = withManifest(
       JSON.stringify({
         peerDependencies: { react: '^18.0.0' },
@@ -48,25 +48,27 @@ describe('collectDeclaredPackages', () => {
       }),
     );
 
-    expect(collectDeclaredPackages(dir)).toEqual(['react']);
+    expect(collectDeclaredPackages(dir)).toEqual({
+      react: ['devDependencies', 'peerDependencies'],
+    });
   });
 
-  it('returns an empty array when the manifest declares no dependencies', () => {
+  it('returns nothing when the manifest declares no dependencies', () => {
     const dir = withManifest(JSON.stringify({ name: 'test-project' }));
 
-    expect(collectDeclaredPackages(dir)).toEqual([]);
+    expect(collectDeclaredPackages(dir)).toEqual({});
   });
 
-  it('returns an empty array when package.json is missing', () => {
+  it('returns nothing when package.json is missing', () => {
     const dir = mkdtempSync(join(tempDir, 'empty-'));
 
-    expect(collectDeclaredPackages(dir)).toEqual([]);
+    expect(collectDeclaredPackages(dir)).toEqual({});
   });
 
-  it('returns an empty array when package.json is not valid JSON', () => {
+  it('returns nothing when package.json is not valid JSON', () => {
     const dir = withManifest('{ not json');
 
-    expect(collectDeclaredPackages(dir)).toEqual([]);
+    expect(collectDeclaredPackages(dir)).toEqual({});
   });
 
   it('skips a malformed bucket without dropping the well-formed ones', () => {
@@ -78,6 +80,8 @@ describe('collectDeclaredPackages', () => {
       }),
     );
 
-    expect(collectDeclaredPackages(dir)).toEqual(['vitest']);
+    expect(collectDeclaredPackages(dir)).toEqual({
+      vitest: ['devDependencies'],
+    });
   });
 });

--- a/tests/utils/aggregator.test.ts
+++ b/tests/utils/aggregator.test.ts
@@ -335,6 +335,35 @@ describe('aggregateReports — banned packages', () => {
 
     expect(result.bannedPackageViolations).toEqual([]);
   });
+
+  it('reports a banned package that is only declared in package.json', () => {
+    const report = reportWithNamedImport('Button', 'react');
+    const config = createConfig({
+      rules: {
+        forbid_packages: [
+          { severity: 'error', patterns: ['jest'], message: 'Use vitest' },
+        ],
+      },
+    });
+
+    const result = aggregateReports(
+      [report],
+      { react: '18.0.0', jest: '29.0.0' },
+      config,
+      {},
+      {},
+      ['jest'],
+    );
+
+    expect(result.bannedPackageViolations).toEqual([
+      { packageName: 'jest', severity: 'error', message: 'Use vitest' },
+    ]);
+    // Declared-only packages stay out of the packages table — they have no
+    // measured usage to report.
+    expect(
+      result.packageDistribution.map((pkg) => pkg.packageName),
+    ).not.toContain('jest');
+  });
 });
 
 describe('aggregateReports — pattern counts', () => {

--- a/tests/utils/aggregator.test.ts
+++ b/tests/utils/aggregator.test.ts
@@ -352,7 +352,7 @@ describe('aggregateReports — banned packages', () => {
       config,
       {},
       {},
-      ['jest'],
+      { jest: ['devDependencies'] },
     );
 
     expect(result.bannedPackageViolations).toEqual([

--- a/tests/utils/package-distribution.test.ts
+++ b/tests/utils/package-distribution.test.ts
@@ -385,6 +385,28 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
     });
   });
 
+  // The inventory also knows about packages that are declared in
+  // package.json but missing from the lockfile. Those have no resolved
+  // version to date-check, and release-age enrichment skips versionless
+  // entries — so they must not reach the packages table either.
+  it('does not surface a declared-but-uninstalled package matching enforceOn', () => {
+    const componentUsageMap = new Map<string, ComponentUsage>();
+    const config = createConfig({
+      releaseAge: { enabled: true, enforceOn: ['eslint'] },
+    });
+
+    const distribution = buildDistribution(
+      componentUsageMap,
+      {},
+      config,
+      {},
+      {},
+      { eslint: ['devDependencies'] },
+    );
+
+    expect(distribution).toEqual([]);
+  });
+
   it('does not surface lockfile-only packages when releaseAge is disabled', () => {
     const componentUsageMap = new Map<string, ComponentUsage>();
     const config = createConfig({

--- a/tests/utils/package-distribution.test.ts
+++ b/tests/utils/package-distribution.test.ts
@@ -4,13 +4,49 @@ import {
   findComponentSource,
 } from '../../src/utils/package-distribution';
 import type { ComponentUsage } from '../../src/utils/package-distribution';
+import { buildPackageInventory } from '../../src/utils/package-inventory';
+import type { DeclaredPackages } from '../../src/utils/package-inventory';
+import type {
+  LockfileResolutionMap,
+  MultiVersionMap,
+} from '../../src/lock-parser';
 import { HermexConfigSchema } from '../../src/config/schema';
 import type { HermexConfigInput } from '../../src/config/schema';
+import { applyOverrides } from '../../src/config/overrides';
 import { createMockReport } from '../helpers/mock-reports';
 
-/** Parse a partial config through the real schema so all defaults apply. */
+/**
+ * Parse a partial config through the real schema, then resolve it like the
+ * pipeline does before the aggregator runs.
+ */
 function createConfig(input: HermexConfigInput = {}) {
-  return HermexConfigSchema.parse(input);
+  return applyOverrides(HermexConfigSchema.parse(input), process.cwd());
+}
+
+/**
+ * Build the inventory then take the distribution view of it — the exact
+ * path `aggregateReports` takes. Keeps these tests written in terms of the
+ * raw inputs (usage + lockfile) while exercising the real two-step.
+ */
+function buildDistribution(
+  componentUsage: Map<string, ComponentUsage>,
+  versions: Record<string, string>,
+  config?: ReturnType<typeof createConfig>,
+  multiVersions: MultiVersionMap = {},
+  resolutions: LockfileResolutionMap = {},
+  declared: DeclaredPackages = {},
+) {
+  return calculatePackageDistribution(
+    buildPackageInventory({
+      versions,
+      multiVersions,
+      resolutions,
+      declared,
+      componentUsage,
+      config,
+    }),
+    config,
+  );
 }
 
 /** Build a ComponentUsage entry for calculatePackageDistribution's input map. */
@@ -72,7 +108,7 @@ describe('calculatePackageDistribution', () => {
       ['Modal', makeComponent('Modal', 'antd', 2)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     expect(distribution).toHaveLength(1);
     expect(distribution[0].packageName).toBe('antd');
@@ -87,7 +123,7 @@ describe('calculatePackageDistribution', () => {
       ['DatePicker', makeComponent('DatePicker', 'moment', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     const totalPercentage = distribution.reduce(
       (sum, pkg) => sum + pkg.percentage,
@@ -106,7 +142,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     expect(distribution).toHaveLength(1);
     expect(distribution[0].packageName).toBe('antd');
@@ -117,7 +153,7 @@ describe('calculatePackageDistribution', () => {
       ['Ghost', makeComponent('Ghost', 'unknown', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     expect(distribution).toEqual([]);
   });
@@ -127,7 +163,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {
+    const distribution = buildDistribution(componentUsageMap, {
       antd: '5.0.0',
     });
 
@@ -139,7 +175,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     expect(distribution[0].version).toBeNull();
   });
@@ -154,7 +190,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { antd: '5.0.0' },
       undefined,
@@ -170,7 +206,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {
+    const distribution = buildDistribution(componentUsageMap, {
       antd: '5.0.0',
     });
 
@@ -182,7 +218,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { antd: '5.0.0' }, // display fallback (highest resolved copy)
       undefined,
@@ -198,7 +234,7 @@ describe('calculatePackageDistribution', () => {
       ['Icon', makeComponent('Icon', '@my-org/ui/icons', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@my-org/ui': '2.0.0' },
       undefined,
@@ -214,7 +250,7 @@ describe('calculatePackageDistribution', () => {
       ['debounce', makeComponent('debounce', 'lodash/debounce', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { lodash: '4.17.21' },
       undefined,
@@ -230,7 +266,7 @@ describe('calculatePackageDistribution', () => {
       ['Icon', makeComponent('Icon', '@my-org/ui/icons', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {
+    const distribution = buildDistribution(componentUsageMap, {
       '@my-org/ui': '2.0.0',
     });
 
@@ -242,7 +278,7 @@ describe('calculatePackageDistribution', () => {
       ['debounce', makeComponent('debounce', 'lodash/debounce', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {
+    const distribution = buildDistribution(componentUsageMap, {
       lodash: '4.17.21',
     });
 
@@ -254,7 +290,7 @@ describe('calculatePackageDistribution', () => {
       ['Icon', makeComponent('Icon', '@my-org/ui/icons', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     expect(distribution[0].version).toBeNull();
   });
@@ -264,7 +300,7 @@ describe('calculatePackageDistribution', () => {
       ['debounce', makeComponent('debounce', 'lodash/debounce', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(componentUsageMap, {});
+    const distribution = buildDistribution(componentUsageMap, {});
 
     expect(distribution[0].version).toBeNull();
   });
@@ -274,7 +310,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { antd: '5.0.0' },
       undefined,
@@ -290,7 +326,7 @@ describe('calculatePackageDistribution', () => {
       ['Button', makeComponent('Button', 'antd', 1)],
     ]);
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { antd: '5.0.0' },
       undefined,
@@ -307,11 +343,7 @@ describe('calculatePackageDistribution', () => {
     ]);
     const config = createConfig({ packages: { internal: ['@my-org/*'] } });
 
-    const distribution = calculatePackageDistribution(
-      componentUsageMap,
-      {},
-      config,
-    );
+    const distribution = buildDistribution(componentUsageMap, {}, config);
 
     expect(distribution[0].internal).toBe(true);
   });
@@ -322,11 +354,7 @@ describe('calculatePackageDistribution', () => {
     ]);
     const config = createConfig({ packages: { ignore: ['antd'] } });
 
-    const distribution = calculatePackageDistribution(
-      componentUsageMap,
-      {},
-      config,
-    );
+    const distribution = buildDistribution(componentUsageMap, {}, config);
 
     expect(distribution).toEqual([]);
   });
@@ -339,7 +367,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,
@@ -363,7 +391,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: false, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,
@@ -376,7 +404,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
     const componentUsageMap = new Map<string, ComponentUsage>();
     const config = createConfig({ releaseAge: { enabled: true } });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0', lodash: '4.17.21' },
       config,
@@ -393,7 +421,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,
@@ -411,7 +439,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,
@@ -427,7 +455,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,
@@ -442,7 +470,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,
@@ -466,7 +494,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/dio'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/dio': '1.0.0' }, // display fallback: highest resolved copy
       config,
@@ -484,7 +512,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/dio'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/dio': '1.0.0' },
       config,
@@ -501,7 +529,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0', lodash: '4.17.21' },
       config,
@@ -520,7 +548,7 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
     });
 
-    const distribution = calculatePackageDistribution(
+    const distribution = buildDistribution(
       componentUsageMap,
       { '@acme-ui/pulse-styles': '2.1.0' },
       config,

--- a/tests/utils/package-inventory.test.ts
+++ b/tests/utils/package-inventory.test.ts
@@ -190,6 +190,38 @@ describe('buildPackageInventory — config flags', () => {
 });
 
 describe('inventory predicates', () => {
+  it('isOwnedByRepo accepts a root dependency the lockfile knows about but the manifest omits', () => {
+    const inventory = buildPackageInventory({
+      versions: { 'react-dom': '18.3.1' },
+      resolutions: {
+        'react-dom': { rootVersion: '18.3.1', allVersions: ['18.3.1'] },
+      },
+    });
+
+    const entry = find(inventory, 'react-dom')!;
+    expect(isDeclared(entry)).toBe(false);
+    expect(isUsed(entry)).toBe(false);
+    // The lockfile's own record of direct dependencies stands in for the
+    // manifest, so an unreadable/out-of-sync package.json does not silently
+    // exempt a repo's direct dependencies from forbid rules.
+    expect(isOwnedByRepo(entry)).toBe(true);
+  });
+
+  it('isOwnedByRepo rejects an ignored package even when it is declared, installed and used', () => {
+    const config = createConfig({ packages: { ignore: ['react'] } });
+    const inventory = buildPackageInventory({
+      versions: { react: '18.0.0' },
+      resolutions: {
+        react: { rootVersion: '18.0.0', allVersions: ['18.0.0'] },
+      },
+      declared: { react: ['dependencies'] },
+      componentUsage: usageMap({ name: 'Button', source: 'react' }),
+      config,
+    });
+
+    expect(isOwnedByRepo(find(inventory, 'react')!)).toBe(false);
+  });
+
   it('isOwnedByRepo accepts declared-but-unused and used-but-undeclared packages', () => {
     const inventory = buildPackageInventory({
       versions: { oxlint: '1.0.0', 'lru-cache': '10.0.0' },

--- a/tests/utils/package-inventory.test.ts
+++ b/tests/utils/package-inventory.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPackageInventory,
+  isDeclared,
+  isInstalled,
+  isOwnedByRepo,
+  isUsed,
+} from '../../src/utils/package-inventory';
+import type {
+  ComponentUsage,
+  PackageInventoryEntry,
+} from '../../src/utils/package-inventory';
+import { HermexConfigSchema } from '../../src/config/schema';
+import type { HermexConfigInput } from '../../src/config/schema';
+import { applyOverrides } from '../../src/config/overrides';
+
+function createConfig(input: HermexConfigInput = {}) {
+  return applyOverrides(HermexConfigSchema.parse(input), process.cwd());
+}
+
+function usageMap(
+  ...components: { name: string; source: string; count?: number }[]
+): Map<string, ComponentUsage> {
+  return new Map(
+    components.map((c) => [
+      `${c.source}::${c.name}`,
+      { name: c.name, source: c.source, count: c.count ?? 1, files: new Set() },
+    ]),
+  );
+}
+
+function find(
+  inventory: PackageInventoryEntry[],
+  packageName: string,
+): PackageInventoryEntry | undefined {
+  return inventory.find((entry) => entry.packageName === packageName);
+}
+
+describe('buildPackageInventory — axes', () => {
+  it('merges declared, installed and used packages into one list', () => {
+    const inventory = buildPackageInventory({
+      versions: { react: '18.0.0', oxlint: '1.0.0', 'lru-cache': '10.0.0' },
+      declared: { react: ['dependencies'], oxlint: ['devDependencies'] },
+      componentUsage: usageMap({ name: 'Button', source: 'react' }),
+    });
+
+    expect(inventory.map((e) => e.packageName).sort()).toEqual([
+      'lru-cache',
+      'oxlint',
+      'react',
+    ]);
+  });
+
+  it('records every bucket that declares a package', () => {
+    const inventory = buildPackageInventory({
+      declared: { react: ['peerDependencies', 'devDependencies'] },
+    });
+
+    expect(find(inventory, 'react')?.declaredIn).toEqual([
+      'peerDependencies',
+      'devDependencies',
+    ]);
+  });
+
+  it('includes a package that is only imported, never declared or installed', () => {
+    const inventory = buildPackageInventory({
+      componentUsage: usageMap({ name: 'Button', source: '@acme/ui' }),
+    });
+
+    const entry = find(inventory, '@acme/ui');
+    expect(entry).toBeDefined();
+    expect(isUsed(entry!)).toBe(true);
+    expect(isDeclared(entry!)).toBe(false);
+    expect(isInstalled(entry!)).toBe(false);
+  });
+
+  it('excludes local and unresolved import sources', () => {
+    const inventory = buildPackageInventory({
+      componentUsage: usageMap(
+        { name: 'Header', source: 'local' },
+        { name: 'Mystery', source: 'unknown' },
+      ),
+    });
+
+    expect(inventory).toEqual([]);
+  });
+
+  it('folds several components from one package into a single entry', () => {
+    const inventory = buildPackageInventory({
+      componentUsage: usageMap(
+        { name: 'Button', source: 'antd', count: 3 },
+        { name: 'Card', source: 'antd', count: 2 },
+      ),
+    });
+
+    const entry = find(inventory, 'antd');
+    expect(entry?.usageCount).toBe(5);
+    expect(entry?.componentCount).toBe(2);
+    expect(entry?.components).toEqual(['Button', 'Card']);
+  });
+
+  it('orders entries by usage, so every view derived from it is usage-ranked', () => {
+    const inventory = buildPackageInventory({
+      versions: { jest: '29.0.0' },
+      componentUsage: usageMap(
+        { name: 'Button', source: 'antd', count: 1 },
+        { name: 'Moment', source: 'moment', count: 9 },
+      ),
+    });
+
+    expect(inventory.map((e) => e.packageName)).toEqual([
+      'moment',
+      'antd',
+      'jest',
+    ]);
+  });
+});
+
+describe('buildPackageInventory — version resolution', () => {
+  it('carries the effective version, root version and every resolved copy', () => {
+    const inventory = buildPackageInventory({
+      versions: { antd: '5.0.0' },
+      multiVersions: { antd: ['5.0.0', '4.0.0'] },
+      resolutions: { antd: { rootVersion: '5.0.0', allVersions: ['5.0.0'] } },
+      componentUsage: usageMap({ name: 'Button', source: 'antd' }),
+    });
+
+    const entry = find(inventory, 'antd');
+    expect(entry?.version).toBe('5.0.0');
+    expect(entry?.rootVersion).toBe('5.0.0');
+    expect(entry?.allVersions).toEqual(['5.0.0', '4.0.0']);
+    expect(entry?.hasVersionConflict).toBe(true);
+  });
+
+  it('resolves a scoped subpath import to its base package version', () => {
+    const inventory = buildPackageInventory({
+      versions: { '@my-org/ui': '2.0.0' },
+      resolutions: {
+        '@my-org/ui': { rootVersion: '2.0.0', allVersions: ['2.0.0'] },
+      },
+      componentUsage: usageMap({ name: 'Icon', source: '@my-org/ui/icons' }),
+    });
+
+    const entry = find(inventory, '@my-org/ui/icons');
+    expect(entry?.version).toBe('2.0.0');
+    expect(entry?.rootVersion).toBe('2.0.0');
+  });
+
+  it('marks a purely transitive dependency as installed on the tree axis only', () => {
+    const inventory = buildPackageInventory({
+      versions: { 'lru-cache': '10.0.0' },
+      resolutions: {
+        'lru-cache': { rootVersion: null, allVersions: ['10.0.0'] },
+      },
+    });
+
+    const entry = find(inventory, 'lru-cache')!;
+    expect(isInstalled(entry, 'tree')).toBe(true);
+    expect(isInstalled(entry, 'root')).toBe(false);
+  });
+});
+
+describe('buildPackageInventory — config flags', () => {
+  it('flags packages matching packages.ignore instead of dropping them', () => {
+    const config = createConfig({ packages: { ignore: ['react'] } });
+    const inventory = buildPackageInventory({
+      versions: { react: '18.0.0' },
+      declared: { react: ['dependencies'] },
+      config,
+    });
+
+    const entry = find(inventory, 'react');
+    // Still present — `require_packages` must be able to see it — but
+    // marked so reporting views and forbid rules can skip it.
+    expect(entry).toBeDefined();
+    expect(entry?.ignored).toBe(true);
+    expect(isOwnedByRepo(entry!)).toBe(false);
+  });
+
+  it('flags packages matching packages.internal', () => {
+    const config = createConfig({ packages: { internal: ['@my-org/*'] } });
+    const inventory = buildPackageInventory({
+      versions: { '@my-org/ui': '2.0.0', react: '18.0.0' },
+      config,
+    });
+
+    expect(find(inventory, '@my-org/ui')?.internal).toBe(true);
+    expect(find(inventory, 'react')?.internal).toBe(false);
+  });
+});
+
+describe('inventory predicates', () => {
+  it('isOwnedByRepo accepts declared-but-unused and used-but-undeclared packages', () => {
+    const inventory = buildPackageInventory({
+      versions: { oxlint: '1.0.0', 'lru-cache': '10.0.0' },
+      resolutions: {
+        oxlint: { rootVersion: '1.0.0', allVersions: ['1.0.0'] },
+        'lru-cache': { rootVersion: null, allVersions: ['10.0.0'] },
+      },
+      declared: { oxlint: ['devDependencies'] },
+      componentUsage: usageMap({ name: 'Button', source: '@acme/ui' }),
+    });
+
+    expect(
+      inventory
+        .filter(isOwnedByRepo)
+        .map((e) => e.packageName)
+        .sort(),
+    ).toEqual(['@acme/ui', 'oxlint']);
+  });
+});

--- a/tests/utils/package-rules.test.ts
+++ b/tests/utils/package-rules.test.ts
@@ -6,7 +6,7 @@ import {
 import { HermexConfigSchema } from '../../src/config/schema';
 import type { HermexConfigInput } from '../../src/config/schema';
 import { applyOverrides } from '../../src/config/overrides';
-import { createMockPackage } from '../helpers/mock-reports';
+import { createMockInventoryEntry } from '../helpers/mock-reports';
 
 /**
  * Parse a partial config through the real schema, then resolve it exactly
@@ -19,9 +19,24 @@ function createConfig(input: HermexConfigInput = {}) {
   return applyOverrides(HermexConfigSchema.parse(input), process.cwd());
 }
 
+/** Imported by scanned source, and declared — the common case. */
+const used = (name: string) => createMockInventoryEntry(name);
+
+/** Declared in package.json but never imported — build tooling, hooks, CLIs. */
+const declaredOnly = (name: string) =>
+  createMockInventoryEntry(name, { usageCount: 0, componentCount: 0 });
+
+/** Installed only as someone else's dependency — this repo cannot remove it. */
+const transitiveOnly = (name: string) =>
+  createMockInventoryEntry(name, {
+    declaredIn: [],
+    rootVersion: null,
+    usageCount: 0,
+    componentCount: 0,
+  });
+
 describe('detectBannedPackages', () => {
   it('flags a package matching a forbid pattern with the rule severity and message', () => {
-    const moment = createMockPackage('moment');
     const config = createConfig({
       rules: {
         forbid_packages: [
@@ -30,7 +45,7 @@ describe('detectBannedPackages', () => {
       },
     });
 
-    const violations = detectBannedPackages([moment], config);
+    const violations = detectBannedPackages([used('moment')], config);
 
     expect(violations).toEqual([
       { packageName: 'moment', severity: 'error', message: 'Use dayjs' },
@@ -38,26 +53,19 @@ describe('detectBannedPackages', () => {
   });
 
   it('matches a scoped package against a glob forbid pattern', () => {
-    const legacyWidget = createMockPackage('@legacy/widget');
     const config = createConfig({
       rules: {
         forbid_packages: [{ severity: 'warn', patterns: ['@legacy/*'] }],
       },
     });
 
-    const violations = detectBannedPackages([legacyWidget], config);
+    const violations = detectBannedPackages([used('@legacy/widget')], config);
 
     expect(violations).toHaveLength(1);
     expect(violations[0].packageName).toBe('@legacy/widget');
   });
 
-  it('uses the first matching rule when a package matches two distinct forbid rules', () => {
-    // Distinct `patterns` (not just distinct severity/message) is
-    // deliberate: identical `patterns` would collapse to one rule during
-    // resolveRules's upsert-by-identity (last write wins — see
-    // tests/config/overrides.test.ts), never reaching detectBannedPackages
-    // as two separate rules in production.
-    const moment = createMockPackage('moment');
+  it('uses the first matching rule when a package matches two forbid rules', () => {
     const config = createConfig({
       rules: {
         forbid_packages: [
@@ -67,7 +75,7 @@ describe('detectBannedPackages', () => {
       },
     });
 
-    const violations = detectBannedPackages([moment], config);
+    const violations = detectBannedPackages([used('moment')], config);
 
     expect(violations).toHaveLength(1);
     expect(violations[0].message).toBe('first rule');
@@ -75,30 +83,29 @@ describe('detectBannedPackages', () => {
   });
 
   it('returns an empty array when no config is provided', () => {
-    const moment = createMockPackage('moment');
-
-    expect(detectBannedPackages([moment])).toEqual([]);
+    expect(detectBannedPackages([used('moment')])).toEqual([]);
   });
 
   it('returns an empty array when there are no forbid_packages rules', () => {
-    const moment = createMockPackage('moment');
     const config = createConfig();
 
-    expect(detectBannedPackages([moment], config)).toEqual([]);
+    expect(detectBannedPackages([used('moment')], config)).toEqual([]);
   });
 
   it('a forbid_packages rule authored with severity "off" resolves away before it ever reaches detectBannedPackages', () => {
-    const moment = createMockPackage('moment');
     const config = createConfig({
       rules: {
         forbid_packages: [{ severity: 'off', patterns: ['moment'] }],
       },
     });
 
-    expect(detectBannedPackages([moment], config)).toEqual([]);
+    expect(detectBannedPackages([used('moment')], config)).toEqual([]);
   });
 
-  it('flags a package declared in package.json but absent from the distribution', () => {
+  // #75: the usage axis is built from component imports, so build-only
+  // tooling — run via npx, an npm script or a git hook — is declared but
+  // never used, and used to slip past a rule naming it outright.
+  it('flags a package declared in package.json but never imported', () => {
     const config = createConfig({
       rules: {
         forbid_packages: [
@@ -111,7 +118,10 @@ describe('detectBannedPackages', () => {
       },
     });
 
-    const violations = detectBannedPackages([], config, ['@acme/coverager']);
+    const violations = detectBannedPackages(
+      [declaredOnly('@acme/coverager')],
+      config,
+    );
 
     expect(violations).toEqual([
       {
@@ -122,34 +132,46 @@ describe('detectBannedPackages', () => {
     ]);
   });
 
-  it('reports a package that is both imported and declared exactly once', () => {
-    const moment = createMockPackage('moment');
+  it('flags a package that is imported without being declared (a phantom dependency)', () => {
     const config = createConfig({
       rules: {
         forbid_packages: [{ severity: 'error', patterns: ['moment'] }],
       },
     });
 
-    const violations = detectBannedPackages([moment], config, ['moment']);
+    const violations = detectBannedPackages(
+      [createMockInventoryEntry('moment', { declaredIn: [] })],
+      config,
+    );
 
     expect(violations).toHaveLength(1);
-    expect(violations[0].packageName).toBe('moment');
   });
 
-  it('matches a declared package against a glob forbid pattern', () => {
+  it('does not flag a purely transitive dependency, which the repo cannot remove', () => {
     const config = createConfig({
       rules: {
-        forbid_packages: [{ severity: 'warn', patterns: ['@legacy/*'] }],
+        forbid_packages: [{ severity: 'error', patterns: ['moment'] }],
       },
     });
 
-    const violations = detectBannedPackages([], config, ['@legacy/widget']);
+    const violations = detectBannedPackages([transitiveOnly('moment')], config);
 
-    expect(violations).toHaveLength(1);
-    expect(violations[0].packageName).toBe('@legacy/widget');
+    expect(violations).toEqual([]);
   });
 
-  it('does not flag a declared package excluded by packages.ignore', () => {
+  it('reports a package exactly once however many axes it is present on', () => {
+    const config = createConfig({
+      rules: {
+        forbid_packages: [{ severity: 'error', patterns: ['moment'] }],
+      },
+    });
+
+    const violations = detectBannedPackages([used('moment')], config);
+
+    expect(violations).toHaveLength(1);
+  });
+
+  it('does not flag a package excluded by packages.ignore', () => {
     const config = createConfig({
       packages: { ignore: ['@legacy/*'] },
       rules: {
@@ -157,52 +179,119 @@ describe('detectBannedPackages', () => {
       },
     });
 
-    const violations = detectBannedPackages([], config, ['@legacy/widget']);
+    const violations = detectBannedPackages(
+      [createMockInventoryEntry('@legacy/widget', { ignored: true })],
+      config,
+    );
 
     expect(violations).toEqual([]);
   });
 
-  it('reports distribution packages before declared-only ones', () => {
-    const moment = createMockPackage('moment');
+  it('reports violations in inventory order, which is usage-ranked', () => {
     const config = createConfig({
       rules: {
         forbid_packages: [{ severity: 'error', patterns: ['moment', 'jest'] }],
       },
     });
 
-    const violations = detectBannedPackages([moment], config, [
-      'jest',
-      'moment',
-    ]);
+    const violations = detectBannedPackages(
+      [used('moment'), declaredOnly('jest')],
+      config,
+    );
 
     expect(violations.map((v) => v.packageName)).toEqual(['moment', 'jest']);
   });
 });
 
 describe('detectRequiredPackages', () => {
-  it('is satisfied by a lockfile versions key even when the package is absent from the distribution', () => {
+  it('is satisfied by an installed package that is never imported', () => {
     const config = createConfig({
       rules: {
         require_packages: [{ severity: 'error', patterns: ['react'] }],
       },
     });
 
-    const violations = detectRequiredPackages([], { react: '18.0.0' }, config);
+    const violations = detectRequiredPackages([declaredOnly('react')], config);
 
     expect(violations).toEqual([]);
   });
 
-  it('is satisfied by a distribution packageName even when absent from versions', () => {
-    const reactPkg = createMockPackage('react');
+  it('is satisfied by an imported package that is absent from the lockfile', () => {
     const config = createConfig({
       rules: {
         require_packages: [{ severity: 'error', patterns: ['react'] }],
       },
     });
 
-    const violations = detectRequiredPackages([reactPkg], {}, config);
+    const violations = detectRequiredPackages(
+      [
+        createMockInventoryEntry('react', {
+          version: null,
+          rootVersion: null,
+          allVersions: [],
+        }),
+      ],
+      config,
+    );
 
     expect(violations).toEqual([]);
+  });
+
+  // Unlike forbid_packages, "required" asks whether the package is available
+  // to the code — a transitive copy counts, and `packages.ignore` (a
+  // reporting filter, not an uninstall) must not make it look missing.
+  it('is satisfied by a purely transitive dependency', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['react'] }],
+      },
+    });
+
+    const violations = detectRequiredPackages(
+      [transitiveOnly('react')],
+      config,
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('is satisfied by an installed package excluded from reporting by packages.ignore', () => {
+    const config = createConfig({
+      packages: { ignore: ['react'] },
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['react'] }],
+      },
+    });
+
+    const violations = detectRequiredPackages(
+      [createMockInventoryEntry('react', { ignored: true })],
+      config,
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('is not satisfied by a package that is declared but not installed', () => {
+    const config = createConfig({
+      rules: {
+        require_packages: [{ severity: 'error', patterns: ['react'] }],
+      },
+    });
+
+    const violations = detectRequiredPackages(
+      [
+        createMockInventoryEntry('react', {
+          version: null,
+          rootVersion: null,
+          allVersions: [],
+          usageCount: 0,
+          componentCount: 0,
+        }),
+      ],
+      config,
+    );
+
+    expect(violations).toHaveLength(1);
   });
 
   it('yields a require_packages violation with the rule patterns and empty matchedFiles when unsatisfied', () => {
@@ -214,7 +303,7 @@ describe('detectRequiredPackages', () => {
       },
     });
 
-    const violations = detectRequiredPackages([], {}, config);
+    const violations = detectRequiredPackages([], config);
 
     expect(violations).toEqual([
       {
@@ -230,7 +319,7 @@ describe('detectRequiredPackages', () => {
   it('returns an empty array when there are no require_packages rules', () => {
     const config = createConfig();
 
-    expect(detectRequiredPackages([], {}, config)).toEqual([]);
+    expect(detectRequiredPackages([], config)).toEqual([]);
   });
 
   it('a require_packages rule authored with severity "off" resolves away before it ever reaches detectRequiredPackages, even unsatisfied', () => {
@@ -240,6 +329,6 @@ describe('detectRequiredPackages', () => {
       },
     });
 
-    expect(detectRequiredPackages([], {}, config)).toEqual([]);
+    expect(detectRequiredPackages([], config)).toEqual([]);
   });
 });

--- a/tests/utils/package-rules.test.ts
+++ b/tests/utils/package-rules.test.ts
@@ -97,6 +97,86 @@ describe('detectBannedPackages', () => {
 
     expect(detectBannedPackages([moment], config)).toEqual([]);
   });
+
+  it('flags a package declared in package.json but absent from the distribution', () => {
+    const config = createConfig({
+      rules: {
+        forbid_packages: [
+          {
+            severity: 'error',
+            patterns: ['@acme/coverager'],
+            message: 'Remove deprecated internal package',
+          },
+        ],
+      },
+    });
+
+    const violations = detectBannedPackages([], config, ['@acme/coverager']);
+
+    expect(violations).toEqual([
+      {
+        packageName: '@acme/coverager',
+        severity: 'error',
+        message: 'Remove deprecated internal package',
+      },
+    ]);
+  });
+
+  it('reports a package that is both imported and declared exactly once', () => {
+    const moment = createMockPackage('moment');
+    const config = createConfig({
+      rules: {
+        forbid_packages: [{ severity: 'error', patterns: ['moment'] }],
+      },
+    });
+
+    const violations = detectBannedPackages([moment], config, ['moment']);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].packageName).toBe('moment');
+  });
+
+  it('matches a declared package against a glob forbid pattern', () => {
+    const config = createConfig({
+      rules: {
+        forbid_packages: [{ severity: 'warn', patterns: ['@legacy/*'] }],
+      },
+    });
+
+    const violations = detectBannedPackages([], config, ['@legacy/widget']);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].packageName).toBe('@legacy/widget');
+  });
+
+  it('does not flag a declared package excluded by packages.ignore', () => {
+    const config = createConfig({
+      packages: { ignore: ['@legacy/*'] },
+      rules: {
+        forbid_packages: [{ severity: 'error', patterns: ['@legacy/*'] }],
+      },
+    });
+
+    const violations = detectBannedPackages([], config, ['@legacy/widget']);
+
+    expect(violations).toEqual([]);
+  });
+
+  it('reports distribution packages before declared-only ones', () => {
+    const moment = createMockPackage('moment');
+    const config = createConfig({
+      rules: {
+        forbid_packages: [{ severity: 'error', patterns: ['moment', 'jest'] }],
+      },
+    });
+
+    const violations = detectBannedPackages([moment], config, [
+      'jest',
+      'moment',
+    ]);
+
+    expect(violations.map((v) => v.packageName)).toEqual(['moment', 'jest']);
+  });
 });
 
 describe('detectRequiredPackages', () => {


### PR DESCRIPTION
Fixes #75

## Problem

`forbid_packages` only ever saw packages found by import analysis, so a banned package that lives in `package.json` but is never `import`ed — dev/build tooling run via `npx`, an npm script, or a git hook — silently passed `hermex comply`.

The bug is a symptom of something structural: **each feature answered "what packages are in this repo?" for itself.**

| Source | Contains | Read by |
|---|---|---|
| `packageDistribution` | packages reachable from **JSX usage** ∩ lockfile-resolvable | packages table, versus, releaseAge, `forbid_packages` |
| lockfile `versions` | every package, root **and** transitive | `require_packages` |
| lockfile `resolutions` | `rootVersion` vs `allVersions` (the root/tree axis) | releaseAge `scope` |
| `package.json` | declared deps | `forbid_package_fields` |

Those sets disagree, so a package can be visible to one feature and invisible to another. #75 is one symptom; the `releaseAge.enforceOn` back-fill loop in `calculatePackageDistribution` was a local patch for the *same* gap in a second feature — which is why, with the right config, releaseAge could already see a package that `forbid_packages` could not.

## Fix

`buildPackageInventory` (`src/utils/package-inventory.ts`) builds **one list, once per run**, with an entry per package carrying all three axes:

- **declared** — which `package.json` bucket(s) list it, *and/or* the lockfile's own record of the root project's direct dependencies (pnpm `importers`, npm's root entry, yarn's manifest ranges). Two independent sources: a repo whose manifest can't be read still gets its direct dependencies checked, and a manifest entry missing from the lockfile is still checked too.
- **installed** — `rootVersion` for a direct dependency, `allVersions` for every resolved copy: the same `root` vs `tree` distinction `releaseAge.scope` already exposes to users.
- **used** — usage/component counts from import analysis.

`packages.ignore` / `packages.internal` resolve once into flags on the entry instead of being re-applied by each consumer.

Every consumer now **selects an axis** of that one list:

- `calculatePackageDistribution` → the *used* axis (plus installed `enforceOn` matches), so the back-fill loop is deleted.
- `detectBannedPackages` → `isOwnedByRepo`: declared and/or used, never purely transitive — the repo can't remove someone else's dependency, so flagging one would report a violation nobody can fix. This is the #75 fix, expressed as a scope rather than a special case.
- `detectRequiredPackages` → the installed axis, deliberately including ignored and transitive packages: "required" asks whether the package is available to the code, and `packages.ignore` is a reporting filter, not an uninstall.

If a rule ever needs the root/tree distinction, `isInstalled(entry, 'root' | 'tree')` is already there — #75 doesn't, so no config surface was added.

## Testing

**Fixtures now carry a package for every axis**, so the e2e suite exercises real data rather than hand-built objects. `fixtures/package.json` + `fixtures/pnpm-lock.yaml`:

| Package | Axis |
|---|---|
| `@design-system/foundation`, `react` | declared + installed + used |
| `moment` | declared + installed, never imported — the #75 case |
| `eslint` | declared but **not** installed (manifest/lockfile mismatch) |
| `react-dom` | lockfile root dependency this manifest omits |
| `js-tokens` | transitive only |

Seven new e2e tests assert each axis through the real CLI, including the two that pull in opposite directions: `eslint` is forbiddable (declared) while *failing* `require_packages` (not installed), and an ignored package drops out of `forbid_packages` while still satisfying `require_packages`. This matters because `src/commands/pipeline.ts` — where the manifest is read and threaded in — only runs inside the spawned process and has no unit coverage.

- **588 tests pass** (unit + e2e); typecheck, lint, format clean.
- **100% statements/branches/functions** on all five changed modules.
- **No observable change beyond the fix**: `scan --format json` is byte-identical for `packages`, `components`, `versus`, `ruleViolations`, `bannedPackageViolations` and `compliance` against the pre-refactor commit.

## Other findings addressed

- **A direct dependency was exempt** from forbid rules when neither imported nor in `package.json` — found by writing the `react-dom` fixture. The lockfile's root record now counts as declared (above).
- **enforceOn back-fill kept to *installed* packages.** The inventory also knows declared-but-uninstalled ones; those have no resolved version to date-check and would have added versionless rows that release-age enrichment then skips.
- **Glob compilation hoisted.** The inventory spans the whole lockfile now, so re-parsing `packages.ignore`/`internal` patterns per entry cost real time: 5k packages 122ms → 33ms, 20k → 98ms.
- **Prototype-safe manifest parsing.** A `__proto__` dependency key would have hit the prototype setter instead of becoming an own property; the declared map is now null-prototype, with a test.

## Known limitation

Only the manifest at the scan root (`process.cwd()`) is read — same scope as the existing rules rail (`evaluateRules`). In a monorepo, workspace-package manifests are not merged into the declared axis; their dependencies are still seen via the lockfile's installed axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
