### PR TITLE
feat(plugins): run another tool as part of a hermex run

### DIFF
--- a/.changeset/cute-eyes-hammer.md
+++ b/.changeset/cute-eyes-hammer.md
@@ -1,0 +1,6 @@
+---
+"hermex": minor
+---
+
+Add the plugin API: run another tool as part of a hermex run and fold its findings into one verdict. A plugin is a plain object with a canonical name and a hooks envelope; the single hook, onRunComplete, runs after the inventory and hermex's own rules and before rendering, and contributes namespaced violations through ctx.violations.add. Granularity and severity belong to the plugin, which configures itself, so hermex.config.ts never becomes a second place to configure the wrapped tool. A plugin that throws aborts the run with exit 2 rather than degrading silently. Includes an oxlint recipe in docs/plugins.md.
+  

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ are no CLI flags for scan behavior; `scan`/`comply` only take `--config`,
 - **Version Tracking**: Components reported with exact package versions from lockfiles
 - **Multi-Lockfile Support**: Parses package-lock.json, yarn.lock, and pnpm-lock.yaml
 - **Flexible Output**: Table and chart visualization formats
+- **Plugins**: Fold another tool's findings — a linter, a size budget — into one verdict.
+  hermex orchestrates, it never reimplements. See [Plugins](./docs/plugins.md)
 - **Zero Configuration**: Works out of the box with sensible defaults
 
 ## Installation
@@ -169,6 +171,7 @@ Total: 272 patterns detected
 
 - **[Examples](./docs/examples.md)** - Comprehensive examples and command usage
 - **[Patterns Guide](./docs/patterns.md)** - All detectable React usage patterns
+- **[Plugins](./docs/plugins.md)** - Run another tool as part of a hermex run, including an oxlint recipe
 
 ## Tech Stack
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,227 @@
+# hermex — Plugins
+
+**hermex does not reinvent.** If another tool already does something better, it becomes a
+plugin rather than a hermex rule. Linting is the type case: hermex orchestrates a linter
+and folds its findings into one verdict — it never grows into one.
+
+A plugin is a **plain object**. There is no factory to call, no package to install, and no
+registration step.
+
+```ts
+export default {
+  plugins: [
+    {
+      name: 'my-tool',
+      hooks: {
+        onRunComplete(ctx) {
+          ctx.violations.add({
+            ruleId: 'something-wrong',
+            severity: 'warn',
+            message: 'a human-readable description',
+          });
+        },
+      },
+    },
+  ],
+};
+```
+
+That contributes `my-tool/something-wrong` to the rules table, the JSON output, and the
+compliance verdict.
+
+---
+
+## The hook
+
+`onRunComplete` runs **once**, after hermex has finished its own analysis and evaluated its
+own rules, and **before anything is rendered**. So a plugin sees the complete picture, and
+what it contributes still reaches the verdict and the exit code.
+
+It is the only hook today. `hooks` is an object so that more can be added later without
+changing anything you have already written — but note that hermex **rejects an unknown hook
+name** rather than ignoring it. A plugin built against a newer hermex fails loudly instead
+of half-running:
+
+```
+Unknown hook `onFileParsed`. This version of hermex supports: onRunComplete.
+```
+
+Plugins run **sequentially, in array order**. There is no `enforce: pre | post` and no
+dependency graph: with a single hook there is nothing for one plugin to wait on, so order
+only affects how the output reads.
+
+## The context
+
+```ts
+interface PluginContext {
+  cwd: string;
+  config: ResolvedHermexConfig;     // read-only, after overrides are applied
+  files: readonly string[];         // in-scope files, post-exclude
+  inventory: PluginInventoryView;   // summary, packages, components, versus, violations
+
+  violations: { add(v): void };
+  meta: { set(key, value): void; get(key): unknown };
+  logger: { info(msg): void; warn(msg): void };
+}
+```
+
+`inventory.violations` holds everything found so far — hermex's own rule violations plus
+anything earlier plugins contributed. That is what a **reporter** plugin reads: one that
+ships findings to SARIF, Slack or a dashboard and adds nothing itself.
+
+`meta` is a scratch channel shared across plugins for a single run, so one plugin can hand
+structured data to a later one without a global. It is not yet part of the JSON output.
+
+There are deliberately **no host capabilities** — no `resolve()`, no `emitFile()`. With one
+terminal hook there is no pipeline left to re-enter.
+
+## What a plugin contributes
+
+```ts
+ctx.violations.add({
+  ruleId: 'no-unused-vars',              // namespaced to `<plugin>/no-unused-vars`
+  severity: 'error' | 'warn' | 'info',
+  message: 'x is never read',
+  files: ['src/a.tsx'],                  // optional
+  location: { file: 'src/a.tsx', line: 12, column: 3 },  // optional
+});
+```
+
+**Granularity is yours.** One aggregated row or three thousand line-level ones are both
+valid — you know the tool you are wrapping and hermex does not.
+
+**Severity is yours too.** hermex has no lever over it: there is no
+`rules: { 'my-tool/x': 'off' }`, and `overrides` does not reach plugin findings. That is
+deliberate — `hermex.config.ts` must not become a second, drifting place to configure
+another tool. Tune the tool in **its own config**, and expose whatever knobs your plugin
+needs in your plugin's own idiom:
+
+```ts
+const myTool = ({ severity = 'warn' } = {}) => ({ name: 'my-tool', hooks: { /* … */ } });
+```
+
+An `error` fails `hermex comply` through the ordinary verdict path — there is no separate
+pass/fail channel, so a red build always has a row in the table explaining it.
+
+## Failure
+
+**If a hook throws, the run aborts with exit code 2.** It reports neither pass nor fail: a
+governance tool that stays green because its lint plugin silently did not run is worse than
+one that stops and says so. Handle errors you consider acceptable inside your own hook.
+
+## Trust
+
+hermex does **not** sandbox plugins. It cannot meaningfully do so — `hermex.config.ts` is
+already executed as arbitrary TypeScript, so a plugin is not a new trust boundary. hermex's
+obligation is visibility instead: every run names the plugins that executed.
+
+```
+✔ Ran 1 plugin(s): oxlint — 47 finding(s)
+```
+
+Treat a plugin like any other dependency you let run in your repo.
+
+---
+
+## Recipe: oxlint
+
+There is no `hermex-plugin-oxlint` package to install, on purpose. The plugin is short
+enough to own, and owning it means no version to keep in step with hermex.
+
+```ts
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { HermexConfigInput } from 'hermex';
+
+const exec = promisify(execFile);
+
+const oxlintPlugin = ({ severity = 'warn' as const } = {}) => ({
+  name: 'oxlint',
+  hooks: {
+    async onRunComplete(ctx) {
+      let stdout = '';
+      try {
+        ({ stdout } = await exec('oxlint', ['--format', 'json', ...ctx.files], {
+          cwd: ctx.cwd,
+          // node_modules/.bin is not on PATH outside npm scripts.
+          env: { ...process.env, PATH: `${ctx.cwd}/node_modules/.bin:${process.env.PATH}` },
+          // On Windows those are .cmd shims, which execFile cannot spawn directly.
+          shell: process.platform === 'win32',
+          maxBuffer: 64 * 1024 * 1024,
+        }));
+      } catch (err: any) {
+        // oxlint exits non-zero *when it finds problems* — stdout is still valid.
+        // Only a genuine failure (missing binary, bad flag) has no stdout.
+        if (!err?.stdout) throw err;
+        stdout = err.stdout;
+      }
+
+      for (const d of JSON.parse(stdout).diagnostics ?? []) {
+        ctx.violations.add({
+          ruleId: d.code ?? 'unknown',
+          severity,
+          message: d.message,
+          location: { file: d.filename, line: d.labels?.[0]?.line },
+        });
+      }
+    },
+  },
+});
+
+export default {
+  plugins: [oxlintPlugin({ severity: 'warn' })],
+} satisfies HermexConfigInput;
+```
+
+Start at `severity: 'warn'` so the first run shows you everything without failing the
+build, and tighten to `'error'` once the backlog is clear.
+
+Three things that bite, all of them oxlint's shape rather than hermex's:
+
+1. **oxlint exits non-zero when it finds problems.** `execFile` treats that as a throw, so
+   read `stdout` off the error.
+2. **`node_modules/.bin` is not on `PATH`** outside npm scripts — prepend it.
+3. **On Windows those are `.cmd` shims**, which `execFile` cannot spawn without `shell`.
+
+### The no-install variant
+
+If your CI job runs `npx hermex comply` without `pnpm install`, nothing is available to
+spawn. Have a prior CI step write the report and let the plugin ingest it — this needs no
+`node_modules` at all:
+
+```yaml
+- run: pnpm oxlint --format json > oxlint.json || true
+- run: npx hermex comply
+```
+
+```ts
+import { readFileSync, existsSync } from 'node:fs';
+
+const oxlintReport = ({ path = 'oxlint.json', severity = 'warn' as const } = {}) => ({
+  name: 'oxlint',
+  hooks: {
+    onRunComplete(ctx) {
+      if (!existsSync(path)) throw new Error(`${path} not found — did the lint step run?`);
+      for (const d of JSON.parse(readFileSync(path, 'utf8')).diagnostics ?? []) {
+        ctx.violations.add({ ruleId: d.code ?? 'unknown', severity, message: d.message });
+      }
+    },
+  },
+});
+```
+
+## Keeping your config npx-safe
+
+`npx hermex` works in a repo with **no `node_modules`** — but only if your config imports
+nothing that has to be resolved from `node_modules`. Node resolves bare specifiers relative
+to the importing file, and `npx`'s temp directory is not on that path.
+
+| in `hermex.config.ts` | resolves without `node_modules`? |
+| --- | --- |
+| `import type { … } from 'hermex'` | ✅ erased before it runs |
+| `import { execFile } from 'node:child_process'` | ✅ builtin |
+| `import { anything } from 'some-package'` | ❌ `ERR_MODULE_NOT_FOUND` |
+
+So: **declare plugins inline**, use `import type` and `node:` builtins only, and prefer
+`satisfies HermexConfigInput` over a runtime `defineConfig` import. Then the same config
+works whether or not anything is installed.

