### PR TITLE
chore: upgrade pnpm to 12.0.0-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,5 @@
   "engines": {
     "node": ">=24.11.1"
   },
-  "packageManager": "pnpm@12.0.0-rc.5"
+  "packageManager": "pnpm@12.0.0-rc.6+sha512.3927fce49c3054b7e5541dc720bce7b4ebab07f4562fa6ffce7b39720a25e6a767d76384984e2265c800799613f7f79c5c422e9f5cedc9b66cfffd08ca3c77a9"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,96 +7,96 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: 12.0.0-rc.5
-        version: 12.0.0-rc.5
+        specifier: 12.0.0-rc.6
+        version: 12.0.0-rc.6
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
-    resolution: {integrity: sha512-CYNIBkLIcQ3dv9Bp4p8BUS9JMoQQM30ulEa72B8oqtgMweqraQ/60mnJut0iqflt6F9OSPgNJxTLmUVM0X/8ew==}
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-m57z/dG0gzeh4rCApyLaHbaLh+4SwOiIoEQAyYUvY/YVVThBY4PrgJIE/0jxfNe9WeJR2cGO6W0ehiQ9LZ4csg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
-    resolution: {integrity: sha512-kJYD1EpisLlPrvIsA9SB40EAo0k/qPGioi56rMr9Us2pLTKNnzW6qyU/oeDDf9RcKDXWyjNsO9hHHVIfCS9BYA==}
+  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-Kqojv9k2hrAoUKEa+U2J1nMcYGZnxBnZ90Al7RMavfcKIDE13GdnWMaeiNKFBWoyPdYgtR2qCtwyjAprWSUstg==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
-    resolution: {integrity: sha512-yQwz0Ahn62uRSjGT23drqshUWWIfwuZhq8uASp9JvsrRd/+xFG9K5hgyfW+Mhywlh2gWQ0tjQTbzJNdwvPzqUA==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
+    resolution: {integrity: sha512-FGeJUQ9Pralhzibl1o5QZUPhPIIWbomoeJG5Gm2HFFNEkvDWm+MwRw5eRnPdb+zyGtrXfQAc7eZtMgLQh/tuVg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
-    resolution: {integrity: sha512-/SlL2Or1dfiUJeAIusaWnwnQuoA2PwFqtbwFlvsihOfAaAZLw9P6mofu6VbWN/xB9OxLfGIXeElKUeY4PQehtw==}
+  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-/S+hdo/9b8jOa74bpF7p+rTKUlqvsSLGLaCtNAyH+PjEKmTsbOKDinTeFM4MJK+6qEipigmrnSYrt66AwuT+CA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
-    resolution: {integrity: sha512-NkHve9TqSKqOQRjUx4w5niVuEojNHu2gy6s1rAvIWO4HEDC6g3Opn2toGLBYHO7xdzC/tL0iWQBJjhMBWCyq3g==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
+    resolution: {integrity: sha512-Sn88BvO6o1ChhP63qA/J96tWI+WBDtN57ZycUfl3ZV8n4ccmETYkWMRo4JaCexaMZI/b5U17neoBUo0MHZChHQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.5':
-    resolution: {integrity: sha512-U7NiGcExYsbjItnntmB9aR84SA86MUCrpiB/rrK1aoNaTJHhZHXCusqkbYktZEd6PUTw0RA1SdBDrxpeQyLyKw==}
+  '@pnpm/exe.linux-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-gCeOwlSLqMo0J/X4pH9yDH0GpZ+FAxHuFHGdedN7YKhCKxacUt+b4m74xSaBgSK2r4eHYR9bGCsLqSQ9ZaERTQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
-    resolution: {integrity: sha512-j4W16YwEq2xJ01fw8hUCYme8UwRZHxMxUVF3DMUtr4+GxrMgqpjgHsWtlybRLVjVhXe4rTjNE7VIkrIvReuHpg==}
+  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-q7b2oxEcCBTBTh15qORCfCZfa3EHoNiIPdHJCS1Vs1tvv2qPys2AW9FpSwdPY6N9zb419CDQxb+Cwjfe2n/ZjQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.5':
-    resolution: {integrity: sha512-IQrykr2gv9X6/hW2DgxyNNm7O2jl40xzDpgH2gAI0Z+A6gZaOn0BWBIAfv1j87W0yt1OC41I7qvgEPC9kO3dvQ==}
+  '@pnpm/exe.win32-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-YBFLDcLgl60ssEeLJlBikCwK0LIjbmeVngA/0hu2MTvbbkV1GQcNlFKuVpG5OLW17PH5YGydIAbs0qEf0PQPiA==}
     cpu: [x64]
     os: [win32]
 
-  pnpm@12.0.0-rc.5:
-    resolution: {integrity: sha512-MvAerV1e6ufMdA5zy0am6ENHGiIWoGz8ADQEuViZJ1kVmoSW7xuCicO0BXICoqlUyX7p5jH+BN2HGzMYIi70Vg==}
+  pnpm@12.0.0-rc.6:
+    resolution: {integrity: sha512-OSf85JwwVLflVB3HILzntOurB/RWL6b/zns5cgol5qdn12OEmE4iZcgAeZYT9/ecXEIun1ztybZs//0Iyjx3qQ==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
+  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
+  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.5':
+  '@pnpm/exe.linux-x64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
+  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.5':
+  '@pnpm/exe.win32-x64@12.0.0-rc.6':
     optional: true
 
-  pnpm@12.0.0-rc.5:
+  pnpm@12.0.0-rc.6:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-rc.5
-      '@pnpm/exe.darwin-x64': 12.0.0-rc.5
-      '@pnpm/exe.linux-arm64': 12.0.0-rc.5
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.5
-      '@pnpm/exe.linux-x64': 12.0.0-rc.5
-      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.5
-      '@pnpm/exe.win32-arm64': 12.0.0-rc.5
-      '@pnpm/exe.win32-x64': 12.0.0-rc.5
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.6
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.6
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.6
+      '@pnpm/exe.win32-x64': 12.0.0-rc.6
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
## Summary
- Bump `packageManager` to `pnpm@12.0.0-rc.6` (rc.5 broke corepack)
- Regenerate `pnpm-lock.yaml` for the new pnpm version

## Test plan
- [x] `pnpm run build:ci`
- [x] `pnpm run lint:ci`
- [x] `pnpm run test:ci` (672 tests passing)