### PR TITLE
fix(json): make patternCounts explain totalUsagePatterns and totalImports

### DIFF
--- a/.changeset/metal-eels-jump.md
+++ b/.changeset/metal-eels-jump.md
@@ -1,0 +1,5 @@
+---
+"hermex": minor
+---
+
+Fix `summary.patternCounts` so it partitions cleanly against the totals it should explain: renamed `imports.aliased` to `imports.named.aliased` (still counted alongside `imports.named`, not subtracted from it — `totalUsagePatterns` counts aliased imports separately too) and added a `usage.props` bucket so props analysis is no longer missing from the pattern breakdown. `imports.aliased` consumers must switch to `imports.named.aliased`.

--- a/src/utils/pattern-counter.ts
+++ b/src/utils/pattern-counter.ts
@@ -21,9 +21,16 @@ export function countPatterns(
     'imports.namespace',
     report.patterns.imports.namespace.length,
   );
+  // Aliased imports are a subset of `imports.named` (every aliased import is
+  // also a named import — see imports.ts), reported here as an informational
+  // duplicate rather than subtracted out of `imports.named`. Subtracting
+  // would make `imports.named` + `imports.named.aliased` sum to a smaller
+  // total than `totalUsagePatterns`, which independently double-counts
+  // aliased imports (namedImports and aliasedImports are separate
+  // collections in ParserState — see report.ts's calculateTotalPatterns).
   increment(
     patternMap,
-    'imports.aliased',
+    'imports.named.aliased',
     report.patterns.imports.aliased.length,
   );
   increment(patternMap, 'usage.jsx', report.patterns.usage.jsx.length);
@@ -62,6 +69,7 @@ export function countPatterns(
     'advanced.portal',
     report.patterns.advanced.portal.length,
   );
+  increment(patternMap, 'usage.props', report.patterns.props.length);
 }
 
 function increment(map: Map<string, number>, key: string, value: number) {
@@ -73,7 +81,7 @@ export function getPatternDisplayName(patternType: string): string {
     'imports.default': 'Default Imports',
     'imports.named': 'Named Imports',
     'imports.namespace': 'Namespace Imports',
-    'imports.aliased': 'Aliased Imports',
+    'imports.named.aliased': 'Named Imports (aliased)',
     'usage.jsx': 'JSX Usage',
     'usage.variables': 'Variable Assignments',
     'usage.destructuring': 'Destructuring',
@@ -86,6 +94,7 @@ export function getPatternDisplayName(patternType: string): string {
     'advanced.memo': 'Memoized Components',
     'advanced.forwardRef': 'Forward Refs',
     'advanced.portal': 'Portal Usage',
+    'usage.props': 'Props Analyzed',
   };
   return displayNames[patternType] || patternType;
 }

--- a/tests/utils/pattern-counter.test.ts
+++ b/tests/utils/pattern-counter.test.ts
@@ -53,7 +53,74 @@ describe('countPatterns', () => {
 
     expect(patternMap.get('imports.default')).toBe(0);
     expect(patternMap.get('advanced.portal')).toBe(0);
-    expect(patternMap.size).toBe(16);
+    expect(patternMap.size).toBe(17);
+  });
+
+  it('sums to summary.totalUsagePatterns, including props', () => {
+    const report = createMockReport();
+    report.patterns.imports.default.push({ name: 'A', source: 'a' });
+    report.patterns.imports.named.push(
+      { name: 'B', source: 'b' },
+      { name: 'C', source: 'c' },
+    );
+    report.patterns.imports.aliased.push({
+      imported: 'C',
+      local: 'CAlias',
+      source: 'c',
+    });
+    report.patterns.usage.jsx.push(jsxUsage('B'));
+    report.patterns.props.push({
+      component: 'B',
+      analysis: {
+        namedProps: [],
+        hasSpread: false,
+        hasComplexProps: false,
+        hasEventHandlers: false,
+        propDetails: [],
+      },
+    });
+    // Mirrors calculateTotalPatterns: a naive sum of every collection's
+    // size, aliased counted alongside named since it is its own collection.
+    report.summary.totalUsagePatterns =
+      report.patterns.imports.default.length +
+      report.patterns.imports.named.length +
+      report.patterns.imports.namespace.length +
+      report.patterns.imports.aliased.length +
+      report.patterns.usage.jsx.length +
+      report.patterns.props.length;
+
+    const patternMap = new Map<string, number>();
+    countPatterns(report, patternMap);
+    const sumOfCounts = [...patternMap.values()].reduce((a, b) => a + b, 0);
+
+    expect(sumOfCounts).toBe(report.summary.totalUsagePatterns);
+  });
+
+  it('partitions the import buckets to sum to summary.totalImports, with an aliased import present', () => {
+    const report = createMockReport();
+    report.patterns.imports.default.push({ name: 'A', source: 'a' });
+    report.patterns.imports.named.push(
+      { name: 'B', source: 'b' },
+      { name: 'C', source: 'c' },
+    );
+    report.patterns.imports.aliased.push({
+      imported: 'C',
+      local: 'CAlias',
+      source: 'c',
+    });
+    report.summary.totalImports =
+      report.patterns.imports.default.length +
+      report.patterns.imports.named.length +
+      report.patterns.imports.namespace.length;
+
+    const patternMap = new Map<string, number>();
+    countPatterns(report, patternMap);
+    const importBucketSum =
+      (patternMap.get('imports.default') ?? 0) +
+      (patternMap.get('imports.named') ?? 0) +
+      (patternMap.get('imports.namespace') ?? 0);
+
+    expect(importBucketSum).toBe(report.summary.totalImports);
   });
 });
 