--- a/src/commands/pipeline.ts
+++ b/src/commands/pipeline.ts
@@ -12,6 +12,7 @@ import { evaluateRules } from '../rules/evaluator';
 import { collectDeclaredPackages } from '../rules/shared';
 import { enrichWithReleaseAge } from '../npm-registry/enricher';
 import { applyOverrides } from '../config/overrides';
+import { runPlugins } from '../plugins';
 import type { HermexConfig } from '../config/types';
 
 const DECLARATION_FILE_RE = /\.d\.(ts|mts|cts)$/;
@@ -122,6 +123,43 @@ export async function runPipeline(
     spinner.succeed(
       chalk.blue(
         `Release age fetched${skipped > 0 ? chalk.gray(` (${skipped} packages skipped — registry unreachable or not found)`) : ''}`,
+      ),
+    );
+  }
+
+  // Plugins run last, once everything hermex computes itself is finished, so
+  // a plugin sees the complete picture — and still before rendering, so what
+  // it contributes reaches the rules table and the verdict (#102).
+  //
+  // The whole block is inert when no plugins are configured, which is the
+  // default: an unconfigured run prints exactly what it printed before.
+  if (resolvedConfig.plugins.length > 0) {
+    if (spinner.isEnabled) spinner.start('Running plugins...');
+
+    const pluginViolations = await runPlugins({
+      plugins: resolvedConfig.plugins,
+      aggregated,
+      config: resolvedConfig,
+      cwd: process.cwd(),
+      files,
+      quiet: isJson,
+    });
+
+    aggregated.ruleViolations = [
+      ...aggregated.ruleViolations,
+      ...pluginViolations,
+    ];
+
+    // Attribution: third-party code just executed in the user's repo, so
+    // name it. hermex does not sandbox plugins — the config that imports
+    // them already runs as arbitrary code — which makes visibility the
+    // obligation instead (#102).
+    spinner.succeed(
+      chalk.blue(
+        `Ran ${resolvedConfig.plugins.length} plugin(s): ${resolvedConfig.plugins.map((p) => p.name).join(', ')}` +
+          (pluginViolations.length > 0
+            ? chalk.gray(` — ${pluginViolations.length} finding(s)`)
+            : ''),
       ),
     );
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { KNOWN_HOOKS } from '../plugins/types';
+import type { HermexPlugin } from '../plugins/types';
 
 // ── Sub-schemas ────────────────────────────────────────────────────────────────
 
@@ -80,6 +82,86 @@ const OverrideSchema = z
   })
   .strict();
 
