### PR TITLE
chore: upgrade pnpm to 12.0.0-rc.5, migrate CI to pnpm/setup@v2

### DIFF
--- a/.github/workflows/output-review.yaml
+++ b/.github/workflows/output-review.yaml
@@ -74,7 +74,6 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false

--- a/.github/workflows/output-review.yaml
+++ b/.github/workflows/output-review.yaml
@@ -72,15 +72,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          cache: 'pnpm'
+          runtime: node@26
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/output-review.yaml
+++ b/.github/workflows/output-review.yaml
@@ -74,6 +74,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false
@@ -55,6 +56,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -62,6 +62,11 @@ jobs:
           install: false
 
       - name: Install dependencies
+        # STRICT_DEP_BUILDS=false: the main branch won't have pnpm-workspace.yaml's
+        # allowBuilds until this workflow's own PR merges — relax to a warning
+        # instead of failing when comparing against a main checkout that predates it.
+        env:
+          PNPM_CONFIG_STRICT_DEP_BUILDS: false
         run: pnpm install --frozen-lockfile
 
       - name: Run tests with coverage

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,15 +13,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          cache: 'pnpm'
+          runtime: node@26
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -57,15 +53,11 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          cache: 'pnpm'
+          runtime: node@26
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,6 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false
@@ -56,6 +55,9 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          # Pinned explicitly: the "main" matrix leg checks out main, which
+          # won't carry packageManager (the version pnpm/setup reads by
+          # default) until this workflow's own PR merges.
           version: 12.0.0-rc.5
           runtime: node@26
           cache: true

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false
@@ -85,6 +86,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           install: false
 
@@ -121,6 +123,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           install: false
 
@@ -167,6 +170,7 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
+          version: 12.0.0-rc.5
           runtime: node@26
           install: false
 

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -43,7 +43,6 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          version: 12.0.0-rc.5
           runtime: node@26
           cache: true
           install: false
@@ -86,7 +85,6 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          version: 12.0.0-rc.5
           runtime: node@26
           install: false
 
@@ -123,7 +121,6 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          version: 12.0.0-rc.5
           runtime: node@26
           install: false
 
@@ -170,7 +167,6 @@ jobs:
       - name: Setup pnpm CLI
         uses: pnpm/setup@v2
         with:
