### PR TITLE
fix(print-rules): include info count in stdout tally so it matches table rows

### DIFF
--- a/src/utils/compliance.ts
+++ b/src/utils/compliance.ts
@@ -1,6 +1,7 @@
 import type { AggregatedReport } from './aggregator';
 import type { RuleViolation } from '../rules/evaluator';
 import type { PackageDistribution } from './package-distribution';
+import { groupBySeverity } from './severity-format';
 
 /**
  * The canonical, three-state compliance verdict hermex publishes so
@@ -44,15 +45,11 @@ export interface ComplianceResult {
 export function computeCompliance(
   aggregated: AggregatedReport,
 ): ComplianceResult {
-  const errorRuleViolations = aggregated.ruleViolations.filter(
-    (v) => v.severity === 'error',
-  );
+  const { error: errorRuleViolations, warn: warningRuleViolations } =
+    groupBySeverity(aggregated.ruleViolations);
   const releaseAgeViolations = aggregated.packageDistribution.filter(
     (p) =>
       p.releaseAge?.severity === 'error' && p.releaseAge?.worstLevel !== null,
-  );
-  const warningRuleViolations = aggregated.ruleViolations.filter(
-    (v) => v.severity === 'warn',
   );
 
   const compliant =

--- a/src/utils/print-rules.ts
+++ b/src/utils/print-rules.ts
@@ -3,7 +3,11 @@ import Table from 'cli-table3';
 import type { AggregatedReport } from './aggregator';
 import type { RuleViolation } from '../rules/evaluator';
 import { formatTruncatedList } from './format-utils';
-import { severityIcon, sortViolationsBySeverity } from './severity-format';
+import {
+  formatSeverityTally,
+  severityIcon,
+  sortViolationsBySeverity,
+} from './severity-format';
 
 export function formatRuleType(ruleId: RuleViolation['ruleId']): string {
   switch (ruleId) {
@@ -98,15 +102,11 @@ export function printRules(aggregated: AggregatedReport): void {
 
   console.log(table.toString());
 
-  const errorCount = ruleViolations.filter(
-    (v) => v.severity === 'error',
-  ).length;
-  const warnCount = ruleViolations.filter((v) => v.severity === 'warn').length;
-
-  const parts: string[] = [];
-  if (errorCount > 0)
-    parts.push(chalk.red(`${errorCount} error${errorCount > 1 ? 's' : ''}`));
-  if (warnCount > 0)
-    parts.push(chalk.yellow(`${warnCount} warning${warnCount > 1 ? 's' : ''}`));
-  console.log(chalk.gray(`\n${parts.join(', ')}`));
+  // Includes info in the tally — the table above always shows every
+  // severity, so the count below it must too, or the two disagree (#88).
+  console.log(
+    chalk.gray(
+      `\n${formatSeverityTally(ruleViolations, { includeInfo: true })}`,
+    ),
+  );
 }

--- a/src/utils/severity-format.ts
+++ b/src/utils/severity-format.ts
@@ -108,3 +108,53 @@ export function sortViolationsBySeverity<T extends RuleViolation>(
     })
     .map(({ v }) => v);
 }
+
+/**
+ * Buckets violations by severity in one pass — the single place that knows
+ * how to partition a violations array, so `printRules`, `--summary-file`,
+ * and `computeCompliance`'s error/warn buckets all derive from the same
+ * grouping instead of each re-filtering `ruleViolations` independently (#88).
+ */
+export function groupBySeverity<T extends RuleViolation>(
+  violations: T[],
+): Record<RuleViolation['severity'], T[]> {
+  const groups: Record<RuleViolation['severity'], T[]> = {
+    error: [],
+    warn: [],
+    info: [],
+  };
+  for (const v of violations) groups[v.severity].push(v);
+  return groups;
+}
+
+/**
+ * Renders the colored, pluralized "N error(s), N warning(s)[, N info]" tally
+ * line shared by `printRules` and `--summary-file`. Built on
+ * `groupBySeverity` so the count under a table always matches the rows
+ * above it — `printRules` shows every severity and passes
+ * `includeInfo: true` accordingly; `--summary-file` filters `info` out of
+ * its rows before calling this (per #31) and leaves `includeInfo` off, so
+ * its tally stays untouched (#88).
+ */
+export function formatSeverityTally(
+  violations: RuleViolation[],
+  options?: { includeInfo?: boolean },
+): string {
+  const groups = groupBySeverity(violations);
+  const parts: string[] = [];
+  if (groups.error.length > 0)
+    parts.push(
+      severityColor('error')(
+        `${groups.error.length} error${groups.error.length > 1 ? 's' : ''}`,
+      ),
+    );
+  if (groups.warn.length > 0)
+    parts.push(
+      severityColor('warn')(
+        `${groups.warn.length} warning${groups.warn.length > 1 ? 's' : ''}`,
+      ),
+    );
+  if (options?.includeInfo && groups.info.length > 0)
+    parts.push(severityColor('info')(`${groups.info.length} info`));
+  return parts.join(', ');
+}

--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -9,6 +9,7 @@ import {
   resolveInstalledVersion,
 } from './print-packages';
 import {
+  formatSeverityTally,
   severityIcon,
   sortViolationsBySeverity,
   stripAnsi,
@@ -45,16 +46,7 @@ function buildRulesSection(aggregated: AggregatedReport): string {
     );
   }
 