+// ── Plugins ────────────────────────────────────────────────────────────────────
+
+// A plugin holds functions, so it can't be described structurally the way
+// every other branch of this schema is — `z.custom` carries the type and the
+// refinement below does the checking by hand. Note this makes a config that
+// declares plugins non-JSON-serializable, which is inherent: hooks are code.
+const PluginSchema = z.custom<HermexPlugin>().superRefine((value, ctx) => {
+  const fail = (message: string, path: (string | number)[] = []) =>
+    ctx.addIssue({ code: 'custom', message, path });
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail('Plugin must be an object with `name` and `hooks`.');
+    return;
+  }
+
+  const plugin = value as Partial<HermexPlugin>;
+
+  if (typeof plugin.name !== 'string' || plugin.name.trim() === '') {
+    fail('Plugin `name` must be a non-empty string.', ['name']);
+  }
+
+  if (
+    typeof plugin.hooks !== 'object' ||
+    plugin.hooks === null ||
+    Array.isArray(plugin.hooks)
+  ) {
+    fail('Plugin `hooks` must be an object.', ['hooks']);
+    return;
+  }
+
+  const hooks = plugin.hooks as Record<string, unknown>;
+  const declared = Object.keys(hooks);
+
+  for (const key of declared) {
+    // Rejected rather than ignored on purpose: a plugin built against a
+    // newer hermex must fail loudly, not half-run. A hook that silently
+    // never fires is the failure mode this check exists to prevent.
+    if (!(KNOWN_HOOKS as readonly string[]).includes(key)) {
+      fail(
+        `Unknown hook \`${key}\`. This version of hermex supports: ${KNOWN_HOOKS.join(', ')}. ` +
+          `If the plugin targets a newer hermex, upgrade rather than removing the hook.`,
+        ['hooks', key],
+      );
+      continue;
+    }
+    if (typeof hooks[key] !== 'function') {
+      fail(`Hook \`${key}\` must be a function.`, ['hooks', key]);
+    }
+  }
+
+  if (declared.length === 0) {
+    fail(
+      `Plugin "${plugin.name ?? '<unnamed>'}" declares no hooks, so it can never run. ` +
+        `Implement one of: ${KNOWN_HOOKS.join(', ')}.`,
+      ['hooks'],
+    );
+  }
+});
+
+// Identity is the plugin's own `name` — never a namespace the config author
+// assigns. ESLint handed naming to the config layer and had to retrofit
+// `meta.namespace` to recover identity; de-duplicating by declared name here
+// avoids that, and makes a duplicate a config error rather than two
+// silently-merged sources of the same finding.
+const PluginsSchema = z.array(PluginSchema).superRefine((plugins, ctx) => {
+  const seen = new Set<string>();
+  plugins.forEach((plugin, index) => {
+    const name = (plugin as Partial<HermexPlugin>)?.name;
+    if (typeof name !== 'string') return;
+    if (seen.has(name)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Duplicate plugin name "${name}". Plugin names must be unique — hermex de-duplicates by name, not by object identity.`,
+        path: [index, 'name'],
+      });
+    }
+    seen.add(name);
+  });
+});
+
 // ── Main schema with defaults ──────────────────────────────────────────────────
 
 export const HermexConfigSchema = z
@@ -116,6 +198,19 @@ export const HermexConfigSchema = z
      * specific repos.
      */
     overrides: z.array(OverrideSchema).default([]),
+
+    /**
+     * Plugins run other tools and fold their findings into this run — hermex
+     * orchestrates, it never reimplements (#102). Each is a plain object with
+     * a canonical `name` and a `hooks` envelope; declare them inline to keep
+     * the config importable under `npx` with no `node_modules`, since only
+     * `node:` builtins and `import type` resolve there.
+     *
+     * hermex owns the channel and nothing else: granularity and severity are
+     * the plugin's, configured in the plugin's own idiom, so `rules` below
+     * stays exclusively hermex's own.
+     */
+    plugins: PluginsSchema.default([]),
 
     rules: z
       .object({
@@ -229,5 +324,6 @@ export type VersusConfig = HermexConfig['versus'][number];
 export type RulesConfig = HermexConfig['rules'];
 export type OverrideConfig = HermexConfig['overrides'][number];
 export type OutputConfig = HermexConfig['output'];
+export type PluginsConfig = HermexConfig['plugins'];
 export type ReleaseAgeConfig = HermexConfig['releaseAge'];
 export type ReleaseAgeThresholds = HermexConfig['releaseAge']['thresholds'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,23 @@ export function defineConfig(config: HermexConfigInput): HermexConfigInput {
   return config;
 }
 
+/**
+ * The plugin surface (#102). A plugin is inert data — a plain object with a
+ * canonical `name` and a `hooks` envelope — so it can be declared inline in
+ * `hermex.config.ts` with no import at all, which is what keeps a config
+ * loadable under `npx` in a repo that has not installed anything: only
+ * `node:` builtins and `import type` resolve there.
+ */
+export type {
+  HermexPlugin,
+  HermexPluginHooks,
+  PluginContext,
+  PluginInventoryView,
+  PluginViolation,
+  PluginViolationInput,
+  PluginViolationLocation,
+} from './plugins/types';
+
 export type { PatternCount } from './utils/pattern-counter';
 export type {
   ComponentUsage,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,13 @@
+export type {
+  HermexPlugin,
+  HermexPluginHooks,
+  KnownHook,
+  PluginContext,
+  PluginInventoryView,
+  PluginViolation,
+  PluginViolationInput,
+  PluginViolationLocation,
+} from './types';
+export { KNOWN_HOOKS } from './types';
+export { runPlugins, PluginError } from './runner';
+export type { RunPluginsOptions } from './runner';

--- a/src/plugins/runner.ts
+++ b/src/plugins/runner.ts
@@ -1,0 +1,139 @@
+import chalk from 'chalk';
+import type { ResolvedHermexConfig } from '../config/overrides';
+import type { AggregatedReport } from '../utils/aggregator';
+import type {
+  HermexPlugin,
+  PluginContext,
+  PluginInventoryView,
+  PluginViolation,
+  PluginViolationInput,
+} from './types';
+
+/**
+ * Thrown when a plugin's hook rejects or throws. Carries the plugin name so
+ * the failure is attributable — "oxlint failed" rather than an anonymous
+ * stack out of the middle of the pipeline.
+ *
+ * A plugin failure aborts the run: a governance tool whose lint plugin
+ * quietly did not run while CI stayed green is the worst available failure
+ * mode, so hermex reports neither pass nor fail (#102).
+ */
+export class PluginError extends Error {
+  constructor(
+    readonly pluginName: string,
+    readonly cause: unknown,
+  ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Plugin "${pluginName}" failed: ${detail}`);
+    this.name = 'PluginError';
+  }
+}
+
+/**
+ * Namespaces a plugin's rule id under its canonical name, unless the plugin
+ * already did. Both `no-unused-vars` and `oxlint/no-unused-vars` coming from
+ * the `oxlint` plugin land on `oxlint/no-unused-vars`, so attribution can't
+ * be lost or doubled by an inattentive plugin author.
+ */
+function namespaceRuleId(pluginName: string, ruleId: string): string {
+  const prefix = `${pluginName}/`;
+  return ruleId.startsWith(prefix) ? ruleId : `${prefix}${ruleId}`;
+}
+
+function buildInventoryView(
+  aggregated: AggregatedReport,
+  violations: readonly PluginViolation[],
+): PluginInventoryView {
+  return {
+    summary: {
+      filesAnalyzed: aggregated.filesAnalyzed,
+      totalImports: aggregated.totalImports,
+      totalComponents: aggregated.totalComponents,
+      totalUsagePatterns: aggregated.totalUsagePatterns,
+    },
+    packages: aggregated.packageDistribution,
+    components: aggregated.topComponents,
+    versus: aggregated.versusResults,
+    // hermex's own findings plus whatever earlier plugins contributed — the
+    // view is rebuilt per plugin so a reporter running last sees everything.
+    violations: [...aggregated.ruleViolations, ...violations],
+  };
+}
+
+export interface RunPluginsOptions {
+  plugins: readonly HermexPlugin[];
+  aggregated: AggregatedReport;
+  config: ResolvedHermexConfig;
+  cwd: string;
+  files: readonly string[];
+  /** Suppressed under `--format json`, where stdout is the payload. */
+  quiet?: boolean;
+}
+
+/**
+ * Runs every plugin's `onRunComplete` in array order, sequentially, and
+ * returns what they contributed.
+ *
+ * Sequential rather than parallel because `scripts/output-review.ts` diffs
+ * printed output — nondeterministic violation ordering would make every run
+ * a false diff. Parallelism is a valid later optimization, but only one that
+ * preserves result order.
+ *
+ * There is no ordering primitive beyond array order (no `enforce: pre|post`,
+ * no dependency graph): with a single terminal hook there is no data
+ * dependency between plugins, so order only affects how output reads (#102).
+ */
+export async function runPlugins({
+  plugins,
+  aggregated,
+  config,
+  cwd,
+  files,
+  quiet = false,
+}: RunPluginsOptions): Promise<PluginViolation[]> {
+  const collected: PluginViolation[] = [];
+  if (plugins.length === 0) return collected;
+
+  const meta = new Map<string, unknown>();
+
+  for (const plugin of plugins) {
+    const hook = plugin.hooks.onRunComplete;
+    if (!hook) continue;
+
+    const ctx: PluginContext = {
+      cwd,
+      config,
+      files,
+      inventory: buildInventoryView(aggregated, collected),
+      violations: {
+        add(violation: PluginViolationInput) {
+          collected.push({
+            ...violation,
+            ruleId: namespaceRuleId(plugin.name, violation.ruleId),
+            plugin: plugin.name,
+          });
+        },
+      },
+      meta: {
+        set: (key, value) => void meta.set(key, value),
+        get: (key) => meta.get(key),
+      },
+      logger: {
+        info: (message) => {
+          if (!quiet) console.log(chalk.gray(`[${plugin.name}] ${message}`));
+        },
+        warn: (message) => {
+          if (!quiet) console.warn(chalk.yellow(`[${plugin.name}] ${message}`));
+        },
+      },
+    };
+
+    try {
+      await hook(ctx);
+    } catch (error: unknown) {
+      throw new PluginError(plugin.name, error);
+    }
+  }
+
+  return collected;
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,151 @@
+// The plugin surface. See #102 for the decisions these types encode.
+//
+// Every import here is type-only on purpose: `hermex.config.ts` declares
+// plugins inline as plain objects, so nothing in this module may pull runtime
+// code into the config-loading path. It also keeps the deliberate type cycle
+// with `rules/shared` (RuleViolation includes PluginViolation, and
+// PluginInventoryView exposes RuleViolation) erased at runtime.
+
+import type { ResolvedHermexConfig } from '../config/overrides';
+import type { RuleViolation } from '../rules/shared';
+import type {
+  PackageDistribution,
+  ComponentUsage,
+} from '../utils/package-distribution';
+import type { VersusResult } from '../utils/versus';
+
+/**
+ * Every hook hermex knows about. Adding one is additive — a plugin written
+ * against an older hermex keeps working, and `plugins` in the config schema
+ * rejects any key that is *not* in here rather than ignoring it, so a plugin
+ * written against a *newer* hermex fails loudly instead of half-running.
+ * Silent no-ops are the failure mode this list exists to prevent.
+ */
+export const KNOWN_HOOKS = ['onRunComplete'] as const;
+
+export type KnownHook = (typeof KNOWN_HOOKS)[number];
+
+export interface HermexPluginHooks {
+  /**
+   * The only hook in 3.0. Runs once after the inventory and hermex's own
+   * rules are complete, and before anything is rendered — so a plugin sees
+   * the finished picture and whatever it contributes still reaches the
+   * verdict.
+   */
+  onRunComplete?(ctx: PluginContext): void | Promise<void>;
+}
+
+/**
+ * A plugin is inert data — a plain object, declarable inline in
+ * `hermex.config.ts`, with no factory call and no load-time side effects.
+ * The `hooks` envelope is what lets the API grow without a breaking change.
+ */
+export interface HermexPlugin {
+  /**
+   * Canonical identity, declared by the plugin and never by the config
+   * author. hermex de-duplicates by this name and namespaces the plugin's
+   * violations under it. Two plugins sharing a name is a config error.
+   */
+  readonly name: string;
+  readonly hooks: HermexPluginHooks;
+}
+
+/** Where a finding sits in the source, when the wrapped tool reports it. */
+export interface PluginViolationLocation {
+  file: string;
+  line?: number;
+  column?: number;
+}
+
+/**
+ * A finding contributed by a plugin. Structurally uniform — unlike hermex's
+ * own violations, which carry rule-specific fields — because hermex does not
+ * model the wrapped tool's domain.
+ *
+ * `plugin` is the discriminant that separates these from hermex's own
+ * violations in the `RuleViolation` union; narrow with `'plugin' in v`.
+ */
+export interface PluginViolation {
+  /**
+   * Namespaced `${plugin.name}/${foreignRuleId}`. hermex does not parse or
+   * validate the second half — it is the wrapped tool's id space, and
+   * `hermex.config.ts` deliberately cannot address it (#102).
+   */
+  ruleId: string;
+  severity: 'error' | 'warn' | 'info';
+  message: string;
+  /** Canonical name of the contributing plugin. Set by hermex, not the plugin. */
+  plugin: string;
+  files?: string[];
+  location?: PluginViolationLocation;
+}
+
+/** What a plugin may report. `plugin` is stamped on by hermex. */
+export type PluginViolationInput = Omit<PluginViolation, 'plugin'>;
+
+/**
+ * The read-only view of the run handed to a plugin.
+ *
+ * Deliberately *not* `AggregatedReport`. Keeping the pipeline's internal
+ * state out of the plugin surface is what leaves the public API and the JSON
+ * contract free to change (#104, #115) — it was the main reason
+ * plugin-as-pipeline-stage was rejected.
+ */
+export interface PluginInventoryView {
+  readonly summary: {
+    readonly filesAnalyzed: number;
+    readonly totalImports: number;
+    readonly totalComponents: number;
+    readonly totalUsagePatterns: number;
+  };
+  readonly packages: readonly PackageDistribution[];
+  readonly components: readonly ComponentUsage[];
+  readonly versus: readonly VersusResult[];
+  /**
+   * Everything found so far — hermex's own violations plus anything earlier
+   * plugins contributed. This is what a reporter plugin (SARIF, Slack, a
+   * dashboard) reads.
+   */
+  readonly violations: readonly RuleViolation[];
+}
+
+/**
+ * Read-only data plus write channels. There are no host capabilities here —
+ * no `resolve()`, no `emitFile()` — a deliberate divergence from the Rollup
+ * prior art, whose capability argument assumed plugins re-enter the host
+ * pipeline. With one terminal hook there is nothing to re-enter (#102).
+ */
+export interface PluginContext {
+  readonly cwd: string;
+  readonly config: ResolvedHermexConfig;
+  /** In-scope files, post-exclude and post-`.d.ts` filtering. */
+  readonly files: readonly string[];
+  readonly inventory: PluginInventoryView;
+
+  readonly violations: {
+    /**
+     * Contribute a finding. Granularity is the plugin's decision: one
+     * aggregated row or three thousand line-level ones are both valid —
+     * the plugin author knows the wrapped tool and hermex does not (#102).
+     *
+     * An `error` severity fails the run through the ordinary compliance
+     * path; there is no separate verdict channel.
+     */
+    add(violation: PluginViolationInput): void;
+  };
+
+  /**
+   * A scratch channel shared across plugins for one run, so a plugin can
+   * pass structured data to a later one without a global. Not yet surfaced
+   * in the JSON output — that is #115.
+   */
+  readonly meta: {
+    set(key: string, value: unknown): void;
+    get(key: string): unknown;
+  };
+
+  readonly logger: {
+    info(message: string): void;
+    warn(message: string): void;
+  };
+}

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -5,6 +5,10 @@ import type {
   DeclaredPackages,
   DependencyBucket,
 } from '../utils/package-inventory';
+// Type-only: `RuleViolation` includes `PluginViolation` while
+// `PluginInventoryView` exposes `RuleViolation`. The cycle is legal for
+// types and erased at runtime.
+import type { PluginViolation } from '../plugins/types';
 
 interface BaseViolation<T extends string> {
   ruleId: T;
@@ -46,7 +50,11 @@ export interface RequireEngineVersionViolation extends BaseViolation<'require-en
   requiredRange?: string;
 }
 
-export type RuleViolation =
+/**
+ * hermex's own violations — the nine rules it implements itself. Each has a
+ * literal `ruleId` and may carry rule-specific fields.
+ */
+export type CoreRuleViolation =
   | NoFilesViolation
   | RequireFilesViolation
   | RequirePackagesViolation
@@ -56,6 +64,22 @@ export type RuleViolation =
   | NoPackageFieldsViolation
   | RequireEngineVersionViolation
   | RequireCodeownersViolation;
+
+/**
+ * Everything the rules table and the compliance verdict see, hermex's own
+ * rules and plugin-contributed findings alike (#102). Plugin violations are
+ * structurally uniform — hermex does not model the wrapped tool's domain —
+ * and carry a `plugin` field the core ones never have, which is the
+ * discriminant: narrow with `'plugin' in violation`.
+ */
+export type RuleViolation = CoreRuleViolation | PluginViolation;
+
+/** True for findings contributed by a plugin rather than by a hermex rule. */
+export function isPluginViolation(
+  violation: RuleViolation,
+): violation is PluginViolation {
+  return 'plugin' in violation;
+}
 
 export function toArray<T>(val: T | T[] | undefined): T[] {
   if (!val) return [];

--- a/src/utils/print-packages.ts
+++ b/src/utils/print-packages.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import type { AggregatedReport, PackageDistribution } from './aggregator';
 import type { RuleViolation } from '../rules/evaluator';
+import { isPluginViolation } from '../rules/shared';
 import type {
   AvailableUpgrade,
   ReleaseAgeEntry,
@@ -195,7 +196,13 @@ export function findForbidViolation(
   violations: RuleViolation[],
 ): RuleViolation | undefined {
   return violations.find(
-    (v) => v.ruleId === 'no-packages' && v.packageName === pkg.packageName,
+    (v) =>
+      // Plugin findings are excluded before the id check, not just to
+      // narrow the type: this column joins on hermex's own `no-packages`
+      // rule, and a plugin's id space is its own (#102).
+      !isPluginViolation(v) &&
+      v.ruleId === 'no-packages' &&
+      v.packageName === pkg.packageName,
   );
 }
 

--- a/src/utils/print-rules.ts
+++ b/src/utils/print-rules.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import type { AggregatedReport } from './aggregator';
 import type { RuleViolation } from '../rules/evaluator';
+import { isPluginViolation } from '../rules/shared';
 import { formatTruncatedList } from './format-utils';
 import {
   formatSeverityTally,
@@ -9,8 +10,13 @@ import {
   sortViolationsBySeverity,
 } from './severity-format';
 
-export function formatRuleType(ruleId: RuleViolation['ruleId']): string {
-  switch (ruleId) {
+export function formatRuleType(violation: RuleViolation): string {
+  // A plugin's rule id is its own namespace (`oxlint/no-unused-vars`) and
+  // hermex neither parses nor shortens it — orchestrating means passing the
+  // wrapped tool's identifiers through, not translating them (#102).
+  if (isPluginViolation(violation)) return violation.ruleId;
+
+  switch (violation.ruleId) {
     case 'no-files':
       return 'no-files';
     case 'require-files':
@@ -33,6 +39,18 @@ export function formatRuleType(ruleId: RuleViolation['ruleId']): string {
 }
 
 export function describeViolation(v: RuleViolation): string {
+  // Checked before anything reads `patterns`, which plugin violations do not
+  // have: they carry a ready-made `message` from the wrapped tool instead of
+  // hermex-authored prose about hermex's own rule shapes.
+  if (isPluginViolation(v)) {
+    const where = v.location
+      ? `${v.location.file}${v.location.line !== undefined ? `:${v.location.line}` : ''}`
+      : v.files && v.files.length > 0
+        ? formatTruncatedList(v.files, 'file')
+        : '';
+    return where ? `${v.message} ${chalk.gray(`(${where})`)}` : v.message;
+  }
+
   const patterns = v.patterns.join(', ');
   const suffix = v.message ? chalk.gray(` — ${v.message}`) : '';
 
@@ -95,7 +113,7 @@ export function printRules(aggregated: AggregatedReport): void {
 
   for (const v of sortViolationsBySeverity(ruleViolations)) {
     table.push([
-      formatRuleType(v.ruleId),
+      formatRuleType(v),
       `${severityIcon(v.severity)} ${describeViolation(v)}`,
     ]);
   }

--- a/src/utils/write-summary-file.ts
+++ b/src/utils/write-summary-file.ts
@@ -42,7 +42,7 @@ function buildRulesSection(aggregated: AggregatedReport): string {
 
   for (const v of ruleViolations) {
     lines.push(
-      `| ${severityIcon(v.severity)} | ${formatRuleType(v.ruleId)} | ${describeViolation(v)} |`,
+      `| ${severityIcon(v.severity)} | ${formatRuleType(v)} | ${describeViolation(v)} |`,
     );
   }
 

--- a/tests/config/plugins-schema.test.ts
+++ b/tests/config/plugins-schema.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { HermexConfigSchema } from '../../src/config/schema';
+
+/** A minimal valid plugin — `name` plus one known hook. */
+const valid = { name: 'oxlint', hooks: { onRunComplete() {} } };
+
+function parse(plugins: unknown) {
+  return HermexConfigSchema.safeParse({ plugins });
+}
+
+function errorFor(plugins: unknown): string {
+  const result = parse(plugins);
+  if (result.success) throw new Error('expected parse to fail');
+  return result.error.issues.map((i) => i.message).join('\n');
+}
+
+describe('config schema: plugins', () => {
+  it('defaults to an empty array', () => {
+    const config = HermexConfigSchema.parse({});
+    expect(config.plugins).toEqual([]);
+  });
+
+  it('accepts a plugin declared inline', () => {
+    const result = parse([valid]);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts several plugins with distinct names', () => {
+    expect(parse([valid, { ...valid, name: 'other' }]).success).toBe(true);
+  });
+
+  it('rejects a plugin that is not an object', () => {
+    expect(errorFor(['oxlint'])).toMatch(/must be an object/);
+  });
+
+  it('rejects a missing or empty name', () => {
+    expect(errorFor([{ hooks: { onRunComplete() {} } }])).toMatch(
+      /`name` must be a non-empty string/,
+    );
+    expect(errorFor([{ ...valid, name: '   ' }])).toMatch(
+      /`name` must be a non-empty string/,
+    );
+  });
+
+  it('rejects a plugin with no hooks object', () => {
+    expect(errorFor([{ name: 'x' }])).toMatch(/`hooks` must be an object/);
+  });
+
+  it('rejects a plugin that declares no hooks at all', () => {
+    // It could never run, so accepting it would be a silent no-op.
+    expect(errorFor([{ name: 'x', hooks: {} }])).toMatch(/declares no hooks/);
+  });
+
+  it('rejects an unknown hook rather than ignoring it', () => {
+    // A plugin written against a newer hermex must fail loudly — the Vite
+    // trap of hooks that silently never fire is what this prevents (#102).
+    const message = errorFor([
+      { name: 'x', hooks: { onFileParsed() {}, onRunComplete() {} } },
+    ]);
+    expect(message).toMatch(/Unknown hook `onFileParsed`/);
+    expect(message).toMatch(/onRunComplete/); // lists what is supported
+    expect(message).toMatch(/upgrade rather than removing the hook/);
+  });
+
+  it('rejects a hook that is not a function', () => {
+    expect(errorFor([{ name: 'x', hooks: { onRunComplete: true } }])).toMatch(
+      /`onRunComplete` must be a function/,
+    );
+  });
+
+  it('rejects two plugins sharing a name', () => {
+    // Identity is the plugin's declared name, so a duplicate is ambiguous
+    // rather than silently merged — ESLint's identity-by-object-reference
+    // is the cautionary tale here.
+    expect(errorFor([valid, { ...valid }])).toMatch(
+      /Duplicate plugin name "oxlint"/,
+    );
+  });
+
+  it('still rejects unknown top-level config keys', () => {
+    // `plugins` loosens one branch of the schema; the rest stays strict.
+    expect(HermexConfigSchema.safeParse({ plugin: [] }).success).toBe(false);
+  });
+});

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { spawnSync, execSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import packageJson from '../../package.json';
 
@@ -704,5 +710,113 @@ describe('package inventory axes (end to end)', () => {
       releaseAgeViolations: 0,
       warningRuleViolations: 0,
     });
+  });
+});
+
+describe('plugins (end to end)', () => {
+  const pluginConfig = join(ROOT, 'tests', 'e2e', 'hermex-plugin.config.ts');
+  const throwingConfig = join(
+    ROOT,
+    'tests',
+    'e2e',
+    'hermex-plugin-throws.config.ts',
+  );
+
+  it('loads a config declaring an inline plugin and runs it', () => {
+    const result = run(['scan', '--config', pluginConfig]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toMatch(/ERR_MODULE_NOT_FOUND/);
+    expect(result.stdout).toMatch(/Analysis complete/);
+  });
+
+  it('names the plugins that ran, so foreign code is attributable', () => {
+    // hermex does not sandbox plugins, which makes visibility the
+    // obligation instead (#102).
+    const result = run(['scan', '--config', pluginConfig]);
+    expect(result.stdout).toMatch(/Ran 1 plugin\(s\): fake-linter/);
+    expect(result.stdout).toMatch(/3 finding\(s\)/);
+  });
+
+  it('renders plugin findings in the rules table under namespaced ids', () => {
+    const result = run(['scan', '--config', pluginConfig]);
+    expect(result.stdout).toContain('fake-linter/no-debugger');
+    expect(result.stdout).toContain('fake-linter/no-unused-vars');
+    expect(result.stdout).toContain('debugger statement');
+    // location renders as file:line
+    expect(result.stdout).toMatch(/patterns[/\\]imports\.tsx:12/);
+  });
+
+  it('an error-severity plugin finding fails comply through the ordinary verdict path', () => {
+    // There is no separate verdict channel — a plugin fails the run by
+    // reporting an error violation, so the verdict always carries a reason.
+    const result = run(['comply', '--config', pluginConfig]);
+    expect(result.status).toBe(1);
+  });
+
+  it('counts plugin findings alongside hermex-authored ones in the verdict', () => {
+    const result = run([
+      'comply',
+      '--config',
+      pluginConfig,
+      '--format',
+      'json',
+    ]);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.compliance.status).toBe('non-compliant');
+    expect(parsed.compliance.counts.errorRuleViolations).toBe(1);
+    expect(parsed.compliance.counts.warningRuleViolations).toBe(1);
+  });
+
+  it('emits plugin findings in the JSON ruleViolations array', () => {
+    const result = run(['scan', '--config', pluginConfig, '--format', 'json']);
+    const parsed = JSON.parse(result.stdout);
+    const ids = parsed.ruleViolations.map((v: { ruleId: string }) => v.ruleId);
+    expect(ids).toContain('fake-linter/no-debugger');
+    // JSON stays full-fidelity: the info-severity row is present too.
+    expect(ids).toContain('fake-linter/prefer-const');
+    const finding = parsed.ruleViolations.find(
+      (v: { ruleId: string }) => v.ruleId === 'fake-linter/no-debugger',
+    );
+    expect(finding.plugin).toBe('fake-linter');
+  });
+
+  it('aborts with exit 2 when a plugin throws', () => {
+    // Not a degradation (#129 does not model this): a run that could not
+    // complete every declared plugin reports neither pass nor fail.
+    const result = run(['comply', '--config', throwingConfig]);
+    expect(result.status).toBe(2);
+    // The spinner reports to stdout in human mode (it only moves to stderr
+    // under --format json, where stdout is the payload).
+    expect(result.stdout).toMatch(/Plugin "broken-linter" failed/);
+    expect(result.stdout).toMatch(/spawn oxlint ENOENT/);
+  });
+
+  it('reports the plugin failure on stderr under --format json', () => {
+    const result = run([
+      'comply',
+      '--config',
+      throwingConfig,
+      '--format',
+      'json',
+    ]);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/Plugin "broken-linter" failed/);
+  });
+
+  it('rejects an unknown hook at config-parse time', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hermex-plugin-hook-'));
+    const configPath = join(dir, 'hermex.config.ts');
+    writeFileSync(
+      configPath,
+      `export default {
+         plugins: [{ name: 'p', hooks: { onFileParsed() {} } }],
+       };\n`,
+      'utf8',
+    );
+
+    const result = run(['scan', '--config', configPath]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/Unknown hook `onFileParsed`/);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/e2e/hermex-plugin-throws.config.ts
+++ b/tests/e2e/hermex-plugin-throws.config.ts
@@ -1,0 +1,20 @@
+import type { HermexConfigInput } from '../../src/config/types.ts';
+
+/**
+ * A plugin whose hook throws — the "oxlint isn't installed in this CI job"
+ * shape. #102 decided this aborts the run rather than degrading it, so
+ * `comply` must exit 2 and report neither pass nor fail.
+ */
+export default {
+  includes: ['patterns/**/*.{tsx,jsx,ts,js}'],
+  plugins: [
+    {
+      name: 'broken-linter',
+      hooks: {
+        onRunComplete() {
+          throw new Error('spawn oxlint ENOENT');
+        },
+      },
+    },
+  ],
+} satisfies HermexConfigInput;

--- a/tests/e2e/hermex-plugin.config.ts
+++ b/tests/e2e/hermex-plugin.config.ts
@@ -1,0 +1,43 @@
+import type { HermexConfigInput } from '../../src/config/types.ts';
+
+/**
+ * An inline plugin, written the way the docs recommend: a plain object, no
+ * factory, and no bare-specifier imports — only `import type`, which Node
+ * erases. That combination is what keeps a config loadable under `npx` in a
+ * repo with no `node_modules` (#102).
+ *
+ * The plugin contributes one violation of each severity so the e2e run can
+ * assert on rendering, the severity tally and the `comply` exit code without
+ * depending on a real third-party tool being installed.
+ */
+export default {
+  includes: ['patterns/**/*.{tsx,jsx,ts,js}'],
+  plugins: [
+    {
+      name: 'fake-linter',
+      hooks: {
+        onRunComplete(ctx) {
+          ctx.meta.set('files_seen', ctx.files.length);
+
+          ctx.violations.add({
+            ruleId: 'no-debugger',
+            severity: 'error',
+            message: 'debugger statement',
+            location: { file: 'patterns/imports.tsx', line: 12 },
+          });
+          ctx.violations.add({
+            ruleId: 'no-unused-vars',
+            severity: 'warn',
+            message: 'x is never read',
+            files: ['patterns/imports.tsx'],
+          });
+          ctx.violations.add({
+            ruleId: 'prefer-const',
+            severity: 'info',
+            message: 'let could be const',
+          });
+        },
+      },
+    },
+  ],
+} satisfies HermexConfigInput;

--- a/tests/plugins/runner.test.ts
+++ b/tests/plugins/runner.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runPlugins, PluginError } from '../../src/plugins';
+import type { HermexPlugin, PluginContext } from '../../src/plugins';
+import type { AggregatedReport } from '../../src/utils/aggregator';
+import type { ResolvedHermexConfig } from '../../src/config/overrides';
+import type { RuleViolation } from '../../src/rules/shared';
+
+function aggregated(
+  overrides: Partial<AggregatedReport> = {},
+): AggregatedReport {
+  return {
+    filesAnalyzed: 3,
+    totalImports: 7,
+    totalComponents: 2,
+    totalUsagePatterns: 11,
+    patternCounts: [],
+    componentUsage: new Map(),
+    topComponents: [],
+    packageInventory: [],
+    packageDistribution: [],
+    versusResults: [],
+    ruleViolations: [],
+    reports: [],
+    ...overrides,
+  };
+}
+
+/** Only the fields the runner actually reads off the config. */
+const config = {} as ResolvedHermexConfig;
+
+function run(plugins: HermexPlugin[], agg = aggregated()) {
+  return runPlugins({
+    plugins,
+    aggregated: agg,
+    config,
+    cwd: '/repo',
+    files: ['a.tsx', 'b.tsx'],
+    quiet: true,
+  });
+}
+
+/** A plugin whose hook body is supplied by the test. */
+function plugin(
+  name: string,
+  onRunComplete: (ctx: PluginContext) => void | Promise<void>,
+): HermexPlugin {
+  return { name, hooks: { onRunComplete } };
+}
+
+describe('runPlugins', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns nothing and does no work when no plugins are configured', async () => {
+    await expect(run([])).resolves.toEqual([]);
+  });
+
+  it('collects violations contributed through ctx.violations.add', async () => {
+    const violations = await run([
+      plugin('oxlint', (ctx) => {
+        ctx.violations.add({
+          ruleId: 'no-unused-vars',
+          severity: 'warn',
+          message: 'x is unused',
+        });
+      }),
+    ]);
+
+    expect(violations).toEqual([
+      {
+        ruleId: 'oxlint/no-unused-vars',
+        severity: 'warn',
+        message: 'x is unused',
+        plugin: 'oxlint',
+      },
+    ]);
+  });
+
+  it('namespaces rule ids under the plugin name', async () => {
+    const [violation] = await run([
+      plugin('my-tool', (ctx) => {
+        ctx.violations.add({
+          ruleId: 'rule-a',
+          severity: 'error',
+          message: 'm',
+        });
+      }),
+    ]);
+
+    expect(violation.ruleId).toBe('my-tool/rule-a');
+    expect(violation.plugin).toBe('my-tool');
+  });
+
+  it('does not double-prefix a rule id the plugin already namespaced', async () => {
+    const [violation] = await run([
+      plugin('oxlint', (ctx) => {
+        ctx.violations.add({
+          ruleId: 'oxlint/no-debugger',
+          severity: 'error',
+          message: 'm',
+        });
+      }),
+    ]);
+
+    expect(violation.ruleId).toBe('oxlint/no-debugger');
+  });
+
+  it('imposes no limit on how many violations a plugin contributes', async () => {
+    // Granularity is the plugin's decision, not hermex's (#102) — a plugin
+    // wrapping a linter may legitimately push thousands of line-level rows.
+    const violations = await run([
+      plugin('noisy', (ctx) => {
+        for (let i = 0; i < 3000; i++)
+          ctx.violations.add({
+            ruleId: `r${i}`,
+            severity: 'info',
+            message: 'm',
+          });
+      }),
+    ]);
+
+    expect(violations).toHaveLength(3000);
+  });
+
+  it('runs plugins sequentially in array order', async () => {
+    const order: string[] = [];
+    const slow = plugin('slow', async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      order.push('slow');
+    });
+    const fast = plugin('fast', () => void order.push('fast'));
+
+    await run([slow, fast]);
+
+    // Not just "both ran" — `slow` must finish before `fast` starts, or the
+    // output review would diff on ordering alone.
+    expect(order).toEqual(['slow', 'fast']);
+  });
+
+  it('preserves contribution order across plugins', async () => {
+    const violations = await run([
+      plugin('first', (ctx) =>
+        ctx.violations.add({ ruleId: 'a', severity: 'info', message: 'm' }),
+      ),
+      plugin('second', (ctx) =>
+        ctx.violations.add({ ruleId: 'b', severity: 'info', message: 'm' }),
+      ),
+    ]);
+
+    expect(violations.map((v) => v.ruleId)).toEqual(['first/a', 'second/b']);
+  });
+
+  it('skips a plugin that declares no onRunComplete hook', async () => {
+    const violations = await run([
+      { name: 'inert', hooks: {} },
+      plugin('active', (ctx) =>
+        ctx.violations.add({ ruleId: 'a', severity: 'info', message: 'm' }),
+      ),
+    ]);
+
+    expect(violations.map((v) => v.ruleId)).toEqual(['active/a']);
+  });
+
+  describe('context', () => {
+    it('exposes cwd, files and the inventory summary', async () => {
+      let seen: PluginContext | undefined;
+      await run([plugin('probe', (ctx) => void (seen = ctx))]);
+
+      expect(seen?.cwd).toBe('/repo');
+      expect(seen?.files).toEqual(['a.tsx', 'b.tsx']);
+      expect(seen?.inventory.summary).toEqual({
+        filesAnalyzed: 3,
+        totalImports: 7,
+        totalComponents: 2,
+        totalUsagePatterns: 11,
+      });
+    });
+
+    it("exposes hermex's own violations to a plugin", async () => {
+      const core: RuleViolation = {
+        ruleId: 'require-files',
+        severity: 'error',
+        patterns: ['LICENSE'],
+        matchedFiles: [],
+      };
+      let seen: readonly RuleViolation[] = [];
+
+      await run(
+        [plugin('reporter', (ctx) => void (seen = ctx.inventory.violations))],
+        aggregated({ ruleViolations: [core] }),
+      );
+
+      expect(seen).toEqual([core]);
+    });
+
+    it("exposes an earlier plugin's violations to a later one", async () => {
+      let seen: readonly RuleViolation[] = [];
+
+      await run([
+        plugin('producer', (ctx) =>
+          ctx.violations.add({ ruleId: 'a', severity: 'info', message: 'm' }),
+        ),
+        plugin('reporter', (ctx) => void (seen = ctx.inventory.violations)),
+      ]);
+
+      expect(seen.map((v) => v.ruleId)).toEqual(['producer/a']);
+    });
+
+    it('shares the meta channel across plugins within one run', async () => {
+      let seen: unknown;
+
+      await run([
+        plugin('writer', (ctx) => ctx.meta.set('last_commit', 'abc123')),
+        plugin('reader', (ctx) => void (seen = ctx.meta.get('last_commit'))),
+      ]);
+
+      expect(seen).toBe('abc123');
+    });
+
+    it('does not leak the meta channel between runs', async () => {
+      await run([plugin('writer', (ctx) => ctx.meta.set('k', 'v'))]);
+
+      let seen: unknown = 'unset';
+      await run([plugin('reader', (ctx) => void (seen = ctx.meta.get('k')))]);
+
+      expect(seen).toBeUndefined();
+    });
+
+    it('suppresses logger output when quiet (JSON mode owns stdout)', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await run([plugin('chatty', (ctx) => ctx.logger.info('hello'))]);
+      expect(log).not.toHaveBeenCalled();
+    });
+
+    it('prefixes logger output with the plugin name when not quiet', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await runPlugins({
+        plugins: [plugin('chatty', (ctx) => ctx.logger.info('hello'))],
+        aggregated: aggregated(),
+        config,
+        cwd: '/repo',
+        files: [],
+      });
+
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('[chatty] hello'),
+      );
+    });
+  });
+
+  describe('failure', () => {
+    it('wraps a thrown error in PluginError naming the plugin', async () => {
+      const failing = plugin('oxlint', () => {
+        throw new Error('spawn oxlint ENOENT');
+      });
+
+      await expect(run([failing])).rejects.toThrow(PluginError);
+      await expect(run([failing])).rejects.toThrow(
+        /Plugin "oxlint" failed: spawn oxlint ENOENT/,
+      );
+    });
+
+    it('wraps a rejected promise the same way', async () => {
+      const failing = plugin('async-fail', async () => {
+        throw new Error('boom');
+      });
+
+      await expect(run([failing])).rejects.toThrow(
+        /Plugin "async-fail" failed: boom/,
+      );
+    });
+
+    it('aborts the run rather than continuing to later plugins', async () => {
+      // A governance tool that stays green while a plugin silently did not
+      // run is the failure mode #102 rejected — so no later plugin runs.
+      const after = vi.fn();
+
+      await expect(
+        run([
+          plugin('failing', () => {
+            throw new Error('boom');
+          }),
+          plugin('after', after),
+        ]),
+      ).rejects.toThrow(PluginError);
+
+      expect(after).not.toHaveBeenCalled();
+    });
+
+    it('retains the original error as `cause`', async () => {
+      const original = new Error('root cause');
+      const error = await run([
+        plugin('p', () => {
+          throw original;
+        }),
+      ]).catch((e: unknown) => e as PluginError);
+
+      expect(error.cause).toBe(original);
+      expect(error.pluginName).toBe('p');
+    });
+  });
+});

--- a/tests/utils/print-utils.test.ts
+++ b/tests/utils/print-utils.test.ts
@@ -21,7 +21,11 @@ import { printComponents } from '../../src/utils/print-components';
 import { printPatterns } from '../../src/utils/print-patterns';
 import { printDetails } from '../../src/utils/print-details';
 import { printVersus } from '../../src/utils/print-versus';
-import { printRules, describeViolation } from '../../src/utils/print-rules';
+import {
+  printRules,
+  describeViolation,
+  formatRuleType,
+} from '../../src/utils/print-rules';
 import { printErrors } from '../../src/utils/print-errors';
 import { printJson } from '../../src/utils/print-json';
 import { printComplianceVerdict } from '../../src/utils/print-compliance';
@@ -1231,6 +1235,52 @@ describe('describeViolation', () => {
       matchedFiles: [],
     } as unknown as RuleViolation;
     expect(describeViolation(violation)).toBe('whatever not present');
+  });
+
+  describe('plugin violations', () => {
+    // Plugin findings carry a ready-made `message` from the wrapped tool and
+    // have no `patterns`, so they must be handled before anything reads it.
+    const base = {
+      ruleId: 'oxlint/no-debugger',
+      severity: 'error',
+      message: 'debugger statement',
+      plugin: 'oxlint',
+    } as const;
+
+    it('renders the message alone when there is no location or files', () => {
+      expect(describeViolation({ ...base })).toBe('debugger statement');
+    });
+
+    it('appends file:line when a location is given', () => {
+      const out = describeViolation({
+        ...base,
+        location: { file: 'src/a.tsx', line: 12 },
+      });
+      expect(stripAnsi(out)).toBe('debugger statement (src/a.tsx:12)');
+    });
+
+    it('omits the line when the location has none', () => {
+      const out = describeViolation({
+        ...base,
+        location: { file: 'src/a.tsx' },
+      });
+      expect(stripAnsi(out)).toBe('debugger statement (src/a.tsx)');
+    });
+
+    it('falls back to the file list when there is no location', () => {
+      const out = describeViolation({
+        ...base,
+        files: ['src/a.tsx', 'src/b.tsx'],
+      });
+      expect(stripAnsi(out)).toContain('debugger statement (');
+      expect(stripAnsi(out)).toContain('src/a.tsx');
+    });
+
+    it('renders the namespaced rule id as the rule column, unshortened', () => {
+      // hermex passes the wrapped tool's identifiers through rather than
+      // translating them (#102).
+      expect(formatRuleType({ ...base })).toBe('oxlint/no-debugger');
+    });
   });
 });
 


### PR DESCRIPTION
Implements the plugin architecture decided in #102.

**hermex does not reinvent.** If another tool does something better it becomes a plugin,
not a hermex rule. This is the surface that makes that real — and it came out much smaller
than the ticket feared: no bundling, no plugin package, no monorepo.

```ts
export default {
  plugins: [
    {
      name: 'oxlint',
      hooks: {
        async onRunComplete(ctx) {
          const { stdout } = await exec('oxlint', ['--format', 'json', ...ctx.files]);
          for (const d of JSON.parse(stdout).diagnostics) {
            ctx.violations.add({ ruleId: d.code, severity: 'warn', message: d.message });
          }
        },
      },
    },
  ],
} satisfies HermexConfigInput;
```

Real output from `comply` against the new e2e fixture:

```
✔ Ran 1 plugin(s): fake-linter — 3 finding(s)

🔍 Rules
┌────────────────────────────┬─────────────────────────────────────────────────┐
│ Rule                       │ Description                                     │
├────────────────────────────┼─────────────────────────────────────────────────┤
│ fake-linter/no-debugger    │ 🔴 debugger statement (patterns/imports.tsx:12) │
│ fake-linter/no-unused-vars │ 🟡 x is never read (patterns/imports.tsx)       │
│ fake-linter/prefer-const   │ 🔵 let could be const                           │
└────────────────────────────┴─────────────────────────────────────────────────┘

1 error, 1 warning, 1 info

🔴 Not compliant
  1 mandatory violation found
```

## What's in the surface

A plugin is **inert data** — a plain object, declarable inline, no factory, no package, no
registration. The `hooks` envelope is what lets the API grow: adding a hook later is
additive, and an **unknown hook key is a hard config error**, not a silent ignore, so a
plugin built against a newer hermex fails loudly instead of half-running.

One hook ships. `onRunComplete` runs after the inventory and hermex's own rules and before
rendering, and serves both directions — `ctx.violations.add()` wraps a linter; reading
`ctx` alone is a SARIF/Slack/dashboard reporter.

| Decision | |
| --- | --- |
| **Granularity** | The plugin's. One row or three thousand — it knows the wrapped tool, hermex doesn't. |
| **Severity** | The plugin's. No `rules: { 'oxlint/x': 'off' }`, no `overrides` reach — a plugin configures *itself*, so `hermex.config.ts` never becomes a second place to configure oxlint. `rules` keeps `.strict()`. |
| **Verdict** | No `ctx.comply`. A plugin fails the run by reporting an `error` violation, so a red build always has a row explaining it. |
| **Failure** | A hook that throws **aborts with exit 2** — CI staying green while the lint plugin silently didn't run is the worst available outcome. Not a #129 degradation. |
| **Ordering** | Array order, sequential. No `enforce: pre|post`. Sequential is required — `output-review` diffs printed output. |
| **Identity** | Canonical `name` from the plugin, deduped by it, duplicates rejected. No config-assigned namespaces (ESLint's identity-by-reference is the cautionary tale). |
| **Trust** | Documented, not sandboxed — `hermex.config.ts` already runs arbitrary TS. The obligation is attribution, so every run names the plugins that executed. |

The context is read-only data plus write channels (`violations`, `meta`, `logger`) and
grants **no host capabilities**. The prior art recommends Rollup-style capabilities, but
that assumed plugins re-enter the host pipeline; with one terminal hook there's nothing to
re-enter. It exposes a narrow `PluginInventoryView`, **not `AggregatedReport`** — which is
what keeps #104 and #115 unconstrained by the plugin surface.

## `npx` still works

Verified empirically, not asserted. The constraint was never plugins — it's **bare-specifier
imports in the config**, and it already existed:

| in `hermex.config.ts` | resolves with no `node_modules`? |
| --- | --- |
| `import type { … } from 'hermex'` | ✅ erased before it runs |
| `import { execFile } from 'node:child_process'` | ✅ builtin |
| `import { anything } from 'some-package'` | ❌ `ERR_MODULE_NOT_FOUND` |

Declaring plugins **inline** satisfies this automatically, which is why the docs push that
shape and why `satisfies HermexConfigInput` is preferred over a runtime `defineConfig`
import. `docs/plugins.md` also carries a no-install CI variant that ingests an `oxlint.json`
a prior step wrote, needing nothing installed at all.

## Docs

`docs/plugins.md` — the API, plus an oxlint recipe carrying the three real gotchas:
oxlint exits non-zero *on findings* so stdout must be read off the throw;
`node_modules/.bin` isn't on `PATH` outside npm scripts; those are `.cmd` shims on Windows
so `execFile` needs `shell`.

## Verification

- **736 tests pass** (692 existing, unchanged + **44 new**) — `tests/plugins/runner.test.ts`,
  `tests/config/plugins-schema.test.ts`, e2e coverage in `tests/e2e/cli.test.ts` driven by
  two new fixture configs, and rendering cases in `print-utils.test.ts`.
- `format:ci`, `lint:ci`, `typecheck` and `build` all clean.
- **No output change when no plugins are configured** — the whole block is guarded on
  `plugins.length > 0`, so existing output-review baselines are untouched.

## Reviewer notes

Two deliberate choices worth a look:

1. **`scan` still exits 1 on a plugin failure, not 2.** #102's exit-2 rationale is
   verdict-shaped ("reports neither pass nor fail") and `scan` has no verdict, so it keeps
   its existing generic error path. `comply` exits 2. Easy to align if you'd rather.
2. **`defineConfig` is untouched.** #102 and #104 agree it should go, but removing it is
   breaking and belongs to the v3 config work (#114), not here.

`ctx.meta` is implemented as a plugin-to-plugin channel but is **not** surfaced in JSON —
that's #115's call, per the resolution.

Follow-ons already filed: #166 (rules table under high-volume plugin findings) and #167
(prototype the real oxlint plugin against this contract, which should run before #114 locks
the schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
