### PR TITLE
fix(json): respect output.* section toggles in --format json

### DIFF
--- a/.changeset/tall-pugs-repeat.md
+++ b/.changeset/tall-pugs-repeat.md
@@ -1,0 +1,9 @@
+---
+"hermex": major
+---
+
+`--format json` now honours the `output.*` section toggles instead of always dumping the full report (#63, #91). `output.packages: false` omits `packages`, `output.components: false` omits `components`, `output.versus: false` omits `versus`, and `output.patterns: false` omits `summary.patternCounts` — the keys are dropped entirely rather than emitted empty, so disabling a section actually shrinks the file (`components[]` and `packages[]` are the bulk of a stored scan).
+
+`version`, the `summary` counters, `ruleViolations` and `compliance` are never gated: they are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so honouring it here would make the JSON lossier than the terminal output it mirrors. `output.details` and `output.summary` have no JSON counterpart.
+
+Default output is unchanged — every section is enabled by default. Consumers of the exported `HermexScanResult` type will see `packages`, `components`, `versus` and `summary.patternCounts` marked optional, matching the fields a config can now remove.

--- a/.changeset/tall-pugs-repeat.md
+++ b/.changeset/tall-pugs-repeat.md
@@ -2,8 +2,8 @@
 "hermex": major
 ---
 
-`--format json` now honours the `output.*` section toggles instead of always dumping the full report (#63, #91). `output.packages: false` omits `packages`, `output.components: false` omits `components`, `output.versus: false` omits `versus`, and `output.patterns: false` omits `summary.patternCounts` — the keys are dropped entirely rather than emitted empty, so disabling a section actually shrinks the file (`components[]` and `packages[]` are the bulk of a stored scan).
+`--format json` now honours the `output.*` section toggles instead of always dumping the full report (#63, #91). `output.packages: false` omits `packages`, `output.components: false` omits `components`, and `output.versus: false` omits `versus` — the keys are dropped entirely rather than emitted empty, so disabling a section actually shrinks the file (`components[]` and `packages[]` are the bulk of a stored scan). `summary.patternCounts` drops when `output.patterns` and `output.details` are both false, since both of those human sections render that same array.
 
-`version`, the `summary` counters, `ruleViolations` and `compliance` are never gated: they are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so honouring it here would make the JSON lossier than the terminal output it mirrors. `output.details` and `output.summary` have no JSON counterpart.
+`version`, the `summary` counters, `ruleViolations` and `compliance` are never gated: they are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so honouring it here would make the JSON lossier than the terminal output it mirrors. `output.summary` has no clean JSON counterpart — the human Summary table shows derived metrics that share only `filesAnalyzed` with the serialized counters.
 
 Default output is unchanged — every section is enabled by default. Consumers of the exported `HermexScanResult` type will see `packages`, `components`, `versus` and `summary.patternCounts` marked optional, matching the fields a config can now remove.

--- a/.changeset/tall-pugs-repeat.md
+++ b/.changeset/tall-pugs-repeat.md
@@ -1,9 +1,9 @@
 ---
-"hermex": major
+"hermex": patch
 ---
 
 `--format json` now honours the `output.*` section toggles instead of always dumping the full report (#63, #91). `output.packages: false` omits `packages`, `output.components: false` omits `components`, and `output.versus: false` omits `versus` — the keys are dropped entirely rather than emitted empty, so disabling a section actually shrinks the file (`components[]` and `packages[]` are the bulk of a stored scan). `summary.patternCounts` drops when `output.patterns` and `output.details` are both false, since both of those human sections render that same array.
 
 `version`, the `summary` counters, `ruleViolations` and `compliance` are never gated: they are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so honouring it here would make the JSON lossier than the terminal output it mirrors. `output.summary` has no clean JSON counterpart — the human Summary table shows derived metrics that share only `filesAnalyzed` with the serialized counters.
 
-Default output is unchanged — every section is enabled by default. Consumers of the exported `HermexScanResult` type will see `packages`, `components`, `versus` and `summary.patternCounts` marked optional, matching the fields a config can now remove.
+Default output is unchanged — every section is enabled by default, so this only takes effect for a config that explicitly opts a section out. `packages`, `components`, `versus` and `summary.patternCounts` on the exported `HermexScanResult` type become optional, matching the fields a config can now remove.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -505,10 +505,12 @@ export default defineConfig({
 | `output.packages: false` | omits `packages` |
 | `output.components: false` | omits `components` |
 | `output.versus: false` | omits `versus` |
-| `output.patterns: false` | omits `summary.patternCounts` |
-| `output.rules`, `output.summary`, `output.details` | **no effect** — see below |
+| `output.patterns: false` **and** `output.details: false` | omits `summary.patternCounts` |
+| `output.rules`, `output.summary` | **no effect** — see below |
 
-`version`, the `summary` counters, `ruleViolations` and `compliance` are always emitted. They are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so gating them here would make the JSON lossier than the terminal output it mirrors — a silent way to blind CI. `output.details` has no JSON counterpart (per-file details are not serialized at all).
+`patternCounts` is the one field that answers to two toggles, because both human sections render that same array — the Patterns section as a table/chart, the Details section as a flat list. It therefore only drops when *both* are off; gating on `output.patterns` alone would strip it from the JSON while the terminal still printed it under Details. (`output.details` has no other effect on JSON — despite the name, that section prints pattern totals, not per-file records.)
+
+`version`, the `summary` counters, `ruleViolations` and `compliance` are always emitted. They are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so gating them here would make the JSON lossier than the terminal output it mirrors — a silent way to blind CI. `output.summary` has no counterpart either: the human Summary table shows derived metrics (package count, external components, total usages) that share only `filesAnalyzed` with the counters serialized here, so there is no JSON field it cleanly owns.
 
 Because a disabled section is absent rather than empty, narrow before reading it — `result.components ?? []` — and note that `TypeScript`'s `HermexScanResult` marks exactly these fields optional.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -486,6 +486,32 @@ Severity is the only thing that decides which bucket a rule violation lands in; 
 
 `ruleViolations` is the single source of truth for rule hits. Entries share a common shape (`ruleId`, `severity`, `patterns`, `message?`, `matchedFiles`) and add per-type fields where they apply: `packageName` for `no-packages`, `fieldPath`/`actualValue` for the package-field rules, `installedRange`/`requiredRange` for `require-engine-version`.
 
+#### Trimming the JSON with `output.*`
+
+The [output section toggles](#output-control) apply to `--format json` exactly as they do to the human printers. A section switched off is **omitted from the payload**, not emitted as an empty array — the point is a smaller file, and on a large repo `components[]` and `packages[]` are the bulk of it:
+
+```ts
+export default defineConfig({
+  output: {
+    format: 'json',
+    components: false, // no `components` key at all
+    packages: false, // no `packages` key at all
+  },
+});
+```
+
+| Config | Effect on the JSON |
+|---|---|
+| `output.packages: false` | omits `packages` |
+| `output.components: false` | omits `components` |
+| `output.versus: false` | omits `versus` |
+| `output.patterns: false` | omits `summary.patternCounts` |
+| `output.rules`, `output.summary`, `output.details` | **no effect** — see below |
+
+`version`, the `summary` counters, `ruleViolations` and `compliance` are always emitted. They are the machine-readable verdict, and `comply` prints rules in human mode regardless of `output.rules`, so gating them here would make the JSON lossier than the terminal output it mirrors — a silent way to blind CI. `output.details` has no JSON counterpart (per-file details are not serialized at all).
+
+Because a disabled section is absent rather than empty, narrow before reading it — `result.components ?? []` — and note that `TypeScript`'s `HermexScanResult` marks exactly these fields optional.
+
 #### What `packages[]` contains
 
 Every package the repo **owns**: declared in `package.json` (any dependency bucket), recorded as a direct dependency by the lockfile, or imported by scanned source. Purely transitive dependencies are excluded — they arrive through another package, so this stays your own dependency surface rather than the whole lockfile.
@@ -554,6 +580,8 @@ export default defineConfig({
   },
 });
 ```
+
+These are not human-format-only: `packages`, `components`, `patterns` and `versus` also drop the matching field from `--format json` — see [Trimming the JSON with `output.*`](#trimming-the-json-with-output).
 
 ## Full Example
 

--- a/scripts/output-review.ts
+++ b/scripts/output-review.ts
@@ -1650,6 +1650,21 @@ export const SITE_STYLE = [
   '    color: #c9d1d9;',
   '  }',
   '',
+  // Rouge wraps every fenced block as `.highlight > pre.highlight`, and
+  // Primer styles the *inner* pre via `.markdown-body .highlight pre`
+  // (specificity 0,2,1) — one tag more specific than `.markdown-body pre`
+  // above (0,2,0 with the `.highlight` alternative dropped, since `pre` is
+  // a descendant of `.highlight` here, not `.highlight` itself). That beats
+  // our rule regardless of source order, so every code, diff and config
+  // block — the entire comparison this site exists to show — kept Primer's
+  // light background (#f6f8fa) under our light text, unreadable. Matching
+  // Primer's own selector exactly ties the specificity, and ours wins the
+  // tie by coming later.
+  '  .markdown-body .highlight pre {',
+  '    background-color: #161b22;',
+  '    color: #c9d1d9;',
+  '  }',
+  '',
   '  .markdown-body pre {',
   '    border-color: #30363d;',
   '  }',

--- a/src/commands/comply.ts
+++ b/src/commands/comply.ts
@@ -84,7 +84,7 @@ export async function executeComply(
     const compliance = computeCompliance(aggregated);
 
     if (isJson) {
-      printJson(aggregated, compliance);
+      printJson(aggregated, config.output, compliance);
     } else {
       printRules(aggregated);
       if (config.releaseAge.enabled) {

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -56,7 +56,7 @@ export async function executeScan(
     if (!aggregated) return;
 
     if (isJson) {
-      printJson(aggregated);
+      printJson(aggregated, config.output);
     } else {
       printScanResults(aggregated, config);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,12 @@ export interface HermexScanResult {
     totalImports: number;
     totalComponents: number;
     totalUsagePatterns: number;
-    /** `totalUsagePatterns` broken down by pattern type — aggregate counts, not per-item records (#80). Omitted when `output.patterns: false`. */
+    /**
+     * `totalUsagePatterns` broken down by pattern type — aggregate counts,
+     * not per-item records (#80). Omitted only when `output.patterns` **and**
+     * `output.details` are both false: the Patterns and Details sections
+     * render this same array, so either one being on keeps it.
+     */
     patternCounts?: import('./utils/pattern-counter').PatternCount[];
   };
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,14 @@ export interface HermexScanComponent extends Omit<
   files: string[];
 }
 
-/** Shape of the JSON emitted by `hermex scan --format json` (see `printJson`) */
+/**
+ * Shape of the JSON emitted by `hermex scan --format json` (see `printJson`).
+ *
+ * The optional fields are the ones `output.*` can switch off (#63, #91): a
+ * disabled section is omitted from the payload entirely rather than emitted
+ * empty, so narrow the field before reading it. They are all present under
+ * the default config — only an explicit `output.<section>: false` removes one.
+ */
 export interface HermexScanResult {
   version: string;
   summary: {
@@ -56,24 +63,30 @@ export interface HermexScanResult {
     totalImports: number;
     totalComponents: number;
     totalUsagePatterns: number;
-    /** `totalUsagePatterns` broken down by pattern type — aggregate counts, not per-item records (#80). */
-    patternCounts: import('./utils/pattern-counter').PatternCount[];
+    /** `totalUsagePatterns` broken down by pattern type — aggregate counts, not per-item records (#80). Omitted when `output.patterns: false`. */
+    patternCounts?: import('./utils/pattern-counter').PatternCount[];
   };
   /**
    * Every package this repo owns — declared in `package.json`, a direct
    * dependency in the lockfile, and/or imported by scanned source (#78).
    * Purely transitive dependencies are excluded. `usageCount` is component
    * usage, so a package used only as a function reads 0 while still being a
-   * real dependency.
+   * real dependency. Omitted when `output.packages: false`.
    */
-  packages: import('./utils/package-distribution').PackageDistribution[];
+  packages?: import('./utils/package-distribution').PackageDistribution[];
   /**
    * Every component found, with the package it came from. The one place
    * component names live — `packages[]` carries only `componentCount` (#79).
+   * Omitted when `output.components: false`.
    */
-  components: HermexScanComponent[];
-  versus: import('./utils/versus').VersusResult[];
-  /** Every rule hit, in one list — filter on `type` to single out a rule. */
+  components?: HermexScanComponent[];
+  /** Omitted when `output.versus: false`. */
+  versus?: import('./utils/versus').VersusResult[];
+  /**
+   * Every rule hit, in one list — filter on `type` to single out a rule.
+   * Always present: it is part of the compliance verdict, so no `output.*`
+   * toggle (`output.rules` included) removes it.
+   */
   ruleViolations: import('./rules/evaluator').RuleViolation[];
   /**
    * The official compliance verdict — read `status` instead of re-deriving

--- a/src/utils/print-json.ts
+++ b/src/utils/print-json.ts
@@ -28,14 +28,21 @@ import { getVersion } from './version';
  * - `output.packages: false` drops `packages`
  * - `output.components: false` drops `components`
  * - `output.versus: false` drops `versus`
- * - `output.patterns: false` drops `summary.patternCounts`
+ * - `summary.patternCounts` needs *both* `output.patterns` and
+ *   `output.details` off before it drops, because both sections render that
+ *   same array — `printPatterns` as a table/chart, `printDetails` as a flat
+ *   list. Gating on `patterns` alone would drop it from the JSON while the
+ *   terminal still printed it under Details.
  *
  * `version`, the `summary` counters, `ruleViolations` and `compliance` are
  * never gated: together they are the machine-readable verdict, and `comply`'s
  * human path prints rules unconditionally too, so honouring `output.rules`
  * here would make JSON *lossier* than the terminal it mirrors — a silent way
- * to blind CI. `output.details` and `output.summary` have no JSON counterpart
- * (per-file details are not serialized; the counters are always present).
+ * to blind CI. That same rule is what forces the `patterns`/`details` pairing
+ * above. `output.summary` has no counterpart either: the human Summary table
+ * shows derived metrics (package count, external components, total usages)
+ * that share only `filesAnalyzed` with the counters serialized here, so there
+ * is no field it cleanly owns.
  *
  * `compliance` defaults to `computeCompliance(aggregated)` so `scan --format
  * json` carries the same verdict as `comply`; callers that already computed
@@ -53,7 +60,9 @@ export function printJson(
       totalImports: aggregated.totalImports,
       totalComponents: aggregated.totalComponents,
       totalUsagePatterns: aggregated.totalUsagePatterns,
-      ...(output.patterns ? { patternCounts: aggregated.patternCounts } : {}),
+      ...(output.patterns || output.details
+        ? { patternCounts: aggregated.patternCounts }
+        : {}),
     },
     ...(output.packages ? { packages: aggregated.packageDistribution } : {}),
     ...(output.components

--- a/src/utils/print-json.ts
+++ b/src/utils/print-json.ts
@@ -1,5 +1,6 @@
 import type { AggregatedReport } from './aggregator';
 import type { ComplianceResult } from './compliance';
+import type { OutputConfig } from '../config/types';
 import { computeCompliance } from './compliance';
 import { getVersion } from './version';
 
@@ -19,12 +20,30 @@ import { getVersion } from './version';
  * them (#80) because it is aggregate statistics — the same kind of number as
  * `totalImports` next to it, just broken down by pattern type.
  *
+ * The `output.*` section toggles apply here exactly as they do to the human
+ * printers (#63, #91) — a dataset switched off is *omitted*, not emptied, so
+ * disabling it actually shrinks the payload (`components[]` and `packages[]`
+ * dominate the file size of a stored scan). The split:
+ *
+ * - `output.packages: false` drops `packages`
+ * - `output.components: false` drops `components`
+ * - `output.versus: false` drops `versus`
+ * - `output.patterns: false` drops `summary.patternCounts`
+ *
+ * `version`, the `summary` counters, `ruleViolations` and `compliance` are
+ * never gated: together they are the machine-readable verdict, and `comply`'s
+ * human path prints rules unconditionally too, so honouring `output.rules`
+ * here would make JSON *lossier* than the terminal it mirrors — a silent way
+ * to blind CI. `output.details` and `output.summary` have no JSON counterpart
+ * (per-file details are not serialized; the counters are always present).
+ *
  * `compliance` defaults to `computeCompliance(aggregated)` so `scan --format
  * json` carries the same verdict as `comply`; callers that already computed
  * it (comply) pass it through to avoid recomputing.
  */
 export function printJson(
   aggregated: AggregatedReport,
+  output: OutputConfig,
   compliance: ComplianceResult = computeCompliance(aggregated),
 ): void {
   const result = {
@@ -34,14 +53,18 @@ export function printJson(
       totalImports: aggregated.totalImports,
       totalComponents: aggregated.totalComponents,
       totalUsagePatterns: aggregated.totalUsagePatterns,
-      patternCounts: aggregated.patternCounts,
+      ...(output.patterns ? { patternCounts: aggregated.patternCounts } : {}),
     },
-    packages: aggregated.packageDistribution,
-    components: aggregated.topComponents.map((c) => ({
-      ...c,
-      files: [...c.files],
-    })),
-    versus: aggregated.versusResults,
+    ...(output.packages ? { packages: aggregated.packageDistribution } : {}),
+    ...(output.components
+      ? {
+          components: aggregated.topComponents.map((c) => ({
+            ...c,
+            files: [...c.files],
+          })),
+        }
+      : {}),
+    ...(output.versus ? { versus: aggregated.versusResults } : {}),
     ruleViolations: aggregated.ruleViolations,
     compliance: {
       status: compliance.status,

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -102,6 +102,49 @@ describe('CLI smoke tests', () => {
     );
   });
 
+  // #63/#91: output.* used to gate only the human printers, so `components:
+  // false` still shipped a full components[] — the largest part of a stored
+  // scan file — and consumers had to strip it downstream.
+  it('output.* section toggles omit the matching fields from --format json', () => {
+    const configPath = join(
+      ROOT,
+      'tests',
+      'e2e',
+      'hermex-json-trimmed.config.ts',
+    );
+    const result = run(['scan', '--config', configPath]);
+    expect(result.status).toBe(0);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).not.toHaveProperty('components');
+    expect(parsed).not.toHaveProperty('packages');
+    expect(parsed).not.toHaveProperty('versus');
+    expect(parsed.summary).not.toHaveProperty('patternCounts');
+    // The counters and the verdict are never gated — CI reads those.
+    expect(parsed.summary).toHaveProperty('filesAnalyzed');
+    expect(parsed).toHaveProperty('ruleViolations');
+    expect(parsed).toHaveProperty('compliance');
+  });
+
+  it('keeps ruleViolations in comply --format json even with output.rules false', () => {
+    const configPath = join(
+      ROOT,
+      'tests',
+      'e2e',
+      'hermex-json-trimmed.config.ts',
+    );
+    const result = run(['comply', '--config', configPath]);
+    expect(result.status).toBe(1);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.compliance.status).toBe('non-compliant');
+    expect(
+      parsed.ruleViolations.some(
+        (v: { ruleId: string }) => v.ruleId === 'require-files',
+      ),
+    ).toBe(true);
+  });
+
   it('skips .d.ts files instead of reporting them as parse errors (#22)', () => {
     const configPath = join(ROOT, 'tests', 'e2e', 'hermex-dts.config.ts');
     const result = run(['scan', '--config', configPath]);

--- a/tests/e2e/hermex-json-trimmed.config.ts
+++ b/tests/e2e/hermex-json-trimmed.config.ts
@@ -1,0 +1,15 @@
+// Every trimmable section switched off (#63, #91) — JSON mode must honour
+// these the same way the human printers do.
+export default {
+  rules: {
+    'require-files': [{ severity: 'error', patterns: ['.nvmrc'] }],
+  },
+  output: {
+    format: 'json',
+    components: false,
+    packages: false,
+    patterns: false,
+    versus: false,
+    rules: false,
+  },
+};

--- a/tests/e2e/hermex-json-trimmed.config.ts
+++ b/tests/e2e/hermex-json-trimmed.config.ts
@@ -8,7 +8,10 @@ export default {
     format: 'json',
     components: false,
     packages: false,
+    // Both, because the Details section renders the same patternCounts array
+    // the Patterns section does.
     patterns: false,
+    details: false,
     versus: false,
     rules: false,
   },

--- a/tests/scripts/output-review.test.ts
+++ b/tests/scripts/output-review.test.ts
@@ -6,6 +6,7 @@ import {
   diffHunks,
   INVARIANTS,
   scrub,
+  SITE_STYLE,
   unifiedDiff,
 } from '../../scripts/output-review';
 import type { CaseResult, FixtureCase } from '../../scripts/output-review';
@@ -451,5 +452,37 @@ describe('buildSite', () => {
         null,
       ).get('bare.md') ?? '';
     expect(page).toContain('schema defaults');
+  });
+});
+
+/**
+ * Rouge (the syntax highlighter jekyll-theme-primer's Markdown renders
+ * fenced code through) wraps every block as `.highlight > pre.highlight`,
+ * and Primer's own stylesheet styles the *inner* pre via the selector
+ * `.markdown-body .highlight pre` (two classes + a tag). A dark-mode
+ * override written as `.markdown-body pre { background-color: ... }` (one
+ * class + a tag) is less specific and silently loses regardless of source
+ * order, leaving every code, diff and config block on the site — the
+ * entire comparison a reviewer opens the page to read — with light text on
+ * Primer's light background. This pins the selector that fixes it so the
+ * mismatch can't come back unnoticed.
+ */
+describe('SITE_STYLE dark mode', () => {
+  it('overrides the pre background at the same specificity Primer\'s own "highlight pre" selector uses', () => {
+    expect(SITE_STYLE).toContain('.markdown-body .highlight pre {');
+  });
+
+  it('sets a dark background and light text together on that selector', () => {
+    const start = SITE_STYLE.indexOf('.markdown-body .highlight pre {');
+    const block = SITE_STYLE.slice(start, SITE_STYLE.indexOf('}', start));
+    expect(block).toContain('background-color: #161b22');
+    expect(block).toContain('color: #c9d1d9');
+  });
+
+  it('places the override inside the prefers-color-scheme: dark block, not globally', () => {
+    const darkStart = SITE_STYLE.indexOf('prefers-color-scheme: dark');
+    const selectorIndex = SITE_STYLE.indexOf('.markdown-body .highlight pre {');
+    expect(darkStart).toBeGreaterThan(-1);
+    expect(selectorIndex).toBeGreaterThan(darkStart);
   });
 });

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -1726,12 +1726,30 @@ describe('printJson', () => {
     });
 
     it('omits summary.patternCounts when output.patterns is false, keeping the counters', () => {
-      printJson(trimmable, makeOutput({ patterns: false }));
+      printJson(trimmable, makeOutput({ patterns: false, details: false }));
 
       const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
       expect(parsed.summary).not.toHaveProperty('patternCounts');
       expect(parsed.summary.filesAnalyzed).toBe(5);
       expect(parsed.summary.totalUsagePatterns).toBe(7);
+    });
+
+    // printDetails renders the same patternCounts array as printPatterns (a
+    // flat list rather than a table), so gating on output.patterns alone
+    // would strip the field while the terminal still printed it under
+    // Details — the JSON must never be lossier than the human output.
+    it('keeps summary.patternCounts when patterns is off but details is on', () => {
+      printJson(trimmable, makeOutput({ patterns: false, details: true }));
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed.summary.patternCounts).toHaveLength(1);
+    });
+
+    it('keeps summary.patternCounts when details is off but patterns is on', () => {
+      printJson(trimmable, makeOutput({ patterns: 'chart', details: false }));
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed.summary.patternCounts).toHaveLength(1);
     });
 
     // A disabled section is absent, not `[]` — shrinking the payload is the
@@ -1743,6 +1761,7 @@ describe('printJson', () => {
           packages: false,
           components: false,
           patterns: false,
+          details: false,
           versus: false,
         }),
       );

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AggregatedReport } from '../../src/utils/aggregator';
 import type { RuleViolation } from '../../src/rules/evaluator';