-  const errorCount = ruleViolations.filter(
-    (v) => v.severity === 'error',
-  ).length;
-  const warnCount = ruleViolations.filter((v) => v.severity === 'warn').length;
-  const parts: string[] = [];
-  if (errorCount > 0)
-    parts.push(`${errorCount} error${errorCount > 1 ? 's' : ''}`);
-  if (warnCount > 0)
-    parts.push(`${warnCount} warning${warnCount > 1 ? 's' : ''}`);
-  lines.push('', parts.join(', '));
+  lines.push('', formatSeverityTally(ruleViolations));
 
   return lines.join('\n') + '\n';
 }

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -959,6 +959,36 @@ describe('printRules', () => {
     expect(output).not.toContain('🟡');
   });
 
+  // The table always shows every severity, including info — so the tally
+  // below it must count every severity too, or the numbers stop matching
+  // the rows (#88).
+  it('includes an info count in the summary line so it matches the table rows shown', () => {
+    const errorViolation: RuleViolation = {
+      ruleId: 'require-files',
+      severity: 'error',
+      patterns: ['.nvmrc'],
+      matchedFiles: [],
+    };
+    const infoViolation: RuleViolation = {
+      ruleId: 'no-files',
+      severity: 'info',
+      patterns: ['orbis.config.*'],
+      matchedFiles: ['orbis.config.ts'],
+    };
+    const aggregated = makeAggregated({
+      ruleViolations: [
+        errorViolation,
+        forbidViolation('moment', 'warn', 'Use dayjs'),
+        infoViolation,
+      ],
+    });
+    printRules(aggregated);
+    const output = stripAnsi(
+      consoleSpy.mock.calls.map((call) => call.join(' ')).join('\n'),
+    );
+    expect(output).toContain('1 error, 1 warning, 1 info');
+  });
+
   it('renders require-package-fields/no-package-fields violations under the package-fields label', () => {
     const violation: RuleViolation = {
       ruleId: 'require-package-fields',

--- a/tests/utils/severity-format.test.ts
+++ b/tests/utils/severity-format.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import chalk from 'chalk';
+import type { RuleViolation } from '../../src/rules/evaluator';
 import {
   severityIcon,
   severityColor,
   resolveColorLevel,
   stripAnsi,
   applyColorLevel,
+  groupBySeverity,
+  formatSeverityTally,
 } from '../../src/utils/severity-format';
+
+function violation(severity: RuleViolation['severity']): RuleViolation {
+  return {
+    ruleId: 'require-files',
+    severity,
+    patterns: ['.nvmrc'],
+    matchedFiles: [],
+  };
+}
 
 describe('severityIcon', () => {
   it('maps each severity to a distinct colored-circle glyph', () => {
@@ -114,6 +126,72 @@ describe('applyColorLevel', () => {
     process.stdout.write(buf);
 
     expect(stdoutChunks[0]).toBe(buf);
+  });
+});
+
+describe('groupBySeverity', () => {
+  it('returns empty buckets for an empty list', () => {
+    expect(groupBySeverity([])).toEqual({ error: [], warn: [], info: [] });
+  });
+
+  it('buckets violations by severity, preserving order within each bucket', () => {
+    const errorA = violation('error');
+    const warnA = violation('warn');
+    const errorB = violation('error');
+    const infoA = violation('info');
+
+    expect(groupBySeverity([errorA, warnA, errorB, infoA])).toEqual({
+      error: [errorA, errorB],
+      warn: [warnA],
+      info: [infoA],
+    });
+  });
+});
+
+describe('formatSeverityTally', () => {
+  it('returns an empty string for an empty list', () => {
+    expect(formatSeverityTally([])).toBe('');
+  });
+
+  it('omits info by default even when info violations are present', () => {
+    const tally = stripAnsi(
+      formatSeverityTally([violation('error'), violation('info')]),
+    );
+    expect(tally).toBe('1 error');
+  });
+
+  it('includes info when includeInfo is true', () => {
+    const tally = stripAnsi(
+      formatSeverityTally(
+        [violation('error'), violation('warn'), violation('info')],
+        { includeInfo: true },
+      ),
+    );
+    expect(tally).toBe('1 error, 1 warning, 1 info');
+  });
+
+  it('omits an info count of zero even with includeInfo: true', () => {
+    const tally = stripAnsi(
+      formatSeverityTally([violation('error')], { includeInfo: true }),
+    );
+    expect(tally).toBe('1 error');
+  });
+
+  it('pluralizes counts greater than one', () => {
+    const tally = stripAnsi(
+      formatSeverityTally(
+        [
+          violation('error'),
+          violation('error'),
+          violation('warn'),
+          violation('warn'),
+          violation('info'),
+          violation('info'),
+        ],
+        { includeInfo: true },
+      ),
+    );
+    expect(tally).toBe('2 errors, 2 warnings, 2 info');
   });
 });
 


### PR DESCRIPTION
## Summary
- `printRules` rendered every severity (including `info`) in its table but only counted `error`/`warn` in the tally line beneath it, so the numbers didn't match the row count (#88).
- Added `groupBySeverity`/`formatSeverityTally` to `src/utils/severity-format.ts` as a single shared severity-counting pipeline, and routed `print-rules.ts`, `write-summary-file.ts`, and `compliance.ts`'s `computeCompliance` through it, so this logic is now defined once instead of three separate ad hoc `.filter()` implementations.
- `printRules` now includes an info count in its tally (`includeInfo: true`); `--summary-file` keeps excluding `info` from both rows and tally (per #31), unchanged.

Closes #88

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:ci`
- [x] `pnpm run format:ci`
- [x] `pnpm run test:ci` (690 passed, 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)