### PR TITLE
feat: move patterns[] under summary as summary.patternCounts (#80)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -477,10 +477,9 @@ Severity is the only thing that decides which bucket a rule violation lands in; 
 | Field | What it holds |
 |---|---|
 | `version` | The hermex version that produced the report. |
-| `summary` | Aggregate counts: `filesAnalyzed`, `totalImports`, `totalComponents`, `totalUsagePatterns`. |
+| `summary` | Aggregate counts: `filesAnalyzed`, `totalImports`, `totalComponents`, `totalUsagePatterns`, plus `patternCounts` — per-pattern-type usage counts (`imports.named`, `usage.jsx`, …). |
 | `packages` | Every package the repo owns — see below. Carries version, `declaredIn`, usage counts, and `releaseAge` when enrichment ran. |
 | `components` | Every component found, with its source package, usage count and the files using it. The one place component names live. |
-| `patterns` | Per-pattern-type usage counts (`imports.named`, `usage.jsx`, …). |
 | `versus` | Head-to-head comparisons configured under `versus`. |
 | `ruleViolations` | **Every rule hit, in one list** — `detect_files`, `require_files`, `require_packages`, `forbid_packages`, `require_scripts`, `require_package_fields`, `forbid_package_fields`, `engine_version`, `codeowners`. Filter on `type`. |
 | `compliance` | The canonical verdict — see above. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ export interface HermexScanResult {
     totalImports: number;
     totalComponents: number;
     totalUsagePatterns: number;
+    /** `totalUsagePatterns` broken down by pattern type — aggregate counts, not per-item records (#80). */
+    patternCounts: import('./utils/pattern-counter').PatternCount[];
   };
   /**
    * Every package this repo owns — declared in `package.json`, a direct
@@ -70,7 +72,6 @@ export interface HermexScanResult {
    * component names live — `packages[]` carries only `componentCount` (#79).
    */
   components: HermexScanComponent[];
-  patterns: import('./utils/pattern-counter').PatternCount[];
   versus: import('./utils/versus').VersusResult[];
   /** Every rule hit, in one list — filter on `type` to single out a rule. */
   ruleViolations: import('./rules/evaluator').RuleViolation[];

--- a/src/utils/print-json.ts
+++ b/src/utils/print-json.ts
@@ -14,6 +14,11 @@ import { getVersion } from './version';
  * `ruleViolations` is the single list of every rule hit, `forbid_packages`
  * included (#77) — there is no second violations field to remember to read.
  *
+ * Every top-level key besides `version`, `summary` and `compliance` is a
+ * per-item dataset. `patternCounts` sits under `summary` rather than beside
+ * them (#80) because it is aggregate statistics — the same kind of number as
+ * `totalImports` next to it, just broken down by pattern type.
+ *
  * `compliance` defaults to `computeCompliance(aggregated)` so `scan --format
  * json` carries the same verdict as `comply`; callers that already computed
  * it (comply) pass it through to avoid recomputing.
@@ -29,13 +34,13 @@ export function printJson(
       totalImports: aggregated.totalImports,
       totalComponents: aggregated.totalComponents,
       totalUsagePatterns: aggregated.totalUsagePatterns,
+      patternCounts: aggregated.patternCounts,
     },
     packages: aggregated.packageDistribution,
     components: aggregated.topComponents.map((c) => ({
       ...c,
       files: [...c.files],
     })),
-    patterns: aggregated.patternCounts,
     versus: aggregated.versusResults,
     ruleViolations: aggregated.ruleViolations,
     compliance: {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -89,8 +89,10 @@ describe('CLI smoke tests', () => {
     expect(parsed).toHaveProperty('summary');
     expect(parsed).toHaveProperty('packages');
     expect(parsed).toHaveProperty('components');
-    expect(parsed).toHaveProperty('patterns');
     expect(parsed.summary).toHaveProperty('filesAnalyzed');
+    // Aggregate stats live under summary, not as a top-level field (#80).
+    expect(parsed).not.toHaveProperty('patterns');
+    expect(parsed.summary).toHaveProperty('patternCounts');
     // scan --format json carries the same official compliance verdict as
     // comply, so consumers get a canonical status off either command (#55).
     expect(parsed).toHaveProperty('compliance');
@@ -567,7 +569,6 @@ describe('package inventory axes (end to end)', () => {
       'summary',
       'packages',
       'components',
-      'patterns',
       'versus',
       'ruleViolations',
       'compliance',

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -1487,7 +1487,6 @@ describe('printJson', () => {
       'summary',
       'packages',
       'components',
-      'patterns',
       'versus',
       'ruleViolations',
       'compliance',
@@ -1496,6 +1495,31 @@ describe('printJson', () => {
     expect(parsed.summary.totalImports).toBe(10);
     expect(parsed.summary.totalComponents).toBe(3);
     expect(parsed.summary.totalUsagePatterns).toBe(7);
+  });
+
+  // #80: these are aggregate counts — the same kind of number as
+  // totalUsagePatterns beside them, just broken down by pattern type — so
+  // they belong in summary rather than alongside the per-item datasets.
+  it('nests pattern counts under summary rather than as a top-level field', () => {
+    printJson(
+      makeAggregated({
+        patternCounts: [
+          { patternType: 'usage.jsx', displayName: 'JSX Usage', count: 5 },
+          {
+            patternType: 'imports.named',
+            displayName: 'Named Imports',
+            count: 2,
+          },
+        ],
+      }),
+    );
+
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+    expect(parsed).not.toHaveProperty('patterns');
+    expect(parsed.summary.patternCounts).toEqual([
+      { patternType: 'usage.jsx', displayName: 'JSX Usage', count: 5 },
+      { patternType: 'imports.named', displayName: 'Named Imports', count: 2 },
+    ]);
   });
 
   it('emits the official compliance verdict (status + counts) so consumers need not re-derive it (#55)', () => {


### PR DESCRIPTION
Closes #80.

## Problem

`patterns[]` was a top-level key sitting beside `packages[]`, `versus[]` and `ruleViolations[]` — all per-item datasets — while containing nothing but aggregate statistics:

```json
"patterns": [
  { "patternType": "imports.named", "displayName": "Named Imports", "count": 205 },
  { "patternType": "usage.jsx",     "displayName": "JSX Usage",     "count": 388 }
]
```

16 rows of counts. The name also implied per-pattern or per-file records, which it never held.

## Change

It moves to `summary.patternCounts`:

```jsonc
"summary": {
  "filesAnalyzed": 17,
  "totalImports": 42,
  "totalComponents": 19,
  "totalUsagePatterns": 96,
  "patternCounts": [ { "patternType": "usage.jsx", "displayName": "JSX Usage", "count": 64 }, … ]
}
```

It's the same kind of number as `totalUsagePatterns` already beside it, just broken down by type. The issue offered renaming in place to `patternCounts` instead — that fixes the name but leaves aggregate statistics in the per-item neighbourhood, which is the other half of the complaint.

## Migration

| Before | After |
|---|---|
| `patterns` | `summary.patternCounts` |

Same array, same order, same element shape. Consistent with #77–#79, this ships as `feat:` rather than a major.

## Verification

`build`, `typecheck`, `lint`, `format:ci` clean; **605 tests across 36 files pass**.

Diffed `scan --format json` on `fixtures/` against a scratch build of `origin/main` (2.10.0):

```
everything except summary/patterns identical: true
summary scalars identical:                    true
moved array identical:                        true
base top-level: version,summary,packages,components,patterns,versus,ruleViolations,compliance
now  top-level: version,summary,packages,components,versus,ruleViolations,compliance
```

Human stdout is **byte-for-byte identical** — the patterns table reads `aggregated.patternCounts` directly and never went through the JSON shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
