### PR TITLE
fix(output): replace [BANNED]/[RESTRICTED] with a severity-neutral [FORBIDDEN] badge

### DIFF
--- a/docs-templates/__examples.md
+++ b/docs-templates/__examples.md
@@ -149,8 +149,9 @@ Purely transitive dependencies are never flagged: they arrive through another pa
 isn't something your repo can do. Packages excluded by `packages.ignore` are never flagged either.
 
 Every banned package appears in the Rules and Compliance sections. Those with measured usage also get a
-`[BANNED]` or `[RESTRICTED]` badge in the packages table, which since #78 lists every package the repo
-owns — so a declared-but-unimported banned package now has a row there too.
+`[FORBIDDEN]` badge in the packages table, which since #78 lists every package the repo owns — so a
+declared-but-unimported banned package now has a row there too. The badge itself is severity-neutral; the
+leading icon (🔴/🟡/🔵) carries how hard the rule is enforced, matching every other surface (#86).
 
 In the JSON output, each hit is an ordinary entry in `ruleViolations` with `type: "forbid_packages"` —
 `patterns` carries the rule's globs, `packageName` the package that matched, and `matchedFiles` is empty

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -259,8 +259,9 @@ Purely transitive dependencies are never flagged: they arrive through another pa
 isn't something your repo can do. Packages excluded by `packages.ignore` are never flagged either.
 
 Every banned package appears in the Rules and Compliance sections. Those with measured usage also get a
-`[BANNED]` or `[RESTRICTED]` badge in the packages table, which since #78 lists every package the repo
-owns — so a declared-but-unimported banned package now has a row there too.
+`[FORBIDDEN]` badge in the packages table, which since #78 lists every package the repo owns — so a
+declared-but-unimported banned package now has a row there too. The badge itself is severity-neutral; the
+leading icon (🔴/🟡/🔵) carries how hard the rule is enforced, matching every other surface (#86).
 
 In the JSON output, each hit is an ordinary entry in `ruleViolations` with `ruleId: "no-packages"` —
 `patterns` carries the rule's globs, `packageName` the package that matched, and `matchedFiles` is empty

--- a/src/utils/print-packages.ts
+++ b/src/utils/print-packages.ts
@@ -12,7 +12,7 @@ import {
   formatDaysOverdue,
   formatDaysRemaining,
 } from './format-utils';
-import { severityIcon, severityColor } from './severity-format';
+import { severityIcon, severityColor, stripAnsi } from './severity-format';
 
 function printHeader() {
   console.log(chalk.blueBright.bold('\n📦 Packages\n'));
@@ -27,10 +27,13 @@ export function formatPackageName(
     prefix += severityColor('error')('[DEPRECATED] ');
   }
   if (banned) {
-    prefix +=
-      banned.severity === 'error'
-        ? severityColor('error')('[BANNED] ')
-        : severityColor('warn')('[RESTRICTED] ');
+    // Severity-neutral badge — the icon carries *how hard* the rule is
+    // enforced (matching every other surface's icon/description split), so
+    // 'warn' and 'info' no longer collapse into an invented "restricted"
+    // concept that doesn't exist anywhere in the config (#86). There is only
+    // one reason a package lands here — `forbid_packages` — so the badge
+    // names that reason, not the severity.
+    prefix += `${severityIcon(banned.severity)} [FORBIDDEN] `;
   } else if (pkg.internal) {
     prefix += severityColor('warn')('[int] ');
   }
@@ -297,25 +300,33 @@ function printPackagesChart(
 
   const maxBarWidth = 40;
   const maxPercentage = Math.max(...charted.map((p) => p.percentage));
+  // Padding is computed from the rendered label itself (ANSI stripped for
+  // width, since escape codes contribute zero visible columns) rather than
+  // re-derived from which badges apply — that re-derivation is what silently
+  // fell out of sync whenever a badge's text changed (#86: [BANNED]/
+  // [RESTRICTED] were never accounted for here at all).
+  const labels = charted.map((pkg) =>
+    formatPackageName(pkg, findForbidViolation(pkg, violations)),
+  );
   const maxLabelLength = Math.max(
-    ...charted.map((p) => p.packageName.length + (p.internal ? 6 : 0)),
+    ...labels.map((label) => stripAnsi(label).length),
   );
 
-  charted.forEach((pkg) => {
+  charted.forEach((pkg, i) => {
     const barLength = Math.round(
       (pkg.percentage / maxPercentage) * maxBarWidth,
     );
     const emptyLength = maxBarWidth - barLength;
-    const label = formatPackageName(
-      pkg,
-      findForbidViolation(pkg, violations),
-    ).padEnd(maxLabelLength, ' ');
+    const label = labels[i]!;
+    const padding = ' '.repeat(
+      Math.max(0, maxLabelLength - stripAnsi(label).length),
+    );
 
     const bar =
       chalk.green('█'.repeat(barLength)) + chalk.gray('░'.repeat(emptyLength));
 
     console.log(
-      `${label} ${bar} ${chalk.bold(pkg.percentage.toFixed(1) + '%')} (${pkg.usageCount})`,
+      `${label}${padding} ${bar} ${chalk.bold(pkg.percentage.toFixed(1) + '%')} (${pkg.usageCount})`,
     );
   });
 }

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -360,6 +360,31 @@ describe('printPackages', () => {
     expect(output).toContain('[int]');
   });
 
+  // (#86) Padding used to be re-derived from which badges applied, so
+  // [BANNED]/[RESTRICTED] were never accounted for and bars misaligned. It's
+  // now computed from the rendered, ANSI-stripped label itself — this
+  // asserts the bars for a badged and an un-badged row actually line up.
+  it('chart mode aligns bars when a forbidden package label is wider than an unbadged one', () => {
+    const aggregated = makeAggregated({
+      packageDistribution: [
+        createMockPackage('react', { usageCount: 4, percentage: 50 }),
+        createMockPackage('moment', { usageCount: 4, percentage: 50 }),
+      ],
+      ruleViolations: [forbidViolation('moment', 'error')],
+    });
+    printPackages(aggregated, 'chart');
+    const output = consoleSpy.mock.calls
+      .map((call) => call.join(' '))
+      .join('\n');
+    const barLines = stripAnsi(output)
+      .split('\n')
+      .filter((l) => l.includes('█') || l.includes('░'));
+    expect(barLines).toHaveLength(2);
+    const barStarts = barLines.map((l) => l.indexOf('█'));
+    expect(barStarts[0]).toBeGreaterThan(0);
+    expect(barStarts[0]).toBe(barStarts[1]);
+  });
+
   it('marks a package with multiple resolved versions as a version conflict', () => {
     const aggregated = makeAggregated({
       packageDistribution: [
@@ -425,18 +450,25 @@ describe('formatPackageName', () => {
     expect(formatPackageName(pkg)).toContain('[DEPRECATED]');
   });
 
-  it('prefixes an error-severity banned package as [BANNED]', () => {
+  it('prefixes an error-severity forbidden package with [FORBIDDEN] and the error icon', () => {
     const pkg = createMockPackage('moment');
-    expect(
-      formatPackageName(pkg, forbidViolation('moment', 'error')),
-    ).toContain('[BANNED]');
+    const name = formatPackageName(pkg, forbidViolation('moment', 'error'));
+    expect(name).toContain('[FORBIDDEN]');
+    expect(name).toContain('🔴');
   });
 
-  it('prefixes a warn-severity banned package as [RESTRICTED]', () => {
+  it('prefixes a warn-severity forbidden package with [FORBIDDEN] and the warn icon', () => {
     const pkg = createMockPackage('moment');
-    expect(formatPackageName(pkg, forbidViolation('moment', 'warn'))).toContain(
-      '[RESTRICTED]',
-    );
+    const name = formatPackageName(pkg, forbidViolation('moment', 'warn'));
+    expect(name).toContain('[FORBIDDEN]');
+    expect(name).toContain('🟡');
+  });
+
+  it('prefixes an info-severity forbidden package with [FORBIDDEN] and the info icon, distinct from warn', () => {
+    const pkg = createMockPackage('moment');
+    const name = formatPackageName(pkg, forbidViolation('moment', 'info'));
+    expect(name).toContain('[FORBIDDEN]');
+    expect(name).toContain('🔵');
   });
 
   it('prefixes an internal package as [int] when not banned', () => {
@@ -444,20 +476,20 @@ describe('formatPackageName', () => {
     expect(formatPackageName(pkg)).toContain('[int]');
   });
 
-  it('prefers [BANNED]/[RESTRICTED] over [int] when a package is both internal and banned', () => {
+  it('prefers [FORBIDDEN] over [int] when a package is both internal and banned', () => {
     const pkg = createMockPackage('@my-org/utils', { internal: true });
     const name = formatPackageName(pkg, forbidViolation('@my-org/utils'));
-    expect(name).toContain('[BANNED]');
+    expect(name).toContain('[FORBIDDEN]');
     expect(name).not.toContain('[int]');
   });
 
-  it('combines [DEPRECATED] with [BANNED] when both apply', () => {
+  it('combines [DEPRECATED] with [FORBIDDEN] when both apply', () => {
     const pkg = createMockPackage('moment', {
       releaseAge: createMockReleaseAge({ deprecated: 'use dayjs' }),
     });
     const name = formatPackageName(pkg, forbidViolation('moment'));
     expect(name).toContain('[DEPRECATED]');
-    expect(name).toContain('[BANNED]');
+    expect(name).toContain('[FORBIDDEN]');
   });
 });
 


### PR DESCRIPTION
## Summary
- The packages table/chart badge for a `forbid_packages` hit was chosen by a plain severity ternary — `error` → `[BANNED]`, anything else → `[RESTRICTED]` — inventing a "restricted" concept that doesn't exist in the config and collapsing `warn`/`info` into one identical label, even though those two severities behave differently everywhere else (`--summary-file` drops `info` rows, only `warn` demotes `compliance.status`).
- Replaced both with a single severity-neutral `[FORBIDDEN]` badge, prefixed by the same severity icon (🔴/🟡/🔵) used by every other surface (Rules table, `--summary-file`, JSON) — matching the description/icon convention laid out in the issue and recovering the `info` vs `warn` distinction for free.
- Fixed the chart's label padding, which never accounted for these badges at all (`[int] ` was the only tag budgeted for, so bars misaligned whenever a flagged package was charted). Padding is now computed from the rendered, ANSI-stripped label itself rather than re-derived from which badges apply, so it can't silently fall out of sync again.
- Updated the one doc sentence that named both badges (`docs-templates/__examples.md`, mirrored into `docs/examples.md`).

## Test plan
- [x] `pnpm run test:ci` — 682 tests pass, including updated/new coverage for `[FORBIDDEN]` at error/warn/info severity and a new chart-alignment regression test
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:ci`
- [x] `pnpm run format:ci`
- [x] `pnpm run build`
- [x] Manually verified against `fixtures/repos/all-rule-types` — table renders `🔴 [FORBIDDEN] moment` for an error-severity hit

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)