### PR TITLE
refactor(json): make printJson satisfy HermexScanResult

### DIFF
--- a/src/utils/print-json.ts
+++ b/src/utils/print-json.ts
@@ -1,6 +1,7 @@
 import type { AggregatedReport } from './aggregator';
 import type { ComplianceResult } from './compliance';
 import type { OutputConfig } from '../config/types';
+import type { HermexScanResult } from '../index';
 import { computeCompliance } from './compliance';
 import { sortViolationsBySeverity } from './severity-format';
 import { getVersion } from './version';
@@ -85,6 +86,6 @@ export function printJson(
         warningRuleViolations: compliance.warningRuleViolations.length,
       },
     },
-  };
+  } satisfies HermexScanResult;
   process.stdout.write(JSON.stringify(result, null, 2) + '\n');
 }


### PR DESCRIPTION
Implements [plan 033](https://github.com/Gallevy/hermex/pull/130/files) (`plans/033-tie-scanresult-to-emitter.md`, from #130 — not yet merged, so this PR can't link the file directly). Ref #115, #104.

## Summary
Ties `printJson`'s emitted object literal to the published `HermexScanResult` type with a `satisfies` clause (not a plain type annotation — `satisfies` still flags excess properties, which is one of the two drift directions this closes). Any future field added, renamed, or retyped on either side is now a `pnpm run typecheck` failure instead of a silent break.

The type and emitter already agreed — no mismatch to resolve, so the plan's Step 2 (fixing `src/index.ts` to match the emitter) was a no-op.

I temporarily added an undeclared `debugScratch` field to the emitter's literal and confirmed `pnpm run typecheck` failed on it with an excess-property error, then removed it — proving the guard actually catches drift rather than silently passing.

## Test plan
- [x] `pnpm run format:ci`
- [x] `pnpm run lint:ci`
- [x] `pnpm run typecheck`
- [x] `pnpm run test:ci` — 690 passed
- [x] `pnpm run build:ci` — no circular-import issue from the type-only `import type { HermexScanResult } from '../index'`
- [x] `pnpm run test:output` → 0 changed, 0 unexpected (26/26 match main) — confirms zero runtime output change
- [x] `grep -n "satisfies HermexScanResult" src/utils/print-json.ts` → 1 match
- [x] `grep -n "debugScratch" src/` → no matches
- [x] Step 3 (temporary field / typecheck failure) actually performed, as above
- [x] No changeset — no user-facing change

🤖 Generated with [Claude Code](https://claude.com/claude-code)