### PR TITLE
perf(ci): cache the target branch's reference build

### DIFF
--- a/.github/workflows/output-review.yaml
+++ b/.github/workflows/output-review.yaml
@@ -309,3 +309,4 @@ jobs:
       - name: Nothing to approve
         if: needs.review.outputs.changed == 'false'
         run: echo "Output matches the target branch — no approval needed."
+

--- a/.github/workflows/output-review.yaml
+++ b/.github/workflows/output-review.yaml
@@ -85,6 +85,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # scripts/output-review.ts builds `--against` itself (git worktree,
+      # install, build) into .output-review/reference/<sha>/ and reuses that
+      # path if it already exists — this just gives it something to find
+      # already there. Keyed on the target branch's exact commit, so it hits
+      # on every PR run until that branch moves, and misses (falling back to
+      # the script doing the real build once, which the post-job save step
+      # then caches) the first run after it does.
+      - name: Cache the target branch's reference build
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: .output-review/reference/${{ github.event.pull_request.base.sha }}
+          key: output-review-reference-${{ github.event.pull_request.base.sha }}
+
       # OUTPUT_REVIEW_SITE is the Pages base URL, e.g.
       # https://gallevy.github.io/hermex/output-review. Setting it is what
       # switches the per-case pages on: the comment then links a page per

--- a/.github/workflows/output-review.yaml
+++ b/.github/workflows/output-review.yaml
@@ -309,4 +309,3 @@ jobs:
       - name: Nothing to approve
         if: needs.review.outputs.changed == 'false'
         run: echo "Output matches the target branch — no approval needed."
-


### PR DESCRIPTION
## Summary

Replaces the reverted node_modules-symlink approach (#131) with the correct fix: cache the whole target-branch reference build (dist/ + node_modules/ together, no need to reason about dependencies at all) via actions/cache, keyed on the target branch's resolved commit SHA.

- Cache hit (the common case — most PRs run after main's already been built once): buildReference() finds the build already at .output-review/reference/<sha>/ and does nothing.
- Cache miss (first PR after main advances): builds once, same as today, then the cache is saved for every other PR until main moves again.

No script changes — this is purely a workflow-level concern, using GitHub's own caching primitive instead of hand-rolled logic in scripts/output-review.ts.

## Test plan

- [x] `pnpm run typecheck`, `lint:ci`, `format:ci`
- [x] `pnpm run test:ci` (666 tests)
- [x] `pnpm run test:output` (all 26 cases match `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)