### PR TITLE
fix(config): reject silently-ignored config keys and missing default exports

### DIFF
--- a/.changeset/wild-donkeys-jump.md
+++ b/.changeset/wild-donkeys-jump.md
@@ -1,0 +1,9 @@
+---
+"hermex": major
+---
+
+`hermex.config.ts` is now validated strictly: a config file with no default export throws instead of silently loading as an all-defaults config, and any config object (root or nested — `rules`, `overrides[].rules`, `output`, `releaseAge`, etc.) carrying an unrecognized key throws instead of silently dropping it.
+
+Both were previously silent failures: a misspelled rule key parsed cleanly and enforced nothing, and a config file that forgot `export default` did the same. Both now fail loudly at load time, naming the offending key or the missing export.
+
+Config authors should check `hermex.config.ts` (and any files referenced by `overrides[].rules`) for stray or misspelled keys before upgrading — anything not in the documented schema will now throw.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -17,8 +17,20 @@ export async function loadConfig(
   }
 
   if (existsSync(configPath)) {
-    const mod = await import(pathToFileURL(configPath).href);
-    return HermexConfigSchema.parse(mod.default ?? mod);
+    const mod = (await import(pathToFileURL(configPath).href)) as Record<
+      string,
+      unknown
+    >;
+
+    if (mod.default === undefined) {
+      throw new Error(
+        `Config file has no default export: ${configPath}\n` +
+          `hermex reads the default export. Add \`export default { ... }\`, or ` +
+          `\`export default defineConfig({ ... })\` for type inference.`,
+      );
+    }
+
+    return HermexConfigSchema.parse(mod.default);
   }
 
   return HermexConfigSchema.parse({});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -10,11 +10,13 @@ import { z } from 'zod';
 // way an override cancels an org-wide rule for specific repos today.
 const RuleSeveritySchema = z.enum(['error', 'warn', 'info', 'off']);
 
-const RuleConfigSchema = z.object({
-  severity: RuleSeveritySchema,
-  patterns: z.array(z.string()),
-  message: z.string().optional(),
-});
+const RuleConfigSchema = z
+  .object({
+    severity: RuleSeveritySchema,
+    patterns: z.array(z.string()),
+    message: z.string().optional(),
+  })
+  .strict();
 
 const RuleConfigOrArraySchema = z.union([
   RuleConfigSchema,
@@ -24,25 +26,29 @@ const RuleConfigOrArraySchema = z.union([
 const PackageFieldRuleSchema = RuleConfigSchema.extend({
   /** Optional micromatch patterns the field's stringified value must match */
   values: z.array(z.string()).optional(),
-});
+}).strict();
 
 const PackageFieldRuleOrArraySchema = z.union([
   PackageFieldRuleSchema,
   z.array(PackageFieldRuleSchema),
 ]);
 
-const EngineVersionRuleSchema = z.object({
-  severity: RuleSeveritySchema,
-  range: z.string(),
-  message: z.string().optional(),
-});
+const EngineVersionRuleSchema = z
+  .object({
+    severity: RuleSeveritySchema,
+    range: z.string(),
+    message: z.string().optional(),
+  })
+  .strict();
 
-const CodeownersRuleSchema = z.object({
-  severity: RuleSeveritySchema,
-  message: z.string().optional(),
-  /** If set, matched files must be owned by at least one of these owner strings (exact match against CODEOWNERS entries, e.g. "@org/team"). */
-  requiredOwners: z.array(z.string()).optional(),
-});
+const CodeownersRuleSchema = z
+  .object({
+    severity: RuleSeveritySchema,
+    message: z.string().optional(),
+    /** If set, matched files must be owned by at least one of these owner strings (exact match against CODEOWNERS entries, e.g. "@org/team"). */
+    requiredOwners: z.array(z.string()).optional(),
+  })
+  .strict();
 
 const ThresholdSchema = z.union([z.number(), z.literal(false)]);
 
@@ -63,132 +69,146 @@ const OverrideRulesSchema = z
       .optional(),
     'require-codeowners': CodeownersRuleSchema.optional(),
   })
+  .strict()
   .default(() => ({}));
 
-const OverrideSchema = z.object({
-  /** Micromatch patterns checked against the current repo's package.json "name" */
-  match: z.array(z.string()).min(1),
-  rules: OverrideRulesSchema,
-});
+const OverrideSchema = z
+  .object({
+    /** Micromatch patterns checked against the current repo's package.json "name" */
+    match: z.array(z.string()).min(1),
+    rules: OverrideRulesSchema,
+  })
+  .strict();
 
 // ── Main schema with defaults ──────────────────────────────────────────────────
 
