### PR TITLE
fix(output-review): drop the pre-pnpm-workspace.yaml fallback in buildReference

### DIFF
--- a/scripts/output-review.ts
+++ b/scripts/output-review.ts
@@ -444,21 +444,6 @@ function buildReference(ref: string): string {
   // itself, for instance). A bare SHA has no such conflict.
   run('git', ['worktree', 'add', '--detach', worktree, sha], ROOT);
 
-  // pnpm resolves its workspace root by walking up from `worktree` looking
-  // for pnpm-workspace.yaml, and does not stop at the nested worktree's own
-  // `.git` file — so without one here it keeps going, lands on ROOT's, and
-  // then fails `--frozen-lockfile` because ROOT's lockfile has no importer
-  // entry for this path. `ref` predates pnpm-workspace.yaml on older
-  // commits; on newer ones the checkout already has its own copy (with its
-  // own allowBuilds) and this is a no-op.
-  const worktreeWorkspaceFile = join(worktree, 'pnpm-workspace.yaml');
-  if (!existsSync(worktreeWorkspaceFile)) {
-    writeFileSync(
-      worktreeWorkspaceFile,
-      "allowBuilds:\n  '@swc/core': true\n  esbuild: true\n",
-    );
-  }
-
   run('pnpm', ['install', '--frozen-lockfile'], worktree);
   run('pnpm', ['run', 'build'], worktree);
   return cli;


### PR DESCRIPTION
## Summary
- `scripts/output-review.ts`'s `buildReference` wrote a fallback `pnpm-workspace.yaml` into worktrees checked out from refs that predated that file — needed at the time because `main` didn't have `pnpm-workspace.yaml` yet (added in #141).
- `main` has had `pnpm-workspace.yaml` since #141 merged, so the fallback is dead code. Removed it.

## Context
Two sibling workarounds from #141 (pinning the pnpm version and relaxing `STRICT_DEP_BUILDS` for a `matrix.branch: main` CI leg, both added for the same "main doesn't have pnpm-workspace.yaml yet" reason) were already removed in #136, when that whole matrix leg was deleted in favor of comparing against a published coverage-baseline artifact. This is the last one.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:ci`
- [x] `pnpm run format:ci`