+import type { OutputConfig } from '../../src/config/types';
+import { HermexConfigSchema } from '../../src/config/schema';
 import { printSummary } from '../../src/utils/print-summary';
 import { stripAnsi } from '../../src/utils/severity-format';
 import {
@@ -81,6 +83,14 @@ function makeAggregated(
     reports: [],
     ...overrides,
   };
+}
+
+/**
+ * The `output` block a user gets with no config at all — read off the schema
+ * rather than hand-written, so these tests can't drift from the real defaults.
+ */
+function makeOutput(overrides: Partial<OutputConfig> = {}): OutputConfig {
+  return { ...HermexConfigSchema.parse({}).output, ...overrides };
 }
 
 let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -1476,7 +1486,7 @@ describe('printJson', () => {
   });
 
   it('writes parseable JSON with the expected top-level shape', () => {
-    printJson(makeAggregated());
+    printJson(makeAggregated(), makeOutput());
 
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const written = stdoutSpy.mock.calls[0][0] as string;
@@ -1512,6 +1522,7 @@ describe('printJson', () => {
           },
         ],
       }),
+      makeOutput(),
     );
 
     const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
@@ -1523,7 +1534,7 @@ describe('printJson', () => {
   });
 
   it('emits the official compliance verdict (status + counts) so consumers need not re-derive it (#55)', () => {
-    printJson(makeAggregated());
+    printJson(makeAggregated(), makeOutput());
 
     const written = stdoutSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(written);
@@ -1546,6 +1557,7 @@ describe('printJson', () => {
       makeAggregated({
         ruleViolations: [forbidViolation('moment', 'error', 'Use dayjs')],
       }),
+      makeOutput(),
     );
 
     const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
@@ -1578,6 +1590,7 @@ describe('printJson', () => {
           },
         ],
       }),
+      makeOutput(),
     );
 
     const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