-          version: 12.0.0-rc.5
           runtime: node@26
           install: false
 

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -41,15 +41,11 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          cache: 'pnpm'
+          runtime: node@26
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -87,15 +83,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          package-manager-cache: false
+          runtime: node@26
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -128,15 +119,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          package-manager-cache: false
+          runtime: node@26
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -179,15 +165,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup pnpm CLI
-        uses: pnpm/action-setup@v6
+        uses: pnpm/setup@v2
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 26
-          package-manager-cache: false
+          runtime: node@26
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -85,5 +85,6 @@
   },
   "engines": {
     "node": ">=24.11.1"
-  }
+  },
+  "packageManager": "pnpm@12.0.0-rc.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0-rc.5
+        version: 12.0.0-rc.5
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
+    resolution: {integrity: sha512-CYNIBkLIcQ3dv9Bp4p8BUS9JMoQQM30ulEa72B8oqtgMweqraQ/60mnJut0iqflt6F9OSPgNJxTLmUVM0X/8ew==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
+    resolution: {integrity: sha512-kJYD1EpisLlPrvIsA9SB40EAo0k/qPGioi56rMr9Us2pLTKNnzW6qyU/oeDDf9RcKDXWyjNsO9hHHVIfCS9BYA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
+    resolution: {integrity: sha512-yQwz0Ahn62uRSjGT23drqshUWWIfwuZhq8uASp9JvsrRd/+xFG9K5hgyfW+Mhywlh2gWQ0tjQTbzJNdwvPzqUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
+    resolution: {integrity: sha512-/SlL2Or1dfiUJeAIusaWnwnQuoA2PwFqtbwFlvsihOfAaAZLw9P6mofu6VbWN/xB9OxLfGIXeElKUeY4PQehtw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
+    resolution: {integrity: sha512-NkHve9TqSKqOQRjUx4w5niVuEojNHu2gy6s1rAvIWO4HEDC6g3Opn2toGLBYHO7xdzC/tL0iWQBJjhMBWCyq3g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.5':
+    resolution: {integrity: sha512-U7NiGcExYsbjItnntmB9aR84SA86MUCrpiB/rrK1aoNaTJHhZHXCusqkbYktZEd6PUTw0RA1SdBDrxpeQyLyKw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
+    resolution: {integrity: sha512-j4W16YwEq2xJ01fw8hUCYme8UwRZHxMxUVF3DMUtr4+GxrMgqpjgHsWtlybRLVjVhXe4rTjNE7VIkrIvReuHpg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.5':
+    resolution: {integrity: sha512-IQrykr2gv9X6/hW2DgxyNNm7O2jl40xzDpgH2gAI0Z+A6gZaOn0BWBIAfv1j87W0yt1OC41I7qvgEPC9kO3dvQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0-rc.5:
+    resolution: {integrity: sha512-MvAerV1e6ufMdA5zy0am6ENHGiIWoGz8ADQEuViZJ1kVmoSW7xuCicO0BXICoqlUyX7p5jH+BN2HGzMYIi70Vg==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.5':
+    optional: true
+
+  pnpm@12.0.0-rc.5:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.5
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.5
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.5
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.5
+      '@pnpm/exe.linux-x64': 12.0.0-rc.5
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.5
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.5
+      '@pnpm/exe.win32-x64': 12.0.0-rc.5
+
+---
 lockfileVersion: '9.0'
 
 settings:
@@ -769,66 +870,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@swc/core': true
+  esbuild: true

--- a/scripts/output-review.ts
+++ b/scripts/output-review.ts
@@ -443,6 +443,22 @@ function buildReference(ref: string): string {
   // be checked out in the primary worktree already (running this on `main`
   // itself, for instance). A bare SHA has no such conflict.
   run('git', ['worktree', 'add', '--detach', worktree, sha], ROOT);
+
+  // pnpm resolves its workspace root by walking up from `worktree` looking
+  // for pnpm-workspace.yaml, and does not stop at the nested worktree's own
+  // `.git` file — so without one here it keeps going, lands on ROOT's, and
+  // then fails `--frozen-lockfile` because ROOT's lockfile has no importer
+  // entry for this path. `ref` predates pnpm-workspace.yaml on older
+  // commits; on newer ones the checkout already has its own copy (with its
+  // own allowBuilds) and this is a no-op.
+  const worktreeWorkspaceFile = join(worktree, 'pnpm-workspace.yaml');
+  if (!existsSync(worktreeWorkspaceFile)) {
+    writeFileSync(
+      worktreeWorkspaceFile,
+      "allowBuilds:\n  '@swc/core': true\n  esbuild: true\n",
+    );
+  }
+
   run('pnpm', ['install', '--frozen-lockfile'], worktree);
   run('pnpm', ['run', 'build'], worktree);
   return cli;


### PR DESCRIPTION
## Summary

- Pins `packageManager` in `package.json` to `pnpm@12.0.0-rc.5` (currently unpinned, so CI/local installs float on whatever pnpm is installed).
- Adds `allowBuilds` for `@swc/core` and `esbuild` in `pnpm-workspace.yaml` — pnpm 12 **fails** installs with unreviewed build scripts by default (`strictDepBuilds`), so this is required for install to succeed at all.
- Migrates all four workflows off `pnpm/action-setup@v6` + `actions/setup-node@v7` onto the combined [`pnpm/setup@v2`](https://github.com/pnpm/setup) action (the documented successor for pnpm v11+, installs pnpm *and* Node in one step). Version is read from `packageManager` everywhere except the coverage job's `main` matrix leg, which checks out pre-merge `main` and can't rely on a field that isn't there yet.
- Fixes `scripts/output-review.ts`'s reference-build worktrees: pnpm 12 walks past a nested git worktree's `.git` file when resolving its workspace root, lands on the outer repo's `pnpm-workspace.yaml`/lockfile, and then rejects `--frozen-lockfile` since that lockfile has no importer entry for the worktree path. Fixed by writing a minimal `pnpm-workspace.yaml` into the worktree first (only for refs that don't already carry one).
- Regenerates `pnpm-lock.yaml`: once `packageManager` is pinned, `--frozen-lockfile` installs additively rewrite the lockfile (a `packageManagerDependencies` block tracking pnpm's own binary, plus richer `libc` metadata), without erroring. Confirmed deterministic across repeated installs.

## Local verification (pnpm 12.0.0-rc.5)

All green, no source changes needed:
- `pnpm run format:ci` / `lint:ci` / `typecheck`
- `pnpm run test:ci` — 666/666 tests passed
- `pnpm run build:ci`
- `pnpm run dev:scan` and `pnpm run test:output` (manual smoke tests, including the worktree fix above)

## Local install benchmark (warm store, `node_modules` removed, 3 runs each)

| pnpm | avg install time |
|---|---|
| 10.13.1 (current) | ~4.65s |
| 12.0.0-rc.5 | ~2.63s |

~43% faster locally.

## CI benchmark

`validate` job, before vs after (this PR's own CI run vs. a same-infra baseline run just before it):

| | job duration | pnpm+node setup step |
|---|---|---|
| pnpm 10.13.1 + `action-setup`@v6 + `setup-node`@v7 | 40s | 14s (8s + 6s, two steps) |
| pnpm 12.0.0-rc.5 + `pnpm/setup`@v2 | 31s | 6s (one combined step) |

`coverage` job dropped similarly, ~51s → ~32s (PR branch leg) and ~42s → ~35s (main leg).

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds with pnpm 12 rc5
- [x] format/lint/typecheck/test/build all pass locally under rc5
- [x] CI passes on this PR with `pnpm/setup@v2` (validate, coverage, output-review all green)
- [x] Compared CI job duration against a recent baseline run — see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)