-export const HermexConfigSchema = z.object({
-  includes: z.array(z.string()).default(['**/*.{tsx,jsx,ts,js}']),
-  excludes: z
-    .array(z.string())
-    .default(['**/node_modules/**', '**/dist/**', '**/build/**']),
+export const HermexConfigSchema = z
+  .object({
+    includes: z.array(z.string()).default(['**/*.{tsx,jsx,ts,js}']),
+    excludes: z
+      .array(z.string())
+      .default(['**/node_modules/**', '**/dist/**', '**/build/**']),
 
-  packages: z
-    .object({
-      ignore: z.array(z.string()).default([]),
-    })
-    .default(() => ({ ignore: [] })),
+    packages: z
+      .object({
+        ignore: z.array(z.string()).default([]),
+      })
+      .strict()
+      .default(() => ({ ignore: [] })),
 
-  versus: z
-    .array(z.object({ name: z.string(), packages: z.array(z.string()).min(2) }))
-    .default([]),
+    versus: z
+      .array(
+        z
+          .object({ name: z.string(), packages: z.array(z.string()).min(2) })
+          .strict(),
+      )
+      .default([]),
 
-  /**
-   * Repo-scoped rule adjustments: when the current repo's package.json "name"
-   * matches an entry's `match` patterns, its `rules` are upserted into the
-   * base `rules` below, keyed by identity (a rule's `patterns`, or `range`
-   * for require-engine-version) — a rule with new patterns is added, one
-   * whose patterns match an existing base rule replaces it, and severity
-   * 'off' replaces it with nothing (like ESLint's per-rule 'off'). Lets one
-   * shared config both add rules to a subset of repos (a mandatory
-   * dependency for 30 of 150 apps) and loosen/cancel an org-wide rule for
-   * specific repos.
-   */
-  overrides: z.array(OverrideSchema).default([]),
+    /**
+     * Repo-scoped rule adjustments: when the current repo's package.json "name"
+     * matches an entry's `match` patterns, its `rules` are upserted into the
+     * base `rules` below, keyed by identity (a rule's `patterns`, or `range`
+     * for require-engine-version) — a rule with new patterns is added, one
+     * whose patterns match an existing base rule replaces it, and severity
+     * 'off' replaces it with nothing (like ESLint's per-rule 'off'). Lets one
+     * shared config both add rules to a subset of repos (a mandatory
+     * dependency for 30 of 150 apps) and loosen/cancel an org-wide rule for
+     * specific repos.
+     */
+    overrides: z.array(OverrideSchema).default([]),
 
-  rules: z
-    .object({
-      'no-files': RuleConfigOrArraySchema.default([]),
-      'require-files': RuleConfigOrArraySchema.default([]),
-      'no-packages': RuleConfigOrArraySchema.default([]),
-      'require-packages': RuleConfigOrArraySchema.default([]),
-      'require-scripts': RuleConfigOrArraySchema.default([]),
-      'require-package-fields': PackageFieldRuleOrArraySchema.default([]),
-      'no-package-fields': PackageFieldRuleOrArraySchema.default([]),
-      'require-engine-version': z
-        .union([EngineVersionRuleSchema, z.array(EngineVersionRuleSchema)])
-        .optional(),
-      'require-codeowners': CodeownersRuleSchema.optional(),
-    })
-    .default(() => ({
-      'no-files': [] as RuleConfig[],
-      'require-files': [] as RuleConfig[],
-      'no-packages': [] as RuleConfig[],
-      'require-packages': [] as RuleConfig[],
-      'require-scripts': [] as RuleConfig[],
-      'require-package-fields': [] as PackageFieldRule[],
-      'no-package-fields': [] as PackageFieldRule[],
-    })),
+    rules: z
+      .object({
+        'no-files': RuleConfigOrArraySchema.default([]),
+        'require-files': RuleConfigOrArraySchema.default([]),
+        'no-packages': RuleConfigOrArraySchema.default([]),
+        'require-packages': RuleConfigOrArraySchema.default([]),
+        'require-scripts': RuleConfigOrArraySchema.default([]),
+        'require-package-fields': PackageFieldRuleOrArraySchema.default([]),
+        'no-package-fields': PackageFieldRuleOrArraySchema.default([]),
+        'require-engine-version': z
+          .union([EngineVersionRuleSchema, z.array(EngineVersionRuleSchema)])
+          .optional(),
+        'require-codeowners': CodeownersRuleSchema.optional(),
+      })
+      .strict()
+      .default(() => ({
+        'no-files': [] as RuleConfig[],
+        'require-files': [] as RuleConfig[],
+        'no-packages': [] as RuleConfig[],
+        'require-packages': [] as RuleConfig[],
+        'require-scripts': [] as RuleConfig[],
+        'require-package-fields': [] as PackageFieldRule[],
+        'no-package-fields': [] as PackageFieldRule[],
+      })),
 
-  output: z
-    .object({
-      summary: z.union([z.literal('log'), z.literal(false)]).default('log'),
-      components: z
-        .union([z.enum(['table', 'chart']), z.literal(false)])
-        .default('table'),
-      packages: z
-        .union([z.enum(['table', 'chart']), z.literal(false)])
-        .default('table'),
-      patterns: z
-        .union([z.enum(['table', 'chart']), z.literal(false)])
-        .default('table'),
-      details: z.boolean().default(false),
-      versus: z.boolean().default(true),
-      rules: z.boolean().default(true),
-      format: z.enum(['human', 'json']).default('human'),
-    })
-    .default(() => ({
-      summary: 'log' as const,
-      components: 'table' as const,
-      packages: 'table' as const,
-      patterns: 'table' as const,
-      details: false,
-      versus: true,
-      rules: true,
-      format: 'human' as const,
-    })),
+    output: z
+      .object({
+        summary: z.union([z.literal('log'), z.literal(false)]).default('log'),
+        components: z
+          .union([z.enum(['table', 'chart']), z.literal(false)])
+          .default('table'),
+        packages: z
+          .union([z.enum(['table', 'chart']), z.literal(false)])
+          .default('table'),
+        patterns: z
+          .union([z.enum(['table', 'chart']), z.literal(false)])
+          .default('table'),
+        details: z.boolean().default(false),
+        versus: z.boolean().default(true),
+        rules: z.boolean().default(true),
+        format: z.enum(['human', 'json']).default('human'),
+      })
+      .strict()
+      .default(() => ({
+        summary: 'log' as const,
+        components: 'table' as const,
+        packages: 'table' as const,
+        patterns: 'table' as const,
+        details: false,
+        versus: true,
+        rules: true,
+        format: 'human' as const,
+      })),
 
-  releaseAge: z
-    .object({
-      enabled: z.boolean().default(false),
-      registry: z.string().default('https://registry.npmjs.org'),
-      authToken: z.string().optional(),
-      thresholds: z
-        .object({
-          patch: ThresholdSchema.default(30),
-          minor: ThresholdSchema.default(45),
-          major: ThresholdSchema.default(60),
-        })
-        .default(() => ({ patch: 30, minor: 45, major: 60 })),
-      enforceOn: z.array(z.string()).default([]),
-      cacheTtlMs: z.number().int().positive().optional(),
-      cacheDisabled: z.boolean().default(false),
-      // 'root' checks only each package's direct/root-installed version;
-      // 'tree' checks every resolved copy in the lockfile, failing if any
-      // is overdue. Nested duplicates are always visible as advisory data
-      // regardless of scope — this only decides what's mandatory (#57).
-      scope: z.enum(['root', 'tree']).default('root'),
-      // Glob-matched (like enforceOn): packages matching here use the
-      // OPPOSITE of `scope`, letting one global policy carve out
-      // exceptions for specific packages.
-      scopeExceptions: z.array(z.string()).default([]),
-    })
-    .default(() => ({
-      enabled: false,
-      registry: 'https://registry.npmjs.org',
-      thresholds: { patch: 30, minor: 45, major: 60 },
-      enforceOn: [],
-      cacheDisabled: false,
-      scope: 'root' as const,
-      scopeExceptions: [],
-    })),
-});
+    releaseAge: z
+      .object({
+        enabled: z.boolean().default(false),
+        registry: z.string().default('https://registry.npmjs.org'),
+        authToken: z.string().optional(),
+        thresholds: z
+          .object({
+            patch: ThresholdSchema.default(30),
+            minor: ThresholdSchema.default(45),
+            major: ThresholdSchema.default(60),
+          })
+          .strict()
+          .default(() => ({ patch: 30, minor: 45, major: 60 })),
+        enforceOn: z.array(z.string()).default([]),
+        cacheTtlMs: z.number().int().positive().optional(),
+        cacheDisabled: z.boolean().default(false),
+        // 'root' checks only each package's direct/root-installed version;
+        // 'tree' checks every resolved copy in the lockfile, failing if any
+        // is overdue. Nested duplicates are always visible as advisory data
+        // regardless of scope — this only decides what's mandatory (#57).
+        scope: z.enum(['root', 'tree']).default('root'),
+        // Glob-matched (like enforceOn): packages matching here use the
+        // OPPOSITE of `scope`, letting one global policy carve out
+        // exceptions for specific packages.
+        scopeExceptions: z.array(z.string()).default([]),
+      })
+      .strict()
+      .default(() => ({
+        enabled: false,
+        registry: 'https://registry.npmjs.org',
+        thresholds: { patch: 30, minor: 45, major: 60 },
+        enforceOn: [],
+        cacheDisabled: false,
+        scope: 'root' as const,
+        scopeExceptions: [],
+      })),
+  })
+  .strict();
 
 // ── Derived types ──────────────────────────────────────────────────────────────
 

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from '../../src/config/loader';
+
+describe('loadConfig', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0))
+      rmSync(dir, { recursive: true, force: true });
+  });
+
+  function scratchDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hermex-loader-'));
+    dirs.push(dir);
+    return dir;
+  }
+
+  /** Each test needs a uniquely-named file — Node caches ES modules by URL. */
+  function writeConfig(dir: string, contents: string): string {
+    const path = join(dir, `config-${randomUUID()}.ts`);
+    writeFileSync(path, contents, 'utf8');
+    return path;
+  }
+
+  it('returns the all-defaults config when no config file exists and no explicitPath is given', async () => {
+    const cwd = scratchDir();
+    const result = await loadConfig(cwd);
+    expect(result.includes).toEqual(['**/*.{tsx,jsx,ts,js}']);
+  });
+
+  it('throws when explicitPath points at a missing file', async () => {
+    const cwd = scratchDir();
+    await expect(
+      loadConfig(cwd, join(cwd, 'does-not-exist.ts')),
+    ).rejects.toThrow(/Config file not found/);
+  });
+
+  it('loads a valid config with a default export', async () => {
+    const cwd = scratchDir();
+    const configPath = writeConfig(
+      cwd,
+      `export default { includes: ['a/**'] };`,
+    );
+    const result = await loadConfig(cwd, configPath);
+    expect(result.includes).toEqual(['a/**']);
+  });
+
+  it('throws when the config file has only a named export, no default', async () => {
+    const cwd = scratchDir();
+    const configPath = writeConfig(
+      cwd,
+      `export const config = { includes: ['a/**'] };`,
+    );
+    await expect(loadConfig(cwd, configPath)).rejects.toThrow(
+      /no default export/,
+    );
+  });
+
+  it('throws a zod error when the config value fails the schema', async () => {
+    const cwd = scratchDir();
+    const configPath = writeConfig(
+      cwd,
+      `export default { includes: 'not-an-array' };`,
+    );
+    await expect(loadConfig(cwd, configPath)).rejects.toThrow();
+  });
+
+  it('throws when the config has an unrecognized key', async () => {
+    const cwd = scratchDir();
+    const configPath = writeConfig(cwd, `export default { rulez: {} };`);
+    await expect(loadConfig(cwd, configPath)).rejects.toThrow(
+      /[Uu]nrecognized|unknown/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `loadConfig` (`src/config/loader.ts`) fell back to `mod.default ?? mod`: a config file with no `export default` returned the ES module namespace object, which zod happily accepted and stripped down to an all-defaults config — no error, no warning. Now throws, naming the config path and telling the author to add `export default`.
- Every schema object in `src/config/schema.ts` (root + all nested: `rules`, `overrides[].rules`, `output`, `releaseAge`, `packages`, `versus[]`, etc.) is now `.strict()`. Previously a misspelled or stray key (e.g. `rulez` instead of `rules`) parsed cleanly and silently enforced nothing — the worst failure mode for a compliance gate. Now throws at load time.
- **Breaking change**: existing configs carrying unrecognized keys will now fail to load. Included per operator instruction — this is Step 3 of the plan, gated on an assumption about issue #114's still-open decision (reject vs. warn on unknown keys); see the plan doc's "Assumption this plan encodes" box.

Implements `plans/030-config-loader-hardening.md` from #130 (map ticket #114), Steps 1–4.

## Test plan
- [x] New `tests/config/loader.test.ts`, 6 cases: no config file → defaults, missing `explicitPath` → throws, valid config loads, no default export → throws, schema type failure → throws, unrecognized key → throws
- [x] Confirmed cases 4 (no default export) and 6 (unknown key) are genuine regressions — both fail against the pre-fix code
- [x] Step 4: full `test:ci` confirms every real `hermex.config.ts` in the repo (fixtures, e2e tests) still loads cleanly against the tightened schema — no hidden unknown-key usage
- [x] `pnpm run format:ci`, `lint:ci`, `typecheck`, `test:ci` (682 tests), `build:ci` all pass
- [x] `pnpm run test:output` — 26/26 match, no baseline drift
- [x] `grep -n "mod.default ?? mod" src/config/loader.ts` — no matches
- [x] Added a major changeset (breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)