### PR TITLE
chore: remove unused internal package marking feature

### DIFF
--- a/docs-templates/__examples.md
+++ b/docs-templates/__examples.md
@@ -37,20 +37,17 @@ export default defineConfig({
 });
 ```
 
-## Internal Package Marking
+## Ignoring Packages
 
-Mark your own packages so they're visually separated in the packages table and skipped during release age checks:
+Exclude packages from the packages table entirely:
 
 ```ts
 export default defineConfig({
   packages: {
-    internal: ['@myorg/*', '@company/design-system'],
     ignore: ['react', 'react-dom'], // exclude from output entirely
   },
 });
 ```
-
-Internal packages show an `[int]` badge in the packages table.
 
 `ignore` is a *reporting* filter, not an uninstall: an ignored package is left out of the packages
 table and is never flagged by `forbid_packages`, but it still counts as installed for
@@ -271,7 +268,6 @@ export default defineConfig({
   excludes: ['**/node_modules/**', '**/dist/**', '**/*.test.*'],
 
   packages: {
-    internal: ['@myorg/*'],
     ignore: [],
   },
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,20 +37,17 @@ export default defineConfig({
 });
 ```
 
-## Internal Package Marking
+## Ignoring Packages
 
-Mark your own packages so they're visually separated in the packages table and skipped during release age checks:
+Exclude packages from the packages table entirely:
 
 ```ts
 export default defineConfig({
   packages: {
-    internal: ['@myorg/*', '@company/design-system'],
     ignore: ['react', 'react-dom'], // exclude from output entirely
   },
 });
 ```
-
-Internal packages show an `[int]` badge in the packages table.
 
 `ignore` is a *reporting* filter, not an uninstall: an ignored package is left out of the packages
 table and is never flagged by `no-packages`, but it still counts as installed for
@@ -526,7 +523,6 @@ Every package the repo **owns**: declared in `package.json` (any dependency buck
   "usageCount": 0,                    // component usage — see the caveat below
   "componentCount": 0,
   "percentage": 0,
-  "internal": false,
   "hasVersionConflict": false,
   "allVersions": ["2.29.4"]
 }