### PR DESCRIPTION
Implements [plan 031](https://github.com/Gallevy/hermex/pull/130/files#diff-245b5d283a3c7e656e553d00950a52c6eb4a31102c13623182ffd4dc2376c189) (`plans/031-json-summary-arithmetic.md`, from #130 — not yet merged, so this PR can't link the file directly). Ref #115.

## Summary
- `summary.patternCounts` was missing a `usage.props` bucket entirely, so it undercounted `totalUsagePatterns` (220 vs 284 on the `fixtures` repo). Added the bucket.
- Renamed `imports.aliased` to `imports.named.aliased` for clarity (it's a property of a named import, not a separate import category).

## Deviation from the plan
The plan's Step 1 called for **subtracting** the aliased count out of `imports.named` to make the import buckets a strict partition. I found that breaks the exact invariant the plan's own Step 5 verifies: `totalUsagePatterns` (`calculateTotalPatterns` in `src/swc-parser/core/report.ts`) sums the size of *every* collection in `ParserState.usagePatterns`, and `aliasedImports` is its own `Map`, separate from `namedImports` — so `totalUsagePatterns` already double-counts aliased imports, independent of this plan's scope. Subtracting made the bucket sum 278 against a `totalUsagePatterns` of 284 (a mismatch equal to the aliased count).

Instead, `imports.named` stays at its full length, and `imports.named.aliased` is reported as an informational duplicate of the same subset. Verified against real fixture output:
- `Total usage patterns: 284` now equals `Total: 284 patterns detected` (previously 220, then 278 with the literal subtraction).
- `totalImports` (80) still equals `imports.default + imports.named + imports.namespace` (39+37+4), unaffected either way since that formula never included aliased imports.

## Test plan
- [x] `pnpm run format:ci`
- [x] `pnpm run lint:ci`
- [x] `pnpm run typecheck`
- [x] `pnpm run test:ci` — 692 passed, including 2 new tests asserting both partition invariants (one with an aliased import present)
- [x] `pnpm run build:ci`
- [x] `pnpm run test:output` — 5 of 26 cases changed, all attributable to the `patternCounts` rename/new bucket, nothing unrelated
- [x] `grep -rn "'imports.aliased'" src/` → no matches
- [x] Changeset added (minor — `imports.aliased` consumers need to switch keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)