### PR TITLE
fix(lock-parser): sort allVersions by semver, not lexicographically

### DIFF
--- a/.changeset/lucky-carrots-sort.md
+++ b/.changeset/lucky-carrots-sort.md
@@ -1,0 +1,5 @@
+---
+"hermex": patch
+---
+
+`allVersions` in lockfile resolution output is now sorted by semver instead of lexicographically, so a package resolved at `1.9.0` and `1.10.0` reports `["1.9.0", "1.10.0"]` instead of `["1.10.0", "1.9.0"]`. Non-semver version strings (git URLs, `file:` links, workspace protocol) are collated last, in stable lexicographic order.

--- a/src/lock-parser/lock-file-adapter.ts
+++ b/src/lock-parser/lock-file-adapter.ts
@@ -73,12 +73,27 @@ export function createResolutionAccumulator(): {
       for (const [pkgName, versions] of Object.entries(versionSets)) {
         result[pkgName] = {
           rootVersion: roots[pkgName] ?? null,
-          allVersions: Array.from(versions).sort(),
+          allVersions: Array.from(versions).sort(compareVersions),
         };
       }
       return result;
     },
   };
+}
+
+/**
+ * Orders versions by semver, with non-semver strings (git URLs, `file:` links,
+ * workspace protocol) collated last in stable lexicographic order. A plain
+ * `.sort()` here put 1.10.0 before 1.9.0; `semver.compare` alone throws on the
+ * non-semver strings lockfiles legitimately contain.
+ */
+export function compareVersions(a: string, b: string): number {
+  const aValid = semver.valid(a);
+  const bValid = semver.valid(b);
+  if (aValid && bValid) return semver.compare(a, b);
+  if (aValid) return -1;
+  if (bValid) return 1;
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 /** Highest valid semver among `versions`, or `undefined` if none are valid. */

--- a/tests/lock-parser/lock-parser.test.ts
+++ b/tests/lock-parser/lock-parser.test.ts
@@ -6,7 +6,10 @@ import lockfileLib from '@yarnpkg/lockfile';
 import { PnpmLockfileAdapter } from '../../src/lock-parser/patterns/pnpm';
 import { NpmLockfileAdapter } from '../../src/lock-parser/patterns/npm';
 import { YarnLockfileAdapter } from '../../src/lock-parser/patterns/yarn';
-import { readAndParseLockfile } from '../../src/lock-parser/lock-file-adapter';
+import {
+  readAndParseLockfile,
+  compareVersions,
+} from '../../src/lock-parser/lock-file-adapter';
 import {
   findAndParseLockfile,
   getPackageVersion,
@@ -525,6 +528,39 @@ describe('getPackageVersion / getPackageVersions', () => {
       'does-not-exist-pkg',
     ]);
     expect(versions).toEqual({ chalk: '5.3.0', vitest: '1.6.0' });
+  });
+});
+
+describe('compareVersions', () => {
+  it('sorts versions by semver value, not lexicographically', () => {
+    expect(['1.10.0', '1.9.0'].sort(compareVersions)).toEqual([
+      '1.9.0',
+      '1.10.0',
+    ]);
+  });
+
+  it('sorts valid semver first, non-semver strings last in lexicographic order', () => {
+    expect(['2.0.0', 'workspace:*', '1.0.0'].sort(compareVersions)).toEqual([
+      '1.0.0',
+      '2.0.0',
+      'workspace:*',
+    ]);
+  });
+
+  it('does not throw when all versions are non-semver, and returns a stable order', () => {
+    const versions = ['file:../local-pkg', 'git+https://example.com/pkg.git'];
+    expect(() => versions.sort(compareVersions)).not.toThrow();
+    expect(versions.sort(compareVersions)).toEqual([
+      'file:../local-pkg',
+      'git+https://example.com/pkg.git',
+    ]);
+  });
+
+  it('orders a prerelease before its final release', () => {
+    expect(['1.0.0', '1.0.0-beta.1'].sort(compareVersions)).toEqual([
+      '1.0.0-beta.1',
+      '1.0.0',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `allVersions` (every resolved version of a package across the lockfile) was sorted with a bare `Array.prototype.sort()`, so it ordered as strings — `1.10.0` before `1.9.0`.
- Adds `compareVersions` in `src/lock-parser/lock-file-adapter.ts`: valid semver sorts numerically via `semver.compare`, non-semver strings (git URLs, `file:` links, workspace protocol) collate last in stable lexicographic order — a naive `sort(semver.compare)` would throw on those.
- `build()` now sorts `allVersions` with `compareVersions` instead of the plain `.sort()`.

Implements `plans/032-allversions-semver-order.md` from #130 (map ticket #115).

## Test plan
- [x] 4 new tests for `compareVersions` in `tests/lock-parser/lock-parser.test.ts`: semver-vs-lexicographic ordering, mixed valid/invalid, all-invalid (no throw), prerelease ordering
- [x] Confirmed the ordering and prerelease cases are genuine regressions (fail when the fix is stashed out)
- [x] `pnpm run format:ci`, `lint:ci`, `typecheck`, `test:ci` (676 tests), `build:ci` all pass
- [x] `pnpm run test:output` — 26/26 match, no baseline drift
- [x] `grep -n "Array.from(versions).sort()" src/` — no matches
- [x] Added a patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)