### PR TITLE
fix(output): sort rules table by severity, not detection order

### DIFF
--- a/.changeset/shy-adults-bathe.md
+++ b/.changeset/shy-adults-bathe.md
@@ -1,0 +1,6 @@
+---
+"hermex": patch
+---
+
+Sort ruleViolations by severity (error, then warn, then info) across every surface — the rules table, --summary-file, and --format json — so a failing row is never buried among passing ones
+  

--- a/src/utils/print-json.ts
+++ b/src/utils/print-json.ts
@@ -2,6 +2,7 @@ import type { AggregatedReport } from './aggregator';
 import type { ComplianceResult } from './compliance';
 import type { OutputConfig } from '../config/types';
 import { computeCompliance } from './compliance';
+import { sortViolationsBySeverity } from './severity-format';
 import { getVersion } from './version';
 
 /**
@@ -74,7 +75,7 @@ export function printJson(
         }
       : {}),
     ...(output.versus ? { versus: aggregated.versusResults } : {}),
-    ruleViolations: aggregated.ruleViolations,
+    ruleViolations: sortViolationsBySeverity(aggregated.ruleViolations),
     compliance: {
       status: compliance.status,
       compliant: compliance.compliant,

--- a/src/utils/print-rules.ts
+++ b/src/utils/print-rules.ts
@@ -3,7 +3,7 @@ import Table from 'cli-table3';
 import type { AggregatedReport } from './aggregator';
 import type { RuleViolation } from '../rules/evaluator';
 import { formatTruncatedList } from './format-utils';
-import { severityIcon } from './severity-format';
+import { severityIcon, sortViolationsBySeverity } from './severity-format';
 
 export function formatRuleType(ruleId: RuleViolation['ruleId']): string {
   switch (ruleId) {
@@ -89,7 +89,7 @@ export function printRules(aggregated: AggregatedReport): void {
     style: { head: ['cyan'], border: ['gray'] },
   });
 
-  for (const v of ruleViolations) {
+  for (const v of sortViolationsBySeverity(ruleViolations)) {
     table.push([
       formatRuleType(v.ruleId),
       `${severityIcon(v.severity)} ${describeViolation(v)}`,

--- a/src/utils/severity-format.ts
+++ b/src/utils/severity-format.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import type { RuleViolation } from '../rules/evaluator';
 
 export type DisplaySeverity = 'error' | 'warn' | 'info' | 'success';
 
@@ -77,4 +78,33 @@ export function applyColorLevel(level: 0 | 1 | undefined): void {
     stripAnsiWrites(process.stdout);
     stripAnsiWrites(process.stderr);
   }
+}
+
+const SEVERITY_RANK: Record<RuleViolation['severity'], number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+};
+
+/**
+ * Sorts rule violations by severity descending (error → warn → info), with
+ * detection order as the tiebreak so runs stay deterministic and diffable
+ * (#87). Render-time only — `ruleViolations` on `AggregatedReport` itself
+ * stays in detection order, so nothing upstream (compliance counting,
+ * further aggregation) has to account for a sort. Every rendered surface —
+ * the terminal table (`printRules`), `--summary-file`, and `--format json` —
+ * routes through this one helper, so none of them can drift from each other
+ * or from a second, differently-ordered notion of "the" rule violations.
+ */
+export function sortViolationsBySeverity<T extends RuleViolation>(
+  violations: T[],
+): T[] {
+  return violations
+    .map((v, index) => ({ v, index }))
+    .sort((a, b) => {
+      const rankDiff =
+        SEVERITY_RANK[a.v.severity] - SEVERITY_RANK[b.v.severity];
+      return rankDiff !== 0 ? rankDiff : a.index - b.index;
+    })
+    .map(({ v }) => v);
 }

--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -8,7 +8,11 @@ import {
   resolveCompliantTarget,
   resolveInstalledVersion,
 } from './print-packages';
-import { severityIcon, stripAnsi } from './severity-format';
+import {
+  severityIcon,
+  sortViolationsBySeverity,
+  stripAnsi,
+} from './severity-format';
 
 // A table, mirroring the Packages section below it, rather than a bullet
 // list — same shape, same scanability, in both output surfaces.
@@ -16,8 +20,8 @@ function buildRulesSection(aggregated: AggregatedReport): string {
   // Info-severity rows are excluded here (unlike the terminal `printRules`,
   // which shows everything) — a summary meant for a PR comment or job
   // summary should only surface what's actually enforceable (#31).
-  const ruleViolations = aggregated.ruleViolations.filter(
-    (v) => v.severity !== 'info',
+  const ruleViolations = sortViolationsBySeverity(
+    aggregated.ruleViolations.filter((v) => v.severity !== 'info'),
   );
 
   // Nothing to report — omit the section entirely, matching


### PR DESCRIPTION
## Summary
- `ruleViolations` is now sorted by severity descending (error → warn → info, detection order as the tiebreak) before rendering, through one shared helper (`sortViolationsBySeverity` in `src/utils/severity-format.ts`) used by the terminal `Rules` table, `--summary-file`, and `--format json` alike — so the three surfaces can't drift into different orderings of "the" violations.
- `aggregated.ruleViolations` itself is left in detection order; only rendering sorts.

Fixes #87.

## Test plan
- [x] `pnpm run build` / `pnpm run typecheck`
- [x] `pnpm run test:ci` — 680 passed
- [x] `pnpm run lint` / `pnpm run format:ci`
- [x] `pnpm run test:output` against `main` — the only 4 diffs are the intended row reordering in `comply-human-warn-only`, `comply-all-rule-types` (text + json), and `comply-overrides`; everything else matches
- [x] Added a patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)