### PR TITLE
perf(output-review): reuse node_modules for the reference build

### DIFF
--- a/scripts/output-review.ts
+++ b/scripts/output-review.ts
@@ -33,6 +33,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -439,11 +440,41 @@ function buildReference(ref: string): string {
   rmSync(worktree, { recursive: true, force: true });
   mkdirSync(REFERENCE_DIR, { recursive: true });
 
+  // git tracks a worktree's registration separately from its directory —
+  // deleting `worktree` above (or the whole of .output-review/, which
+  // isn't a git operation) leaves that registration behind, and `add`
+  // refuses to reuse the path until it's pruned.
+  run('git', ['worktree', 'prune'], ROOT);
+
   // `--detach`: a branch name would collide if that same branch happens to
   // be checked out in the primary worktree already (running this on `main`
   // itself, for instance). A bare SHA has no such conflict.
   run('git', ['worktree', 'add', '--detach', worktree, sha], ROOT);
-  run('pnpm', ['install', '--frozen-lockfile'], worktree);
+
+  // A full `pnpm install` is most of this function's cost — network,
+  // dependency resolution, thousands of files. It's also almost always
+  // unnecessary: this tree's own `node_modules` already satisfies the
+  // reference commit's dependencies whenever its lockfile is byte-identical
+  // to this tree's, which the vast majority of PRs never touch. Reuse it
+  // via a symlink in that case; only fall back to a real install when the
+  // lockfile actually differs, or this tree has no node_modules to reuse
+  // (a first run with no prior `pnpm install` at all).
+  const sameLockfile =
+    existsSync(join(ROOT, 'node_modules')) &&
+    existsSync(join(worktree, 'pnpm-lock.yaml')) &&
+    readFileSync(join(ROOT, 'pnpm-lock.yaml'), 'utf8') ===
+      readFileSync(join(worktree, 'pnpm-lock.yaml'), 'utf8');
+
+  if (sameLockfile) {
+    symlinkSync(
+      join(ROOT, 'node_modules'),
+      join(worktree, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+  } else {
+    run('pnpm', ['install', '--frozen-lockfile'], worktree);
+  }
+
   run('pnpm', ['run', 'build'], worktree);
   return cli;
 }


### PR DESCRIPTION
## Summary

`buildReference()` was doing a full `pnpm install --frozen-lockfile` inside the reference worktree on every cache miss — the most expensive part of building the comparison target, and almost always unnecessary: this tree's own `node_modules` already has everything the reference commit needs, as long as its `pnpm-lock.yaml` is byte-identical to this tree's, which the large majority of PRs never touch (they don't change dependencies).

Now it symlinks this tree's `node_modules` into the reference worktree when the lockfiles match, and only falls back to a real install when they genuinely differ.

Also fixes a bug this surfaced along the way: deleting `.output-review/reference/` (or just `.output-review/` wholesale) outside of git leaves the worktree's registration behind in `.git/worktrees/`, so a later `git worktree add` at the same path fails with "missing but already registered". Added `git worktree prune` before `add`.

## Test plan

- [x] Cleared the reference cache, ran `pnpm run test:output`, confirmed via `ls -la` that `node_modules` in the reference worktree is a real symlink pointing at this tree's `node_modules` (not a copy or directory)
- [x] Forced a lockfile mismatch (appended a comment to `pnpm-lock.yaml`), confirmed the reference worktree's `node_modules` came back as a real directory (fallback path taken correctly), then reverted
- [x] `pnpm run typecheck`, `lint:ci`, `format:ci`
- [x] `pnpm run test:ci` (666 tests)
- [x] `pnpm run test:output` (all 26 cases match `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)