@@ -595,7 +591,6 @@ export default defineConfig({
   excludes: ['**/node_modules/**', '**/dist/**', '**/*.test.*'],
 
   packages: {
-    internal: ['@myorg/*'],
     ignore: [],
   },
 

--- a/fixtures/hermex.config.ts
+++ b/fixtures/hermex.config.ts
@@ -22,9 +22,6 @@ export default {
     'registry/**',
     'repos/**',
   ],
-  packages: {
-    internal: ['@design-system/*'],
-  },
   versus: [
     {
       name: 'Design System Migration',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -81,10 +81,9 @@ export const HermexConfigSchema = z.object({
 
   packages: z
     .object({
-      internal: z.array(z.string()).default([]),
       ignore: z.array(z.string()).default([]),
     })
-    .default(() => ({ internal: [], ignore: [] })),
+    .default(() => ({ ignore: [] })),
 
   versus: z
     .array(z.object({ name: z.string(), packages: z.array(z.string()).min(2) }))

--- a/src/npm-registry/enricher.ts
+++ b/src/npm-registry/enricher.ts
@@ -361,7 +361,7 @@ export async function enrichWithReleaseAge(
   // depends on while leaving registry traffic and the compliance verdict
   // exactly where they were.
   const targets = packages.filter(
-    (p) => !p.internal && p.version && isReleaseAgeTarget(p, config.enforceOn),
+    (p) => p.version && isReleaseAgeTarget(p, config.enforceOn),
   );
   const enriched = [...packages];
   let skipped = 0;

--- a/src/utils/package-distribution.ts
+++ b/src/utils/package-distribution.ts
@@ -23,7 +23,6 @@ export interface PackageDistribution {
   usageCount: number;
   /** Share of total measured component usage. 0 for a package that is never rendered as a component — which includes every package used only as a function. */
   percentage: number;
-  internal: boolean;
   hasVersionConflict: boolean;
   allVersions: string[];
   /**
@@ -149,7 +148,6 @@ export function calculatePackageDistribution(
       componentCount: entry.componentCount,
       usageCount: entry.usageCount,
       percentage: 0,
-      internal: entry.internal,
       hasVersionConflict: entry.hasVersionConflict,
       allVersions: entry.allVersions,
     }));

--- a/src/utils/package-inventory.ts
+++ b/src/utils/package-inventory.ts
@@ -45,8 +45,6 @@ export interface PackageInventoryEntry {
   /** Every resolved copy in the lockfile — the `tree` axis. */
   allVersions: string[];
   hasVersionConflict: boolean;
-  /** Matches `packages.internal`. */
-  internal: boolean;
   /** Matches `packages.ignore`. Kept in the inventory rather than filtered out at construction so each consumer can decide — the packages table and forbid rules skip these, `require-packages` deliberately does not. */
   ignored: boolean;
   usageCount: number;
@@ -160,7 +158,6 @@ export function buildPackageInventory(
   } = input;
 
   const isIgnored = createGlobMatcher(config?.packages.ignore ?? []);
-  const isInternal = createGlobMatcher(config?.packages.internal ?? []);
 
   // Fold component usage up to one record per package first — several
   // components can come from the same source.
@@ -204,7 +201,6 @@ export function buildPackageInventory(
       rootVersion: getRootVersion(packageName, resolutions),
       allVersions,
       hasVersionConflict: allVersions.length > 1,
-      internal: isInternal(packageName),
       ignored: isIgnored(packageName),
       usageCount: packageUsage?.usageCount ?? 0,
       componentCount: packageUsage?.componentCount ?? 0,

--- a/src/utils/print-packages.ts
+++ b/src/utils/print-packages.ts
@@ -31,8 +31,6 @@ export function formatPackageName(
       banned.severity === 'error'
         ? severityColor('error')('[BANNED] ')
         : severityColor('warn')('[RESTRICTED] ');
-  } else if (pkg.internal) {
-    prefix += severityColor('warn')('[int] ');
   }
   return prefix + pkg.packageName;
 }
@@ -297,9 +295,7 @@ function printPackagesChart(
 
   const maxBarWidth = 40;
   const maxPercentage = Math.max(...charted.map((p) => p.percentage));
-  const maxLabelLength = Math.max(
-    ...charted.map((p) => p.packageName.length + (p.internal ? 6 : 0)),
-  );
+  const maxLabelLength = Math.max(...charted.map((p) => p.packageName.length));
 
   charted.forEach((pkg) => {
     const barLength = Math.round(

--- a/tests/helpers/mock-reports.test.ts
+++ b/tests/helpers/mock-reports.test.ts
@@ -20,7 +20,6 @@ describe('mock report factory', () => {
   it('createMockPackage returns a valid PackageDistribution', () => {
     const pkg = createMockPackage('react');
     expect(pkg.packageName).toBe('react');
-    expect(pkg.internal).toBe(false);
   });
 
   it('createMockReleaseAge returns a valid ReleaseAgeEntry', () => {

--- a/tests/helpers/mock-reports.ts
+++ b/tests/helpers/mock-reports.ts
@@ -61,7 +61,6 @@ export function createMockPackage(
     usageCount: 1,
     percentage: 100,
     declaredIn: ['dependencies'],
-    internal: false,
     hasVersionConflict: false,
     // Defaults to a single-entry array matching `version` (not a fixed
     // '1.0.0') so overriding just `version` doesn't silently produce a
@@ -91,7 +90,6 @@ export function createMockInventoryEntry(
     rootVersion: version,
     allVersions: version ? [version] : [],
     hasVersionConflict: false,
-    internal: false,
     ignored: false,
     usageCount: 1,
     componentCount: 1,

--- a/tests/npm-registry/enricher.test.ts
+++ b/tests/npm-registry/enricher.test.ts
@@ -41,15 +41,6 @@ describe('enrichWithReleaseAge â€” skipped packages', () => {
     expect(enriched[0].releaseAge).toBeUndefined();
   });
 
-  it('skips internal packages', async () => {
-    const pkg = createMockPackage('@company/ui', {
-      internal: true,
-      version: '1.0.0',
-    });
-    await enrichWithReleaseAge([pkg], BASE_CONFIG);
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
   // #78 made `packages[]` every package the repo owns rather than only the
   // used ones. Enrichment must NOT follow it there: one registry request per
   // declared dependency is a large traffic increase, and — because an empty

--- a/tests/utils/aggregator.test.ts
+++ b/tests/utils/aggregator.test.ts
@@ -232,7 +232,6 @@ describe('aggregateReports — package distribution', () => {
     expect(dist.componentCount).toBe(1);
     expect(dist.usageCount).toBe(1);
     expect(dist.percentage).toBe(100);
-    expect(dist.internal).toBe(false);
   });
 
   it('resolves subpath imports to the base package', () => {
@@ -256,23 +255,6 @@ describe('aggregateReports — package distribution', () => {
     expect(result.packageDistribution).toEqual([]);
     // Components are still counted even when their source is local/unknown
     expect(result.totalComponents).toBe(2);
-  });
-
-  it('marks packages matching internal patterns as internal', () => {
-    const report = reportWithNamedImport('Card', '@company/ui');
-    const config = createConfig({ packages: { internal: ['@company/*'] } });
-
-    const result = aggregateReports(
-      [report],
-      { '@company/ui': '2.0.0' },
-      config,
-    );
-
-    expect(result.packageDistribution).toHaveLength(1);
-    const dist = result.packageDistribution[0];
-    expect(dist.packageName).toBe('@company/ui');
-    expect(dist.version).toBe('2.0.0');
-    expect(dist.internal).toBe(true);
   });
 
   it('surfaces a lockfile-only, side-effect-imported package that matches releaseAge.enforceOn', () => {

--- a/tests/utils/package-distribution.test.ts
+++ b/tests/utils/package-distribution.test.ts
@@ -336,17 +336,6 @@ describe('calculatePackageDistribution', () => {
     expect(distribution[0].allVersions).toEqual(['5.0.0']);
   });
 
-  it('marks a package as internal when it matches a configured internal pattern', () => {
-    const componentUsageMap = new Map<string, ComponentUsage>([
-      ['Widget', makeComponent('Widget', '@my-org/ui', 1)],
-    ]);
-    const config = createConfig({ packages: { internal: ['@my-org/*'] } });
-
-    const distribution = buildDistribution(componentUsageMap, {}, config);
-
-    expect(distribution[0].internal).toBe(true);
-  });
-
   it('excludes a package matched by a configured ignore pattern', () => {
     const componentUsageMap = new Map<string, ComponentUsage>([
       ['Button', makeComponent('Button', 'antd', 1)],
@@ -379,7 +368,6 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
       componentCount: 0,
       usageCount: 0,
       percentage: 0,
-      internal: false,
     });
   });
 
@@ -473,22 +461,6 @@ describe('calculatePackageDistribution — lockfile-only enforceOn deps', () => 
     );
 
     expect(distribution).toEqual([]);
-  });
-
-  it('marks a lockfile-only enforceOn match as internal when it matches an internal pattern', () => {
-    const componentUsageMap = new Map<string, ComponentUsage>();
-    const config = createConfig({
-      packages: { internal: ['@acme-ui/*'] },
-      releaseAge: { enabled: true, enforceOn: ['@acme-ui/pulse-styles'] },
-    });
-
-    const distribution = buildDistribution(
-      componentUsageMap,
-      { '@acme-ui/pulse-styles': '2.1.0' },
-      config,
-    );
-
-    expect(distribution[0].internal).toBe(true);
   });
 
   it('flags hasVersionConflict/allVersions for a lockfile-only enforceOn match', () => {

--- a/tests/utils/package-inventory.test.ts
+++ b/tests/utils/package-inventory.test.ts
@@ -175,17 +175,6 @@ describe('buildPackageInventory — config flags', () => {
     expect(entry?.ignored).toBe(true);
     expect(isOwnedByRepo(entry!)).toBe(false);
   });
-
-  it('flags packages matching packages.internal', () => {
-    const config = createConfig({ packages: { internal: ['@my-org/*'] } });
-    const inventory = buildPackageInventory({
-      versions: { '@my-org/ui': '2.0.0', react: '18.0.0' },
-      config,
-    });
-
-    expect(find(inventory, '@my-org/ui')?.internal).toBe(true);
-    expect(find(inventory, 'react')?.internal).toBe(false);
-  });
 });
 
 describe('inventory predicates', () => {

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -347,19 +347,6 @@ describe('printPackages', () => {
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
-  it('chart mode pads an internal package label wider to make room for the [int] tag', () => {
-    const aggregated = makeAggregated({
-      packageDistribution: [
-        createMockPackage('@my-org/ui', { internal: true, percentage: 100 }),
-      ],
-    });
-    expect(() => printPackages(aggregated, 'chart')).not.toThrow();
-    const output = consoleSpy.mock.calls
-      .map((call) => call.join(' '))
-      .join('\n');
-    expect(output).toContain('[int]');
-  });
-
   it('marks a package with multiple resolved versions as a version conflict', () => {
     const aggregated = makeAggregated({
       packageDistribution: [
@@ -437,18 +424,6 @@ describe('formatPackageName', () => {
     expect(formatPackageName(pkg, forbidViolation('moment', 'warn'))).toContain(
       '[RESTRICTED]',
     );
-  });
-
-  it('prefixes an internal package as [int] when not banned', () => {
-    const pkg = createMockPackage('@my-org/utils', { internal: true });
-    expect(formatPackageName(pkg)).toContain('[int]');
-  });
-
-  it('prefers [BANNED]/[RESTRICTED] over [int] when a package is both internal and banned', () => {
-    const pkg = createMockPackage('@my-org/utils', { internal: true });
-    const name = formatPackageName(pkg, forbidViolation('@my-org/utils'));
-    expect(name).toContain('[BANNED]');
-    expect(name).not.toContain('[int]');
   });
 
   it('combines [DEPRECATED] with [BANNED] when both apply', () => {


### PR DESCRIPTION
## Summary
- Removes `packages.internal` config and the `[int]` badge — confirmed unused, adds config surface and a release-age enrichment skip nobody relies on
- Cleans up the `internal` flag from `PackageInventoryEntry` / `PackageDistribution`, the enricher's skip filter, and the print-packages badge/column-padding logic
- Updates docs (`docs/examples.md`, `docs-templates/__examples.md`) and fixtures, removes now-dead tests

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test:ci` (672 passed)
- [x] `pnpm run lint:ci`
- [x] `pnpm run format:ci`
- [x] `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)