### PR TITLE
perf(ci): serve the coverage baseline from an artifact, prettify the report

### DIFF
--- a/.github/workflows/coverage-baseline.yaml
+++ b/.github/workflows/coverage-baseline.yaml
@@ -1,0 +1,78 @@
+# .github/workflows/coverage-baseline.yaml
+#
+# Measures main/beta's coverage once per push and publishes the resulting
+# coverage-summary.json as an artifact, for the `coverage` job in
+# pull-request.yaml to compare a pull request against.
+#
+# This workflow exists so that job doesn't have to. It used to run the whole
+# suite twice on every PR — once for the PR, once for a fresh checkout of
+# main — so every open PR re-derived the same unchanged number from scratch,
+# on every push, forever (#34). Nothing about main's coverage depends on
+# which PR is asking; it only changes when something merges here.
+#
+# An artifact rather than a cache: artifacts are readable across branches by
+# run id, so a PR just takes the newest one this workflow published. A cache
+# would have to be keyed on a commit SHA the PR could name in advance, which
+# is precisely the thing a PR cannot do — github.event.pull_request.base.sha
+# goes stale the moment anything merges, and a key that misses puts the
+# duplicate suite run straight back.
+#
+# Deliberately not folded into push-release.yaml: that pipeline is scoped to
+# releases, is serialised by its own concurrency group, and holds credentials
+# (`id-token: write` on one job) that this has no business sharing a run with.
+name: Coverage baseline
+
+on:
+  push:
+    branches: ['main', 'beta']
+
+permissions:
+  contents: read
+
+# One baseline per branch at a time, and a superseded run is worth
+# cancelling: pull requests read the newest successful run, so a baseline for
+# a commit the branch has already moved past is one nothing will ask for.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm CLI
+        uses: pnpm/setup@v2
+        with:
+          runtime: node@26
+          cache: true
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: pnpm run test:coverage
+
+      # Only the summary is published. The rest of coverage/ — lcov, the
+      # per-statement coverage-final.json — is what a report is built *from*,
+      # and the PR side builds its own from its own run.
+      #
+      # 90 days, well beyond the 14 that output-review's pages get: this is
+      # the only copy of the number, and a quiet month on main must not leave
+      # every open PR without a comparison. It is one small JSON file.
+      #
+      # `if-no-files-found: error` on purpose. A silently empty baseline
+      # artifact would degrade every PR that pulls it, and the failure would
+      # surface a merge too late to connect to its cause.
+      - name: Publish the coverage baseline
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-baseline
+          path: coverage/coverage-summary.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,9 +1,14 @@
-# .github/workflows/pull-request.yml
+# .github/workflows/pull-request.yaml
 name: PR
 
 on:
   pull_request:
     branches: ['main', 'beta']
+
+# Reset to the minimum; the coverage job grants itself the one extra
+# permission it needs to leave its comment.
+permissions:
+  contents: read
 
 jobs:
   validate:
@@ -37,82 +42,103 @@ jobs:
       - name: Build project
         run: pnpm run build:ci
 
+  # Reports this PR's coverage, compared against the target branch's.
+  #
+  # The suite runs once here, for the PR, and never for the target branch:
+  # `.github/workflows/coverage-baseline.yaml` measures main/beta once per
+  # push and publishes the summary as an artifact, and this job downloads the
+  # newest one. Re-deriving that number per PR is what #34 is about.
   coverage:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - branch: main
-            artifact: main
-          - branch: ${{ github.head_ref }}
-            artifact: pull-request
+    permissions:
+      contents: read
+      pull-requests: write
+      # Read the baseline workflow's runs, and download an artifact from one.
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-        with:
-          ref: ${{ matrix.branch }}
 
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          # Pinned explicitly: the "main" matrix leg checks out main, which
-          # won't carry packageManager (the version pnpm/setup reads by
-          # default) until this workflow's own PR merges.
-          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false
 
       - name: Install dependencies
-        # STRICT_DEP_BUILDS=false: the main branch won't have pnpm-workspace.yaml's
-        # allowBuilds until this workflow's own PR merges — relax to a warning
-        # instead of failing when comparing against a main checkout that predates it.
-        env:
-          PNPM_CONFIG_STRICT_DEP_BUILDS: false
         run: pnpm install --frozen-lockfile
 
       - name: Run tests with coverage
-        # --if-present: the main branch won't have this script until this
-        # workflow's own PR merges — skip cleanly instead of failing when
-        # comparing against a main checkout that predates it.
-        run: pnpm run --if-present test:coverage
+        run: pnpm run test:coverage
 
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-${{ matrix.artifact }}
-          path: coverage
-          if-no-files-found: ignore
+      # The newest successful baseline this branch has published, rather than
+      # one matched to a particular commit: "how does this PR compare to main
+      # as it stands right now" is the question being asked, and the run that
+      # answers it is the last one that finished.
+      #
+      # Tolerates finding nothing. The workflow it names does not exist on
+      # the target branch until this change merges, and `gh` treats an
+      # unknown workflow as an error rather than an empty list.
+      - name: Find the target branch's coverage baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_id="$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow coverage-baseline.yaml \
+            --branch "$GITHUB_BASE_REF" \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
 
-  report-coverage:
-    needs: coverage
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Download PR coverage
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage-pull-request
-          path: coverage
-
-      - name: Download main coverage
-        # No artifact exists yet the first time this runs (main predates the
-        # coverage tooling) — don't fail the job over a baseline that
-        # doesn't exist yet.
+      # `continue-on-error`: a baseline is a nicety, not a gate. If the
+      # artifact has aged out or the run that held it was deleted, the answer
+      # is to report this PR's coverage without a comparison — never to fail
+      # a PR over the state of the branch it is aimed at.
+      - name: Download the target branch's coverage baseline
+        if: steps.baseline.outputs.run-id != ''
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: coverage-main
-          path: coverage-main
+          name: coverage-baseline
+          path: .coverage-baseline
+          run-id: ${{ steps.baseline.outputs.run-id }}
+          github-token: ${{ github.token }}
 
