### PR TITLE
chore: remove config-v2

### DIFF
--- a/config-v2/.hermex.json
+++ b/config-v2/.hermex.json
@@ -1,9 +1,0 @@
-{
-  "$schema2": "...",
-  "files": {
-    "includes": ["**", "!!**/dist", "!!code-examples/**"]
-  },
-  "imports": ["/@biomejs/biome"],
-  "ignoreImports": [],
-  "summary": "log"
-}


### PR DESCRIPTION
## Summary
- Removes the unused `config-v2/` directory (only contained `.hermex.json`)

## Test plan
- N/A — directory removal only, not part of the published package or docs