### PR TITLE
chore: add missing breaking-change changeset for #149

### DIFF
--- a/.changeset/tiny-wombats-relax.md
+++ b/.changeset/tiny-wombats-relax.md
@@ -1,0 +1,7 @@
+---
+"hermex": major
+---
+
+Removed the unused `packages.internal` config option and its `[int]` marker in package output.
+
+Config authors using `packages.internal` in `hermex.config.ts` must remove it — the key is no longer part of the schema. The `internal` field is also gone from the `PackageDistribution` and `PackageInventoryEntry` exported types.


### PR DESCRIPTION
## Summary
- PR #149 removed the `packages.internal` config option (schema, types, and `[int]` output marker) but was merged as a `chore` with no changeset, so the breaking change wasn't captured in the changelog.
- Adds a `major` changeset documenting the removal for config authors relying on `packages.internal`.

## Test plan
- [x] N/A — changeset-only change, no code modified