-      - name: Report coverage (vs main)
-        if: hashFiles('coverage-main/coverage-summary.json') != ''
+      - name: Note a missing baseline
+        if: hashFiles('.coverage-baseline/coverage-summary.json') == ''
+        run: echo "::warning::No coverage baseline published for ${GITHUB_BASE_REF}; reporting without a comparison."
+
+      - name: Report coverage
         uses: davelosert/vitest-coverage-report-action@v2
         with:
-          json-summary-compare-path: coverage-main/coverage-summary.json
+          # Empty is how this action is told "no comparison" — passing a path
+          # that isn't there is not.
+          json-summary-compare-path: >-
+            ${{ hashFiles('.coverage-baseline/coverage-summary.json') != ''
+            && '.coverage-baseline/coverage-summary.json' || '' }}
 
-      - name: Report coverage (no main baseline yet)
-        if: hashFiles('coverage-main/coverage-summary.json') == ''
-        uses: davelosert/vitest-coverage-report-action@v2
+          # Blue on every row is what the action falls back to when nothing
+          # tells it what "good" looks like. These bands are a reading aid,
+          # not a gate: vitest's own `coverage.thresholds` would fail the run
+          # instead, and a PR that lands branches at 94.9% is not one anybody
+          # should have to fix before merging.
+          threshold-icons: "{0: '🔴', 90: '🟠', 95: '🟢'}"
+
+          # Six columns of two-line cells is what made the file table hard to
+          # read. "Uncovered Lines" is the widest of them and empty on most
+          # rows — and this job's log still carries the `text` reporter's
+          # copy, line numbers and all, for the rows where it isn't.
+          show-uncovered-lines: 'false'
+
+          # Worst first. Most changed files sit at 100% and say nothing; the
+          # one or two that don't are the reason to open the table at all.
+          sort-by: statements-asc
+
+          # Two decimals on a delta is noise at this suite's size.
+          comparison-decimal-places: 1

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,10 @@ dist/
 build/
 *.tsbuildinfo
 
-# Test coverage
+# Test coverage, and the target branch's cached summary that a PR run is
+# compared against (.github/workflows/coverage-baseline.yaml)
 coverage/
+.coverage-baseline/
 
 # Output review report and its reference-branch builds — nothing under
 # .output-review/ is a source of truth; both are rebuilt fresh every run.


### PR DESCRIPTION
Closes #34.

## The duplicated `main` run

The `coverage` job was a two-leg matrix — `main` and the PR head — so every PR ran the whole suite twice, re-deriving a number that only changes when something merges.

`.github/workflows/coverage-baseline.yaml` (new) measures `main`/`beta` once per push and publishes `coverage-summary.json` as an artifact. The PR job downloads the newest successful one and reports against it. The matrix and the separate `report-coverage` job are gone; one job now runs the suite once.

**Artifacts rather than a cache.** Artifacts are readable across branches by run id. A cache would have to be keyed on a commit SHA the PR can name in advance, and the only one it has — `github.event.pull_request.base.sha` — goes stale the moment anything merges into the base branch, so a stale key means a miss and a miss means the duplicate suite run is back. Nothing to key, nothing to go stale.

Per PR push: three full suite runs become two, and the removed one is gone outright rather than made conditional on a cache hit.

## Degradation

A missing baseline reports this PR's coverage without a comparison and never fails the PR:

- `gh run list` naming a workflow that doesn't exist on the base branch yet errors instead of returning an empty list, so it's `|| true` — **this PR is that case**, and its own coverage comment will have no comparison. The next PR after it merges will.
- The download is `continue-on-error` for an artifact that has aged out or a deleted run.
- Both land on the same `hashFiles` check, which decides whether the report gets a compare path at all (empty is how the action is told "no comparison"; a path that isn't there is not).

Retention is 90 days, well past output-review's 14 — this is the only copy of the number, and a quiet month on `main` must not leave every open PR without a comparison.

## The report

Status icons were 🔵 on every row, which is the action's fallback when nothing tells it what "good" looks like. `threshold-icons` gives it bands (`0 🔴 / 90 🟠 / 95 🟢`) in preference to vitest's `coverage.thresholds`, which would **fail the run** on a dip rather than colour a cell. Against current numbers that reads 🟠 on branches (91.33%) and 🟢 on the rest — signal instead of four identical dots.

For the cramped table: `show-uncovered-lines: false` drops the widest column (header and cells both, 6 → 5) and `sort-by: statements-asc` puts the worst files first, since most changed files sit at 100% and say nothing. `comparison-decimal-places: 1` shortens the `±` line under every cell.

**Worth a second opinion:** hiding "Uncovered Lines" trades away the most actionable column to fix the width. It was empty on 14 of 16 rows in the last real comment, and the `text` reporter in the job log still has it in full — but it's a one-word flip if you'd rather keep it.

## Checks

`gh run list`'s flags and its bootstrap behaviour were both exercised against this repo. Workflows parse; format and lint are clean. Required checks in the ruleset are `validate`, `review` and `output-approval`, so dropping `report-coverage` strands nothing. The artifact hand-off itself can only be observed once this is on `main`.

No changeset: CI-only, nothing published changes.

## Not done here

`validate` still runs `test:ci` while `coverage` runs `test:coverage`, so the suite executes twice per PR across two jobs. Folding them would save another run, but a format or lint failure would then suppress the coverage comment entirely — that belongs in its own issue rather than smuggled into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