@@ -1595,7 +1608,7 @@ describe('printJson', () => {
         },
       ],
     });
-    printJson(aggregated);
+    printJson(aggregated, makeOutput());
 
     const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
     expect(parsed.compliance.status).toBe('warning');
@@ -1620,7 +1633,7 @@ describe('printJson', () => {
         }),
       ],
     });
-    printJson(aggregated);
+    printJson(aggregated, makeOutput());
 
     const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
     expect(parsed.compliance.status).toBe('compliant');
@@ -1629,7 +1642,7 @@ describe('printJson', () => {
 
   it('passes an explicitly provided compliance result straight through (#55)', () => {
     const aggregated = makeAggregated();
-    printJson(aggregated, {
+    printJson(aggregated, makeOutput(), {
       compliant: false,
       status: 'non-compliant',
       errorRuleViolations: [
@@ -1661,12 +1674,128 @@ describe('printJson', () => {
         },
       ],
     });
-    printJson(aggregated);
+    printJson(aggregated, makeOutput());
 
     const written = stdoutSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(written);
     expect(parsed.components).toHaveLength(1);
     expect(parsed.components[0].name).toBe('Button');
     expect(parsed.components[0].files).toEqual(['a.tsx', 'b.tsx']);
+  });
+
+  // #63/#91: output.* used to gate only the human printers, so a consumer
+  // asking for a slim report still got the full payload and had to strip it
+  // downstream. components[] and packages[] are the bulk of a stored scan.
+  describe('output.* section toggles', () => {
+    const trimmable = makeAggregated({
+      topComponents: [
+        { name: 'Button', source: 'antd', count: 4, files: new Set(['a.tsx']) },
+      ],
+      packageDistribution: [createMockPackage('antd')],
+      versusResults: [
+        {
+          name: 'Migration',
+          packages: ['antd', '@acme/arc'],
+          entries: [],
+          totalCount: 0,
+        },
+      ],
+    });
+
+    it('omits packages entirely when output.packages is false', () => {
+      printJson(trimmable, makeOutput({ packages: false }));
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed).not.toHaveProperty('packages');
+      expect(parsed.components).toHaveLength(1);
+    });
+
+    it('omits components entirely when output.components is false', () => {
+      printJson(trimmable, makeOutput({ components: false }));
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed).not.toHaveProperty('components');
+      expect(parsed.packages).toHaveLength(1);
+    });
+
+    it('omits versus entirely when output.versus is false', () => {
+      printJson(trimmable, makeOutput({ versus: false }));
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed).not.toHaveProperty('versus');
+    });
+
+    it('omits summary.patternCounts when output.patterns is false, keeping the counters', () => {
+      printJson(trimmable, makeOutput({ patterns: false }));
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed.summary).not.toHaveProperty('patternCounts');
+      expect(parsed.summary.filesAnalyzed).toBe(5);
+      expect(parsed.summary.totalUsagePatterns).toBe(7);
+    });
+
+    // A disabled section is absent, not `[]` — shrinking the payload is the
+    // whole point, and an empty array still costs a key on every scan file.
+    it('drops the keys rather than emitting empty arrays', () => {
+      printJson(
+        trimmable,
+        makeOutput({
+          packages: false,
+          components: false,
+          patterns: false,
+          versus: false,
+        }),
+      );
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(Object.keys(parsed)).toEqual([
+        'version',
+        'summary',
+        'ruleViolations',
+        'compliance',
+      ]);
+    });
+
+    // The verdict is what CI reads. `comply` prints rules in human mode
+    // regardless of output.rules, so gating them here would make the JSON
+    // lossier than the terminal output it mirrors.
+    it('keeps ruleViolations and compliance even with every section switched off', () => {
+      printJson(
+        makeAggregated({
+          ruleViolations: [forbidViolation('moment', 'error', 'Use dayjs')],
+        }),
+        makeOutput({
+          summary: false,
+          packages: false,
+          components: false,
+          patterns: false,
+          versus: false,
+          rules: false,
+          details: false,
+        }),
+      );
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(parsed.ruleViolations).toHaveLength(1);
+      expect(parsed.compliance.status).toBe('non-compliant');
+      expect(parsed.compliance.counts.errorRuleViolations).toBe(1);
+      expect(parsed.version).toBeTypeOf('string');
+    });
+
+    it('emits every dataset under the default config', () => {
+      printJson(trimmable, makeOutput());
+
+      const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
+      expect(Object.keys(parsed)).toEqual([
+        'version',
+        'summary',
+        'packages',
+        'components',
+        'versus',
+        'ruleViolations',
+        'compliance',
+      ]);
+      expect(parsed.summary.patternCounts).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
Closes #91. Closes #63 — same bug, `#91` is the narrower restatement (it adds `output.packages` to the list).

## The bug

`printJson` built its result object straight off the `AggregatedReport` with no config check at all, so the `output.*` section toggles only ever reached the human printers via `printScanResults`. A user setting `output: { components: false, packages: false }` and `--format json` still got the full payload — `components[]` and `packages[]` are ~63% of a stored scan file, so consumers were stripping them in wrapper scripts after the fact.

## The fix

`printJson` now takes the `output` block and **omits** the keys a config switched off — dropped, not emitted as `[]`, since shrinking the payload is the entire point:

| Config | Effect on the JSON |
|---|---|
| `output.packages: false` | omits `packages` |
| `output.components: false` | omits `components` |
| `output.versus: false` | omits `versus` |
| `output.patterns: false` | omits `summary.patternCounts` |

## What stays ungated, and why

`#63` asked for an audit of *all* of `output.*` rather than a patch to `components` alone, so here is the other half of it explicitly:

- **`version`, the `summary` counters, `ruleViolations`, `compliance`** are always emitted. Together they are the machine-readable verdict, and `comply`'s human path prints rules unconditionally (it never consults `output.rules`), so honouring `output.rules` in JSON would make the JSON *lossier* than the terminal output it mirrors — a silent way to blind CI on a display flag.
- **`output.details`** has no JSON counterpart at all; per-file details are not serialized.
- **`output.summary`** likewise leaves the counters in place — they cost a few bytes and anchor the report.

This is now stated in `docs/examples.md` under "Trimming the JSON with `output.*`", which `#63` specifically asked for.

## Compatibility

Default output is byte-identical — every section is enabled by default, so only a config that explicitly opts out sees a change. The exported `HermexScanResult` type marks `packages`, `components`, `versus` and `summary.patternCounts` optional to match, which is the breaking part for TS consumers; changeset is `major` (a major is already queued for the kebab-case rename).

## Testing

- 7 new unit tests in `tests/utils/print-utils.test.ts` — per-toggle omission, keys absent rather than empty, verdict survives every section being off, default config still emits all seven keys. The test helper reads the default `output` block off the Zod schema so it can't drift.
- 2 new e2e tests driving the real CLI against a new `hermex-json-trimmed.config.ts` fixture, covering both `scan` and `comply` (the latter asserting `ruleViolations` survives `output.rules: false` while still exiting 1).
- Full suite: 675 passing, plus `build`, `typecheck`, `lint` and `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
