### PR TITLE
fix(compliance): use sentence case for compliance verdict text

### DIFF
--- a/scripts/output-review.ts
+++ b/scripts/output-review.ts
@@ -941,8 +941,8 @@ export const INVARIANTS: Invariant[] = [
         }
 
         const text = payloadOf(result);
-        const saysNotCompliant = text.includes('NOT COMPLIANT');
-        const saysCompliant = text.includes('COMPLIANT') && !saysNotCompliant;
+        const saysNotCompliant = text.includes('Not compliant');
+        const saysCompliant = text.includes('Compliant') && !saysNotCompliant;
         if (exit === 0 && !saysCompliant) {
           breaches.push(
             `${result.fixture.name}: exited 0 without printing a compliant verdict`,

--- a/src/utils/print-compliance.ts
+++ b/src/utils/print-compliance.ts
@@ -13,12 +13,12 @@ export function printComplianceVerdict(result: ComplianceResult): void {
 
   if (result.compliant) {
     console.log(
-      chalk.greenBright.bold(`\n${severityIcon('success')} COMPLIANT\n`),
+      chalk.greenBright.bold(`\n${severityIcon('success')} Compliant\n`),
     );
     return;
   }
 
-  console.log(chalk.redBright.bold(`\n${severityIcon('error')} NOT COMPLIANT`));
+  console.log(chalk.redBright.bold(`\n${severityIcon('error')} Not compliant`));
   console.log(
     chalk.red(
       `  ${mandatoryCount} mandatory violation${mandatoryCount > 1 ? 's' : ''} found`,

--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -93,12 +93,12 @@ function buildPackagesSection(compliance: ComplianceResult): string {
 
 function buildVerdictSection(compliance: ComplianceResult): string {
   if (compliance.compliant) {
-    return `### ${severityIcon('success')} COMPLIANT\n`;
+    return `### ${severityIcon('success')} Compliant\n`;
   }
 
   const mandatoryCount = countMandatoryViolations(compliance);
 
-  return `### ${severityIcon('error')} NOT COMPLIANT\n\n${mandatoryCount} mandatory violation${mandatoryCount > 1 ? 's' : ''} found\n`;
+  return `### ${severityIcon('error')} Not compliant\n\n${mandatoryCount} mandatory violation${mandatoryCount > 1 ? 's' : ''} found\n`;
 }
 
 export const DEFAULT_SUMMARY_TITLE = 'Hermex Compliance Report';

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -240,7 +240,7 @@ describe('comply command', () => {
     );
     const result = run(['comply', '--config', configPath]);
     expect(result.status).toBe(1);
-    expect(result.stdout).toMatch(/NOT COMPLIANT/);
+    expect(result.stdout).toMatch(/Not compliant/);
   });
 
   it('exits 0 when there are no mandatory violations', () => {
@@ -252,7 +252,7 @@ describe('comply command', () => {
     );
     const result = run(['comply', '--config', configPath]);
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/COMPLIANT/);
+    expect(result.stdout).toMatch(/Compliant/);
   });
 
   it('exits 2 when no files match includes', () => {
@@ -366,19 +366,19 @@ describe('comply command', () => {
         summaryPath,
       ]);
       expect(result.status).toBe(1);
-      expect(result.stdout).toMatch(/NOT COMPLIANT/); // full report on stdout, unchanged
+      expect(result.stdout).toMatch(/Not compliant/); // full report on stdout, unchanged
       expect(existsSync(summaryPath)).toBe(true);
       const content = readFileSync(summaryPath, 'utf8');
       // oxlint-disable-next-line no-control-regex -- asserting the ANSI escape byte is absent
       expect(content).not.toMatch(/\x1b\[/);
-      expect(content).toMatch(/NOT COMPLIANT/);
+      expect(content).toMatch(/Not compliant/);
       expect(content).not.toMatch(/Versus/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
-  it('--summary-file writes a COMPLIANT summary when there are no mandatory violations', () => {
+  it('--summary-file writes a Compliant summary when there are no mandatory violations', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'hermex-summary-e2e-'));
     try {
       const summaryPath = join(tempDir, 'summary.md');
@@ -398,8 +398,8 @@ describe('comply command', () => {
       expect(result.status).toBe(0);
       expect(existsSync(summaryPath)).toBe(true);
       const content = readFileSync(summaryPath, 'utf8');
-      expect(content).toMatch(/COMPLIANT/);
-      expect(content).not.toMatch(/NOT COMPLIANT/);
+      expect(content).toMatch(/Compliant/);
+      expect(content).not.toMatch(/Not compliant/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -454,7 +454,7 @@ describe('comply command', () => {
       expect(() => JSON.parse(result.stdout)).not.toThrow();
       expect(existsSync(summaryPath)).toBe(true);
       const content = readFileSync(summaryPath, 'utf8');
-      expect(content).toMatch(/NOT COMPLIANT/);
+      expect(content).toMatch(/Not compliant/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/scripts/output-review-invariants.test.ts
+++ b/tests/scripts/output-review-invariants.test.ts
@@ -62,7 +62,7 @@ describe('ansi-purity', () => {
       caseResult(
         { name: 'coloured', keepAnsi: true, writes: ['summary.md'] },
         {
-          'summary.md': `${ESC}[31mNOT COMPLIANT${ESC}[39m`,
+          'summary.md': `${ESC}[31mNot compliant${ESC}[39m`,
         },
       ),
     ]);
@@ -77,7 +77,7 @@ describe('exit-code-agrees-with-verdict', () => {
         { name: 'comply-x', args: ['comply'] },
         {
           'exit-code.txt': '0\n',
-          'stdout.txt': '🔴 NOT COMPLIANT\n',
+          'stdout.txt': '🔴 Not compliant\n',
         },
       ),
     ]);
@@ -92,7 +92,7 @@ describe('exit-code-agrees-with-verdict', () => {
         { name: 'comply-x', args: ['comply'] },
         {
           'exit-code.txt': '1\n',
-          'stdout.txt': '🔴 NOT COMPLIANT\n',
+          'stdout.txt': '🔴 Not compliant\n',
         },
       ),
     ]);

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -1252,17 +1252,17 @@ describe('printComplianceVerdict', () => {
     expect(output).not.toContain('violations found');
   });
 
-  it('prints COMPLIANT when there are no mandatory violations', () => {
+  it('prints Compliant when there are no mandatory violations', () => {
     const compliance = computeCompliance(makeAggregated());
     expect(() => printComplianceVerdict(compliance)).not.toThrow();
     const output = consoleSpy.mock.calls
       .map((call) => call.join(' '))
       .join('\n');
-    expect(output).toContain('COMPLIANT');
-    expect(output).not.toContain('NOT COMPLIANT');
+    expect(output).toContain('Compliant');
+    expect(output).not.toContain('Not compliant');
   });
 
-  it('prints NOT COMPLIANT with a count when mandatory violations are present, without repeating per-violation detail', () => {
+  it('prints Not compliant with a count when mandatory violations are present, without repeating per-violation detail', () => {
     const errorViolation: RuleViolation = {
       ruleId: 'require-files',
       severity: 'error',
@@ -1295,7 +1295,7 @@ describe('printComplianceVerdict', () => {
     const output = consoleSpy.mock.calls
       .map((call) => call.join(' '))
       .join('\n');
-    expect(output).toContain('NOT COMPLIANT');
+    expect(output).toContain('Not compliant');
     expect(output).toContain('2 mandatory violations');
     // per-violation detail belongs to the Rules/Packages sections above
     // the verdict, not the verdict itself — see printPackages tests for the

--- a/tests/utils/write-summary-file.test.ts
+++ b/tests/utils/write-summary-file.test.ts
@@ -175,7 +175,7 @@ describe('writeSummaryFile', () => {
       );
       expect(content).not.toContain('### Rules');
       expect(content).not.toContain('no-files');
-      expect(content).toContain('### 🟢 COMPLIANT');
+      expect(content).toContain('### 🟢 Compliant');
     });
 
     // The row wording is unchanged from when banned packages had their own
@@ -250,7 +250,7 @@ describe('writeSummaryFile', () => {
       );
       expect(content).not.toContain('### Rules');
       expect(content).not.toContain('some-pkg');
-      expect(content).toContain('### 🟢 COMPLIANT');
+      expect(content).toContain('### 🟢 Compliant');
     });
   });
 
@@ -498,8 +498,8 @@ describe('writeSummaryFile', () => {
       expect(content).not.toContain('### Packages');
       expect(content).not.toContain('Notes:');
       expect(content).not.toContain('multi-version-lib');
-      expect(content).toContain('### 🟢 COMPLIANT');
-      expect(content).not.toContain('NOT COMPLIANT');
+      expect(content).toContain('### 🟢 Compliant');
+      expect(content).not.toContain('Not compliant');
     });
 
     // (#59) A package can be a MANDATORY failure (root itself is overdue)
@@ -537,7 +537,7 @@ describe('writeSummaryFile', () => {
       expect(content).not.toContain('Notes:');
       expect(content).not.toContain('bundle impact');
       expect(content).not.toContain('nested copy');
-      expect(content).toContain('NOT COMPLIANT');
+      expect(content).toContain('Not compliant');
     });
   });
 
@@ -566,10 +566,10 @@ describe('writeSummaryFile', () => {
     expect(content).not.toContain('ui-kits');
   });
 
-  it('writes a COMPLIANT verdict when there are no violations', () => {
+  it('writes a Compliant verdict when there are no violations', () => {
     const content = write(makeAggregated());
-    expect(content).toContain('COMPLIANT');
-    expect(content).not.toContain('NOT COMPLIANT');
+    expect(content).toContain('Compliant');
+    expect(content).not.toContain('Not compliant');
   });
 
   // A fully clean report shouldn't carry "Rules"/"Packages" boilerplate for
@@ -578,10 +578,10 @@ describe('writeSummaryFile', () => {
     const content = write(makeAggregated());
     expect(content).not.toContain('### Rules');
     expect(content).not.toContain('### Packages');
-    expect(content).toBe(`# ${DEFAULT_SUMMARY_TITLE}\n\n### 🟢 COMPLIANT\n`);
+    expect(content).toBe(`# ${DEFAULT_SUMMARY_TITLE}\n\n### 🟢 Compliant\n`);
   });
 
-  it('writes a NOT COMPLIANT verdict with the mandatory violation count when violations exist', () => {
+  it('writes a Not compliant verdict with the mandatory violation count when violations exist', () => {
     const violation: RuleViolation = {
       ruleId: 'require-files',
       severity: 'error',
@@ -589,7 +589,7 @@ describe('writeSummaryFile', () => {
       matchedFiles: [],
     };
     const content = write(makeAggregated({ ruleViolations: [violation] }));
-    expect(content).toContain('NOT COMPLIANT');
+    expect(content).toContain('Not compliant');
     expect(content).toContain('1 mandatory violation found');
   });
 


### PR DESCRIPTION
## Summary
- Changes the compliance verdict output from ALL CAPS (`COMPLIANT` / `NOT COMPLIANT`) to sentence case (`Compliant` / `Not compliant`), which felt overly aggressive.
- Updates the three places this text is produced: stdout ([print-compliance.ts](src/utils/print-compliance.ts)), the `--summary-file` markdown output ([write-summary-file.ts](src/utils/write-summary-file.ts)), and the exit-code/verdict invariant check in the output-review script ([output-review.ts](scripts/output-review.ts)).
- Updates the corresponding tests to match.

Note: the machine-readable `compliance.status` JSON field (`'compliant'` / `'non-compliant'`) is untouched — this only affects human-facing display text.

## Test plan
- [x] `pnpm run test:ci` — all 692 tests pass
- [x] `pnpm run lint:ci` — clean
- [x] `pnpm run format:ci` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)