### PR TITLE
ci(release): auto-label Version Packages PRs

### DIFF
--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -92,12 +92,22 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Version packages
+        id: version
         uses: changesets/action/version@v2
         with:
           github-token: ${{ steps.app-token.outputs.token }}
         env:
           # @changesets/changelog-github resolves PR numbers and authors.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # changesets/action/version has no label input, so label the PR it
+      # opened (or updated) as a separate step. Flags it as a release-gate PR:
+      # merging it is what ships the pending changesets to npm.
+      - name: Label Version Packages PR
+        if: steps.version.outputs.pr-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr edit "${{ steps.version.outputs.pr-number }}" --repo "${{ github.repository }}" --add-label "release:pending"
 
   # Runs the full quality gate, builds, then packs tarballs for `publish`.
   # Nothing reaches npm unless every check here passes.


### PR DESCRIPTION
## Summary
- Renames the `release-bot` label to `release:pending` (matches the repo's `category:value` label convention, e.g. `wayfinder:map`, `output:approved`), and gives it a description explaining what it means.
- Has the `version` job in the release workflow apply `release:pending` to the Version Packages PR it opens/updates, so it doesn't need to be added by hand.

`changesets/action/version` has no `labels` input, so the new step calls `gh pr edit` with the app token against the PR number the version step outputs.

Follow-up from https://github.com/Gallevy/hermex/pull/133, where the label was added manually.

## Test plan
- [ ] Merge to `main` and confirm the next Version Packages PR (or an update to #133) gets `release:pending` applied automatically by the `Release` workflow.